### PR TITLE
Import nimble locks

### DIFF
--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -628,6 +628,9 @@ proc main(c: var AtlasContext) =
   of "rep":
     optSingleArg(LockFileName)
     replay c, args[0]
+  of "replay":
+    optSingleArg(LockFileName)
+    replay c, args[0]
   of "convert":
     if args.len < 1:
       fatal "convert command takes a nimble lockfile argument"

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -632,7 +632,7 @@ proc main(c: var AtlasContext) =
     if args.len < 1:
       fatal "convert command takes a nimble lockfile argument"
     let lfn = if args.len == 1: LockFileName else: args[1]
-    convertNimbleLock c, args[0], lfn
+    convertAndSaveNimbleLock c, args[0], lfn
   of "install":
     projectCmd()
     if args.len > 1:

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -19,6 +19,7 @@ export osutils, context
 const
   AtlasVersion = "0.6.0"
   LockFileName = "atlas.lock"
+  NimbleLockFileName = "nimble.lock"
   Usage = "atlas - Nim Package Cloner Version " & AtlasVersion & """
 
   (c) 2021 Andreas Rumpf
@@ -627,6 +628,11 @@ proc main(c: var AtlasContext) =
   of "rep":
     optSingleArg(LockFileName)
     replay c, args[0]
+  of "convert":
+    if args.len < 1:
+      fatal "convert command takes a nimble lockfile argument"
+    let lfn = if args.len == 1: LockFileName else: args[1]
+    convertNimbleLock c, args[0], lfn
   of "install":
     projectCmd()
     if args.len > 1:

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -625,10 +625,7 @@ proc main(c: var AtlasContext) =
       pinWorkspace c, args[0]
     else:
       pinProject c, args[0]
-  of "rep":
-    optSingleArg(LockFileName)
-    replay c, args[0]
-  of "replay":
+  of "rep", "replay":
     optSingleArg(LockFileName)
     replay c, args[0]
   of "convert":

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -637,7 +637,7 @@ proc main(c: var AtlasContext) =
       pinWorkspace c, args[0]
     else:
       pinProject c, args[0]
-  of "rep", "replay":
+  of "rep", "replay", "reproduce":
     optSingleArg(LockFileName)
     replay c, args[0]
   of "convert":

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -49,7 +49,9 @@ Command:
                         ['major'|'minor'|'patch'] or a SemVer tag like ['1.0.3']
                         or a letter ['a'..'z']: a.b.c.d.e.f.g
   pin [atlas.lock]      pin the current checkouts and store them in the lock
-  rep [atlas.lock]      replay the state of the projects according to the lock
+  replay [atlas.lock]   replay the state of the projects according to the lock
+  convert <nimble.lock> [atlas.lock]
+                        convert Nimble lockfile into an Atlas one
   outdated              list the packages that are outdated
   build|test|doc|tasks  currently delegates to `nimble build|test|doc`
   task <taskname>       currently delegates to `nimble <taskname>`

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -49,7 +49,7 @@ Command:
                         ['major'|'minor'|'patch'] or a SemVer tag like ['1.0.3']
                         or a letter ['a'..'z']: a.b.c.d.e.f.g
   pin [atlas.lock]      pin the current checkouts and store them in the lock
-  replay [atlas.lock]   replay the state of the projects according to the lock
+  rep [atlas.lock]      replay the state of the projects according to the lock
   convert <nimble.lock> [atlas.lock]
                         convert Nimble lockfile into an Atlas one
   outdated              list the packages that are outdated

--- a/src/context.nim
+++ b/src/context.nim
@@ -119,11 +119,12 @@ proc writeMessage(c: var AtlasContext; k: MsgKind; p: PackageName; arg: string) 
   if NoColors in c.flags:
     message(c, $k, p, arg)
   else:
+    let pn = p.string.relativePath(c.workspace)
     let color = case k
                 of Info: fgGreen
                 of Warning: fgYellow
                 of Error: fgRed
-    stdout.styledWriteLine(color, styleBright, $k, resetStyle, fgCyan, "(", p.string, ")", resetStyle, " ", arg)
+    stdout.styledWriteLine(color, styleBright, $k, resetStyle, fgCyan, "(", pn, ")", resetStyle, " ", arg)
 
 proc writePendingMessages*(c: var AtlasContext) =
   for i in 0..<c.messages.len:

--- a/src/gitops.nim
+++ b/src/gitops.nim
@@ -104,7 +104,7 @@ proc checkoutGitCommit*(c: var AtlasContext; p: PackageName; commit: string) =
   if status != 0:
     error(c, p, "could not checkout commit " & commit)
   else:
-    info(c, p, "updated package " & commit)
+    info(c, p, "updated package to " & commit)
 
 proc gitPull*(c: var AtlasContext; p: PackageName) =
   let (_, status) = exec(c, GitPull, [])

--- a/src/gitops.nim
+++ b/src/gitops.nim
@@ -103,6 +103,8 @@ proc checkoutGitCommit*(c: var AtlasContext; p: PackageName; commit: string) =
   let (_, status) = exec(c, GitCheckout, [commit])
   if status != 0:
     error(c, p, "could not checkout commit " & commit)
+  else:
+    info(c, p, "updated package " & commit)
 
 proc gitPull*(c: var AtlasContext; p: PackageName) =
   let (_, status) = exec(c, GitPull, [])

--- a/src/lockfiles.nim
+++ b/src/lockfiles.nim
@@ -137,7 +137,7 @@ proc convertNimbleLock*(c: var AtlasContext; nimblePath: string): LockFile =
 
   result = newLockFile()
   for (name, pkg) in jsonTree["packages"].pairs:
-    echo "name: ", name, " pkg: ", pkg
+    info c, toName(name), " imported "
     let dir = c.depsDir / name
     result.items[name] = LockFileEntry(
       dir: dir,


### PR DESCRIPTION
This PR adds the ability to convert nimble lock files to atlas lock files. It's pretty nice!

It also does: 

- adds `replay` in addition to `rep` for clarity
- prints status updates for deps after running `replay` to help users know what it did
- when `nimble.lock` is passed to `replay` it will use it
- package paths in messages are relative to workspace when using color mode

