### PR TITLE
Export Nimble lock file

### DIFF
--- a/atlas.nimble
+++ b/atlas.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version = "0.6.2"
+version = "0.6.3"
 author = "Araq"
 description = "Atlas is a simple package cloner tool. It manages an isolated workspace."
 license = "MIT"

--- a/config.nims
+++ b/config.nims
@@ -1,6 +1,6 @@
 
 task build, "Build local atlas":
-  exec "nim c -o:./atlas src/atlas.nim"
+  exec "nim c -d:debug -o:./atlas src/atlas.nim"
 
 task unitTests, "Runs unit tests":
   exec "nim c -d:debug -r tests/unittests.nim"

--- a/config.nims
+++ b/config.nims
@@ -3,10 +3,10 @@ task build, "Build local atlas":
   exec "nim c -o:./atlas src/atlas.nim"
 
 task unitTests, "Runs unit tests":
-  exec "nim c -r tests/unittests.nim"
+  exec "nim c -d:debug -r tests/unittests.nim"
 
 task tester, "Runs integration tests":
-  exec "nim c -r tests/tester.nim"
+  exec "nim c -d:debug -r tests/tester.nim"
 
 task test, "Runs all tests":
   # unitTestsTask() # tester runs both

--- a/config.nims
+++ b/config.nims
@@ -11,3 +11,5 @@ task tester, "Runs integration tests":
 task test, "Runs all tests":
   # unitTestsTask() # tester runs both
   testerTask()
+
+--path:"~/.nimble/pkgs/pretty-0.1.0/"

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -16,8 +16,6 @@ import context, runners, osutils, packagesjson, sat, gitops, nimenv, lockfiles,
 
 export osutils, context
 
-import pretty # REMOVE!
-
 const
   AtlasVersion = "0.6.2"
   LockFileName = "atlas.lock"

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -49,6 +49,7 @@ Command:
                         ['major'|'minor'|'patch'] or a SemVer tag like ['1.0.3']
                         or a letter ['a'..'z']: a.b.c.d.e.f.g
   pin [atlas.lock]      pin the current checkouts and store them in the lock
+    --export            export Nimble lockfile as well
   rep [atlas.lock]      replay the state of the projects according to the lock
   convert <nimble.lock> [atlas.lock]
                         convert Nimble lockfile into an Atlas one
@@ -611,6 +612,7 @@ proc main(c: var AtlasContext) =
       of "noexec": c.flags.incl NoExec
       of "list": c.flags.incl ListVersions
       of "global", "g": c.flags.incl GlobalWorkspace
+      of "export": c.flags.incl ExportNimbleLock
       of "colors":
         case val.normalize
         of "off": c.flags.incl NoColors
@@ -687,7 +689,7 @@ proc main(c: var AtlasContext) =
     if c.projectDir == c.workspace or c.projectDir == c.depsDir:
       pinWorkspace c, args[0]
     else:
-      pinProject c, args[0]
+      pinProject c, args[0], ExportNimbleLock in c.flags
   of "rep", "replay", "reproduce":
     optSingleArg(LockFileName)
     replay c, args[0]

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -430,6 +430,10 @@ proc findCfgDir(c: var AtlasContext): CfgPath =
     return CfgPath c.currentDir / nimbleInfo.srcDir
   return CfgPath c.currentDir
 
+proc findCfgDir(c: var AtlasContext, pkg: Package): CfgPath =
+  let nimbleInfo = extractRequiresInfo(c, pkg.nimble)
+  return CfgPath c.currentDir / nimbleInfo.srcDir
+
 proc installDependencies(c: var AtlasContext; nimbleFile: string; startIsDep: bool) =
   # 1. find .nimble file in CWD
   # 2. install deps from .nimble
@@ -755,6 +759,12 @@ proc main(c: var AtlasContext) =
     setupNimEnv c, args[0]
   of "outdated":
     listOutdated(c)
+  of "checksum":
+    singleArg()
+    let pkg = resolvePackage(c, args[0])
+    let cfg = findCfgDir(c, pkg)
+    let sha = nimbleChecksum(c, pkg, cfg)
+    info c, pkg, "SHA1Digest: " & sha
   else:
     fatal "Invalid action: " & action
 

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -694,7 +694,8 @@ proc main(c: var AtlasContext) =
   of "convert":
     if args.len < 1:
       fatal "convert command takes a nimble lockfile argument"
-    let lfn = if args.len == 1: LockFileName else: args[1]
+    let lfn = if args.len == 1: LockFileName
+              else: args[1]
     convertAndSaveNimbleLock c, args[0], lfn
   of "install":
     # projectCmd()

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -76,7 +76,8 @@ Options:
   --showGraph           show the dependency graph
   --list                list all available and installed versions
   --version             show the version
-  --verbose             print extra debugging information
+  --verbosity:normal|trace|debug
+                        set verbosity level to normal, trace, debug
   --help                show this help
   --global              use global workspace in ~/.atlas
 """
@@ -612,9 +613,9 @@ proc main(c: var AtlasContext) =
         else: writeHelp()
       of "verbosity":
         case val.normalize
-        of "0": c.verbosity = 0
-        of "1": c.verbosity = 1
-        of "2": c.verbosity = 2
+        of "normal": c.verbosity = 0
+        of "trace": c.verbosity = 1
+        of "debug": c.verbosity = 2
         else: writeHelp()
       of "assertonerror": c.flags.incl AssertOnError
       of "resolver":

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -292,15 +292,8 @@ proc resolve(c: var AtlasContext; g: var DepGraph) =
         let destDir = pkg.name.string
         info c, pkg, "satisfiable: " & $pkg
         let dir = pkg.path.string
-        # let dir = selectDir(c.workspace / destDir, c.depsDir / destDir)
-        # withDir c, dir:
-        let oldDir = getCurrentDir()
-        try:
-          info c, pkg, "setting directory: " & dir
-          setCurrentDir(dir)
+        withDir c, dir:
           checkoutGitCommit(c, toRepo(destDir), mapping[i - g.nodes.len][1])
-        finally:
-          setCurrentDir(oldDir)
     if NoExec notin c.flags:
       runBuildSteps(c, g)
       #echo f

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -214,7 +214,7 @@ proc resolve(c: var AtlasContext; g: var DepGraph) =
   # project is listed multiple times in the .nimble file.
   # Implications:
   for i in 0..<g.nodes.len:
-    trace c, g.nodes[i].pkg, "resolving node"
+    trace c, g.nodes[i].pkg, "resolving node i: " & $i & " parents: " & $g.nodes[i].parents
     if g.nodes[i].active:
       debug c, g.nodes[i].pkg, "resolved as active"
       for j in g.nodes[i].parents:
@@ -239,7 +239,7 @@ proc resolve(c: var AtlasContext; g: var DepGraph) =
   # Version selection:
   for i in 0..<g.nodes.len:
     let av = g.availableVersions.getOrDefault(g.nodes[i].pkg.name)
-    trace c, g.nodes[i].pkg, "resolving version"
+    trace c, g.nodes[i].pkg, "resolving version out of " & $len(av)
     if g.nodes[i].active and av.len > 0:
       let bpos = rememberPos(b)
       # A -> (exactly one of: A1, A2, A3)

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -17,7 +17,7 @@ import context, runners, osutils, packagesjson, sat, gitops, nimenv, lockfiles,
 export osutils, context
 
 const
-  AtlasVersion = "0.6.2"
+  AtlasVersion = "0.6.3"
   LockFileName = "atlas.lock"
   NimbleLockFileName = "nimble.lock"
   Usage = "atlas - Nim Package Cloner Version " & AtlasVersion & """

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -334,7 +334,6 @@ proc traverseLoop(c: var AtlasContext; g: var DepGraph; startIsDep: bool): seq[C
             info(c, w.pkg, "cloning: " & $w.pkg)
             cloneUrl(c, w.pkg.url, w.pkg.path.string, false)
         g.nodes[i].status = status
-        discard c.resolvePackage($w.pkg.url)
         info c, w.pkg, "traverseLoop: status: " & $status & " pkg: " & $w.pkg
         case status
         of NotFound:
@@ -342,6 +341,7 @@ proc traverseLoop(c: var AtlasContext; g: var DepGraph; startIsDep: bool): seq[C
         of OtherError:
           error c, w.pkg, err
         else:
+          c.resolveNimble(w.pkg)
           withDir c, w.pkg.path.string:
             collectAvailableVersions c, g, w
     else:

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -355,9 +355,9 @@ proc traverseLoop(c: var AtlasContext; g: var DepGraph; startIsDep: bool): seq[C
   if g.availableVersions.len > 0:
     resolve c, g
 
-proc traverse(c: var AtlasContext; start: Package; startIsDep: bool): seq[CfgPath] =
+proc traverse(c: var AtlasContext; start: string; startIsDep: bool): seq[CfgPath] =
   # returns the list of paths for the nim.cfg file.
-  let (start, url) = resolvePackage(c, start)
+  let pkg = resolvePackage(c, start)
   var g = createGraph(c, start, url)
 
   if $url == "":

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -667,7 +667,8 @@ proc main(c: var AtlasContext) =
   of "clone", "update":
     singleArg()
     let deps = traverse(c, args[0], startIsDep = false)
-    let cfgPath = if CfgHere in c.flags: CfgPath c.currentDir else: findCfgDir(c)
+    let cfgPath = if CfgHere in c.flags: CfgPath c.currentDir
+                  else: findCfgDir(c)
     patchNimCfg c, deps, cfgPath
     when MockupRun:
       if not c.mockupSuccess:
@@ -683,7 +684,7 @@ proc main(c: var AtlasContext) =
       pinWorkspace c, args[0]
     else:
       pinProject c, args[0]
-  of "rep", "replay":
+  of "rep", "replay", "reproduce":
     optSingleArg(LockFileName)
     replay c, args[0]
   of "convert":

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -605,7 +605,12 @@ proc main(c: var AtlasContext) =
         of "off": c.flags.incl NoColors
         of "on": c.flags.excl NoColors
         else: writeHelp()
-      of "verbose": c.flags.incl DebugPrint
+      of "verbosity":
+        case val.normalize
+        of "0": c.verbosity = 0
+        of "1": c.verbosity = 1
+        of "2": c.verbosity = 2
+        else: writeHelp()
       of "assertonerror": c.flags.incl AssertOnError
       of "resolver":
         try:
@@ -663,7 +668,6 @@ proc main(c: var AtlasContext) =
   of "use":
     singleArg()
     let nimbleFile = patchNimbleFile(c, args[0])
-    echo "USE: ", nimbleFile
     if nimbleFile.len > 0:
       installDependencies(c, nimbleFile, startIsDep = false)
   of "pin":

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -210,11 +210,13 @@ proc resolve(c: var AtlasContext; g: var DepGraph) =
   b.add newVar(VarId 0)
 
   assert g.nodes.len > 0
+  trace c, g.nodes[0].pkg, "resolving versions"
+
   #assert g.nodes[0].active # this does not have to be true if some
   # project is listed multiple times in the .nimble file.
   # Implications:
   for i in 0..<g.nodes.len:
-    trace c, g.nodes[i].pkg, "resolving node i: " & $i & " parents: " & $g.nodes[i].parents
+    debug c, g.nodes[i].pkg, "resolving node i: " & $i & " parents: " & $g.nodes[i].parents
     if g.nodes[i].active:
       debug c, g.nodes[i].pkg, "resolved as active"
       for j in g.nodes[i].parents:
@@ -239,7 +241,7 @@ proc resolve(c: var AtlasContext; g: var DepGraph) =
   # Version selection:
   for i in 0..<g.nodes.len:
     let av = g.availableVersions.getOrDefault(g.nodes[i].pkg.name)
-    trace c, g.nodes[i].pkg, "resolving version out of " & $len(av)
+    debug c, g.nodes[i].pkg, "resolving version out of " & $len(av)
     if g.nodes[i].active and av.len > 0:
       let bpos = rememberPos(b)
       # A -> (exactly one of: A1, A2, A3)
@@ -337,7 +339,7 @@ proc traverseLoop(c: var AtlasContext; g: var DepGraph; startIsDep: bool): seq[C
           if w.pkg.url.scheme == FileProtocol:
             copyFromDisk(c, w, w.pkg.path.string)
           else:
-            info(c, w.pkg, "cloning: " & $w.pkg)
+            info(c, w.pkg, "cloning: " & $(w.pkg.url))
             cloneUrl(c, w.pkg.url, w.pkg.path.string, false)
         g.nodes[i].status = status
         debug c, w.pkg, "traverseLoop: status: " & $status & " pkg: " & $w.pkg

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -16,8 +16,6 @@ import context, runners, osutils, packagesjson, sat, gitops, nimenv, lockfiles,
 
 export osutils, context
 
-import pretty # REMOVE!
-
 const
   AtlasVersion = "0.6.2"
   LockFileName = "atlas.lock"
@@ -434,7 +432,6 @@ proc installDependencies(c: var AtlasContext; nimbleFile: string; startIsDep: bo
   echo "installDependencies:repo: ", dir.lastPathComponent
   let pkg = c.resolvePackage("file://" & dir.lastPathComponent)
   let dep = Dependency(pkg: pkg, commit: "", self: 0, algo: c.defaultAlgo)
-  print dep
   g.byName.mgetOrPut(pkg.name, @[]).add(0)
   discard collectDeps(c, g, -1, dep)
   let paths = traverseLoop(c, g, startIsDep)

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -341,12 +341,13 @@ proc traverseLoop(c: var AtlasContext; g: var DepGraph; startIsDep: bool): seq[C
         of OtherError:
           error c, w.pkg, err
         else:
-          c.resolveNimble(w.pkg)
           withDir c, w.pkg.path.string:
             collectAvailableVersions c, g, w
     else:
         withDir c, w.pkg.path.string:
           collectAvailableVersions c, g, w
+
+    c.resolveNimble(w.pkg)
 
     # assume this is the selected version, it might get overwritten later:
     selectNode c, g, w

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -49,7 +49,6 @@ Command:
                         ['major'|'minor'|'patch'] or a SemVer tag like ['1.0.3']
                         or a letter ['a'..'z']: a.b.c.d.e.f.g
   pin [atlas.lock]      pin the current checkouts and store them in the lock
-    --export            export Nimble lockfile as well
   rep [atlas.lock]      replay the state of the projects according to the lock
   convert <nimble.lock> [atlas.lock]
                         convert Nimble lockfile into an Atlas one
@@ -612,7 +611,6 @@ proc main(c: var AtlasContext) =
       of "noexec": c.flags.incl NoExec
       of "list": c.flags.incl ListVersions
       of "global", "g": c.flags.incl GlobalWorkspace
-      of "export": c.flags.incl ExportNimbleLock
       of "colors":
         case val.normalize
         of "off": c.flags.incl NoColors
@@ -689,7 +687,8 @@ proc main(c: var AtlasContext) =
     if c.projectDir == c.workspace or c.projectDir == c.depsDir:
       pinWorkspace c, args[0]
     else:
-      pinProject c, args[0], ExportNimbleLock in c.flags
+      let exportNimble = args[0] == "nimble.lock"
+      pinProject c, args[0], exportNimble
   of "rep", "replay", "reproduce":
     optSingleArg(LockFileName)
     replay c, args[0]

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -134,7 +134,7 @@ const
   ThisVersion = "current_version.atlas"
 
 proc checkoutCommit(c: var AtlasContext; g: var DepGraph; w: Dependency) =
-  let dir = dependencyDir(c, w)
+  let dir = w.pkg.path.string
   withDir c, dir:
     if w.commit.len == 0 or cmpIgnoreCase(w.commit, "head") == 0:
       gitPull(c, w.pkg.repo)
@@ -358,13 +358,13 @@ proc traverseLoop(c: var AtlasContext; g: var DepGraph; startIsDep: bool): seq[C
 proc traverse(c: var AtlasContext; start: string; startIsDep: bool): seq[CfgPath] =
   # returns the list of paths for the nim.cfg file.
   let pkg = resolvePackage(c, start)
-  var g = createGraph(c, start, url)
+  var g = c.createGraph(pkg)
 
-  if $url == "":
-    error c, start, "cannot resolve package name"
+  if $pkg.url == "":
+    error c, pkg, "cannot resolve package name"
     return
 
-  c.projectDir = c.workspace / toDestDir(g.nodes[0].name)
+  c.projectDir = pkg.path.string
 
   result = traverseLoop(c, g, startIsDep)
   afterGraphActions c, g

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -289,9 +289,10 @@ proc resolve(c: var AtlasContext; g: var DepGraph) =
     for i in g.nodes.len..<s.len:
       if s[i] == setToTrue:
         let pkg = mapping[i - g.nodes.len][0]
-        print pkg
         let destDir = pkg.name.string
-        let dir = selectDir(c.workspace / destDir, c.depsDir / destDir)
+        debug c, pkg, "satisfiable"
+        let dir = pkg.path.string
+        # let dir = selectDir(c.workspace / destDir, c.depsDir / destDir)
         # withDir c, dir:
         let oldDir = getCurrentDir()
         try:
@@ -304,12 +305,13 @@ proc resolve(c: var AtlasContext; g: var DepGraph) =
       runBuildSteps(c, g)
       #echo f
     if ListVersions in c.flags:
-      info c, toRepo("resolve"), "selected:"
+      info c, toRepo("../resolve"), "selected:"
       for i in g.nodes.len..<s.len:
+        let item = mapping[i - g.nodes.len]
         if s[i] == setToTrue:
-          info c, toRepo("resolve"), "[x] " & toString mapping[i - g.nodes.len]
+          info c, item[0], "[x] " & toString item
         else:
-          info c, toRepo("resolve"), "[ ] " & toString mapping[i - g.nodes.len]
+          info c, item[0], "[ ] " & toString item
   else:
     error c, toRepo(c.workspace), "version conflict; for more information use --showGraph"
     var usedVersions = initCountTable[Package]()

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -597,6 +597,7 @@ proc main(c: var AtlasContext) =
         of "on": c.flags.excl NoColors
         else: writeHelp()
       of "verbose": c.flags.incl DebugPrint
+      of "assertonerror": c.flags.incl AssertOnError
       of "resolver":
         try:
           c.defaultAlgo = parseEnum[ResolutionAlgorithm](val)

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -295,7 +295,7 @@ proc resolve(c: var AtlasContext; g: var DepGraph) =
         # withDir c, dir:
         let oldDir = getCurrentDir()
         try:
-          echo "Current directory is now ", dir
+          debug c, pkg, "setting directory: " & dir
           setCurrentDir(dir)
           checkoutGitCommit(c, toRepo(destDir), mapping[i - g.nodes.len][1])
         finally:
@@ -304,12 +304,12 @@ proc resolve(c: var AtlasContext; g: var DepGraph) =
       runBuildSteps(c, g)
       #echo f
     if ListVersions in c.flags:
-      echo "selected:"
+      info c, toRepo("resolve"), "selected:"
       for i in g.nodes.len..<s.len:
         if s[i] == setToTrue:
-          echo "[x] ", toString mapping[i - g.nodes.len]
+          info c, toRepo("resolve"), "[x] " & toString mapping[i - g.nodes.len]
         else:
-          echo "[ ] ", toString mapping[i - g.nodes.len]
+          info c, toRepo("resolve"), "[ ] " & toString mapping[i - g.nodes.len]
   else:
     error c, toRepo(c.workspace), "version conflict; for more information use --showGraph"
     var usedVersions = initCountTable[Package]()
@@ -432,6 +432,7 @@ proc installDependencies(c: var AtlasContext; nimbleFile: string; startIsDep: bo
   echo "installDependencies:repo: ", dir.lastPathComponent
   let pkg = c.resolvePackage("file://" & dir.lastPathComponent)
   let dep = Dependency(pkg: pkg, commit: "", self: 0, algo: c.defaultAlgo)
+  print dep
   g.byName.mgetOrPut(pkg.name, @[]).add(0)
   discard collectDeps(c, g, -1, dep)
   let paths = traverseLoop(c, g, startIsDep)

--- a/src/confighandler.nim
+++ b/src/confighandler.nim
@@ -25,17 +25,17 @@ proc parseOverridesFile(c: var AtlasContext; filename: string) =
           let key = line.substr(0, splitPos-1)
           let val = line.substr(splitPos+len(Separator))
           if key.len == 0 or val.len == 0:
-            error c, toName(path), "key/value must not be empty"
+            error c, toRepo(path), "key/value must not be empty"
           let err = c.overrides.addPattern(key, val)
           if err.len > 0:
-            error c, toName(path), "(" & $lineCount & "): " & err
+            error c, toRepo(path), "(" & $lineCount & "): " & err
         else:
           discard "ignore the line"
         inc lineCount
     finally:
       close f
   else:
-    error c, toName(path), "cannot open: " & path
+    error c, toRepo(path), "cannot open: " & path
 
 proc readPluginsDir(c: var AtlasContext; dir: string) =
   for k, f in walkDir(c.workspace / dir):
@@ -46,7 +46,7 @@ proc readConfig*(c: var AtlasContext) =
   let configFile = c.workspace / AtlasWorkspace
   var f = newFileStream(configFile, fmRead)
   if f == nil:
-    error c, toName(configFile), "cannot open: " & configFile
+    error c, toRepo(configFile), "cannot open: " & configFile
     return
   var p: CfgParser
   open(p, f, configFile)
@@ -66,13 +66,13 @@ proc readConfig*(c: var AtlasContext) =
         try:
           c.defaultAlgo = parseEnum[ResolutionAlgorithm](e.value)
         except ValueError:
-          warn c, toName(configFile), "ignored unknown resolver: " & e.key
+          warn c, toRepo(configFile), "ignored unknown resolver: " & e.key
       of "plugins":
         readPluginsDir(c, e.value)
       else:
-        warn c, toName(configFile), "ignored unknown setting: " & e.key
+        warn c, toRepo(configFile), "ignored unknown setting: " & e.key
     of cfgOption:
       discard "who cares about options"
     of cfgError:
-      error c, toName(configFile), e.msg
+      error c, toRepo(configFile), e.msg
   close(p)

--- a/src/context.nim
+++ b/src/context.nim
@@ -86,6 +86,7 @@ type
     ListVersions
     GlobalWorkspace
     AssertOnError
+    ExportNimbleLock
 
   MsgKind = enum
     Info = "[Info] ",

--- a/src/context.nim
+++ b/src/context.nim
@@ -89,6 +89,7 @@ type
     ListVersions
     DebugPrint
     GlobalWorkspace
+    AssertOnError
 
   MsgKind = enum
     Info = "[Info] ",
@@ -101,7 +102,8 @@ type
     hasPackageList*: bool
     flags*: set[Flag]
     urlMapping*: Table[string, Package] # name -> url mapping
-    errors*, warnings*: int
+    errors*: int
+    warnings*: int
     messages: seq[(MsgKind, PackageRepo, string)] # delayed output
     overrides*: Patterns
     defaultAlgo*: ResolutionAlgorithm
@@ -131,6 +133,8 @@ proc warn*(c: var AtlasContext; p: PackageRepo; arg: string) =
   inc c.warnings
 
 proc error*(c: var AtlasContext; p: PackageRepo; arg: string) =
+  if AssertOnError in c.flags:
+    raise newException(AssertionDefect, p.string & ": " & arg)
   c.messages.add (Error, p, arg)
   inc c.errors
 

--- a/src/context.nim
+++ b/src/context.nim
@@ -239,7 +239,7 @@ template withDir*(c: var AtlasContext; dir: string; body: untyped) =
     body
   else:
     let oldDir = getCurrentDir()
-    echo "Current directory is now ", dir
+    info c, toRepo(dir), "Current directory is now: " & dir
     try:
       when ProduceTest:
         echo "Current directory is now ", dir

--- a/src/context.nim
+++ b/src/context.nim
@@ -181,8 +181,8 @@ proc writeMessage(c: var AtlasContext; k: MsgKind; p: PackageRepo; arg: string) 
 
 proc message(c: var AtlasContext; k: MsgKind; p: PackageRepo; arg: string) =
   ## collects messages or prints them out immediately
-  c.messages.add (k, p, arg)
-  # writeMessage c, k, p, arg
+  # c.messages.add (k, p, arg)
+  writeMessage c, k, p, arg
 
 
 proc warn*(c: var AtlasContext; p: PackageRepo; arg: string) =

--- a/src/context.nim
+++ b/src/context.nim
@@ -251,7 +251,7 @@ template withDir*(c: var AtlasContext; dir: string; body: untyped) =
     body
   else:
     let oldDir = getCurrentDir()
-    info c, toRepo(dir), "Current directory is now: " & dir
+    debug c, toRepo(dir), "Current directory is now: " & dir
     try:
       when ProduceTest:
         echo "Current directory is now ", dir

--- a/src/context.nim
+++ b/src/context.nim
@@ -91,7 +91,7 @@ type
     Info = "[Info] ",
     Warning = "[Warning] ",
     Error = "[Error] "
-    Debug = "[Debug] "
+    Trace = "[Trace] "
     ExtraDebug = "[ExtraDebug] "
 
   AtlasContext* = object
@@ -159,7 +159,7 @@ proc writeMessage(c: var AtlasContext; category: string; p: PackageRepo; arg: st
   stdout.writeLine msg
 
 proc writeMessage(c: var AtlasContext; k: MsgKind; p: PackageRepo; arg: string) =
-  if k == Debug and c.verbosity < 1: return
+  if k == Trace and c.verbosity < 1: return
   elif k == ExtraDebug and c.verbosity < 2: return
 
   if NoColors in c.flags:
@@ -168,7 +168,7 @@ proc writeMessage(c: var AtlasContext; k: MsgKind; p: PackageRepo; arg: string) 
     let pn = p.string.relativePath(c.workspace)
     let color = case k
                 of ExtraDebug: fgDefault
-                of Debug: fgWhite
+                of Trace: fgWhite
                 of Info: fgGreen
                 of Warning: fgYellow
                 of Error: fgRed
@@ -193,8 +193,8 @@ proc error*(c: var AtlasContext; p: PackageRepo; arg: string) =
 proc info*(c: var AtlasContext; p: PackageRepo; arg: string) =
   c.message(Info, p, arg)
 
-proc debug*(c: var AtlasContext; p: PackageRepo; arg: string) =
-  c.message(Debug, p, arg)
+proc trace*(c: var AtlasContext; p: PackageRepo; arg: string) =
+  c.message(Trace, p, arg)
 
 proc debugExtra*(c: var AtlasContext; p: PackageRepo; arg: string) =
   c.message(ExtraDebug, p, arg)
@@ -208,8 +208,8 @@ proc error*(c: var AtlasContext; p: Package; arg: string) =
 proc info*(c: var AtlasContext; p: Package; arg: string) =
   c.info(p.repo, arg)
 
-proc debug*(c: var AtlasContext; p: Package; arg: string) =
-  c.debug(p.repo, arg)
+proc trace*(c: var AtlasContext; p: Package; arg: string) =
+  c.trace(p.repo, arg)
 
 proc debugExtra*(c: var AtlasContext; p: Package; arg: string) =
   c.debugExtra(p.repo, arg)

--- a/src/context.nim
+++ b/src/context.nim
@@ -166,13 +166,13 @@ proc writeMessage(c: var AtlasContext; k: MsgKind; p: PackageRepo; arg: string) 
     writeMessage(c, $k, p, arg)
   else:
     let pn = p.string.relativePath(c.workspace)
-    let color = case k
-                of Debug: fgDefault
-                of Trace: fgWhite
-                of Info: fgGreen
-                of Warning: fgYellow
-                of Error: fgRed
-    stdout.styledWriteLine(color, styleBright, $k, resetStyle, fgCyan, "(", pn, ")", resetStyle, " ", arg)
+    let (color, style) = case k
+                of Debug: (fgWhite, styleDim)
+                of Trace: (fgBlue, styleBright)
+                of Info: (fgGreen, styleBright)
+                of Warning: (fgYellow, styleBright)
+                of Error: (fgRed, styleBright)
+    stdout.styledWriteLine(color, style, $k, resetStyle, fgCyan, "(", pn, ")", resetStyle, " ", arg)
 
 proc message(c: var AtlasContext; k: MsgKind; p: PackageRepo; arg: string) =
   # c.messages.add (k, p, arg)

--- a/src/context.nim
+++ b/src/context.nim
@@ -134,6 +134,23 @@ proc hash*(a: Package): Hash =
   # if a.exists:
   #   result = result !& hash a.nimble
 
+proc `$`*(a: Package): string =
+  result = "Package("
+  result &= "name:" 
+  result &= a.name.string
+  result &= ", repo:" 
+  result &= a.repo.string
+  result &= ", url:" 
+  result &= $(a.url)
+  result &= ", p:" 
+  result &= a.path.string
+  result &= ", x:" 
+  result &= $(a.exists)
+  result &= ", nbl:" 
+  if a.exists:
+    result &= $(a.nimble.string)
+  result &= ")"
+
 const
   InvalidCommit* = "#head" #"<invalid commit>"
   ProduceTest* = false
@@ -193,6 +210,8 @@ proc writePendingMessages*(c: var AtlasContext) =
 
 proc infoNow*(c: var AtlasContext; p: PackageRepo; arg: string) =
   writeMessage c, Info, p, arg
+proc infoNow*(c: var AtlasContext; p: Package; arg: string) =
+  infoNow c, p.repo, arg
 
 proc fatal*(msg: string) =
   when defined(debug):

--- a/src/context.nim
+++ b/src/context.nim
@@ -51,7 +51,9 @@ type
     name*: PackageName
     repo*: PackageRepo
     path*: PackageDir
+    nimblePath*: string
     url*: PackageUrl
+    exists*: bool
 
   Dependency* = object
     pkg*: Package
@@ -190,29 +192,6 @@ template projectFromCurrentDir*(): PackageRepo =
 
 proc toDestDir*(pkg: Package): PackageDir =
   pkg.path
-
-proc dependencyDir*(c: AtlasContext; w: Dependency): PackageDir =
-  if w.pkg.path.string.len() != 0:
-    return w.pkg.path
-  result = PackageDir c.workspace / w.pkg.repo.string
-  if not dirExists(result.string):
-    result = PackageDir c.depsDir / w.pkg.repo.string
-
-proc findNimbleFile*(c: var AtlasContext; dep: Dependency): string =
-  when MockupRun:
-    result = TestsDir / dep.name.string & ".nimble"
-    doAssert fileExists(result), "file does not exist " & result
-  else:
-    let dir = dependencyDir(c, dep).string
-    result = dir / (dep.pkg.name.string & ".nimble")
-    if not fileExists(result):
-      result = ""
-      for x in walkFiles(dir / "*.nimble"):
-        if result.len == 0:
-          result = x
-        else:
-          warn c, dep.pkg, "ambiguous .nimble file " & result
-          return ""
 
 template withDir*(c: var AtlasContext; dir: string; body: untyped) =
   when MockupRun:

--- a/src/context.nim
+++ b/src/context.nim
@@ -115,9 +115,24 @@ type
 proc `==`*(a, b: CfgPath): bool {.borrow.}
 
 proc `==`*(a, b: PackageName): bool {.borrow.}
-proc hash*(a: PackageName): Hash {.borrow.}
 proc `==`*(a, b: PackageRepo): bool {.borrow.}
+proc `==`*(a, b: PackageDir): bool {.borrow.}
+proc `==`*(a, b: PackageNimble): bool {.borrow.}
+
+proc hash*(a: PackageName): Hash {.borrow.}
 proc hash*(a: PackageRepo): Hash {.borrow.}
+proc hash*(a: PackageDir): Hash {.borrow.}
+proc hash*(a: PackageNimble): Hash {.borrow.}
+
+proc hash*(a: Package): Hash =
+  result = 0
+  result = result !& hash a.name
+  # result = result !& hash a.repo
+  # result = result !& hash a.url
+  # result = result !& hash a.path
+  # result = result !& hash a.exists
+  # if a.exists:
+  #   result = result !& hash a.nimble
 
 const
   InvalidCommit* = "#head" #"<invalid commit>"
@@ -206,6 +221,7 @@ template withDir*(c: var AtlasContext; dir: string; body: untyped) =
     body
   else:
     let oldDir = getCurrentDir()
+    echo "Current directory is now ", dir
     try:
       when ProduceTest:
         echo "Current directory is now ", dir

--- a/src/context.nim
+++ b/src/context.nim
@@ -200,9 +200,8 @@ proc fatal*(msg: string) =
   quit "[Error] " & msg
 
 proc toRepo*(p: PackageUrl): PackageRepo =
-  result = PackageRepo p.path.lastPathComponent
-  if result.string.endsWith(".git"):
-    result.string.setLen result.string.len - ".git".len
+  result = PackageRepo lastPathComponent($p)
+  result.string.removeSuffix(".git")
 
 proc toRepo*(p: string): PackageRepo =
   if p.contains("://"):

--- a/src/context.nim
+++ b/src/context.nim
@@ -45,15 +45,19 @@ type
 
   PackageName* = distinct string
   PackageDir* = distinct string
+  PackageNimble* = distinct string
   PackageRepo* = distinct string
 
   Package* = ref object
     name*: PackageName
     repo*: PackageRepo
-    path*: PackageDir
-    nimblePath*: string
     url*: PackageUrl
-    exists*: bool
+    case exists*: bool
+    of true:
+      path*: PackageDir
+      nimble*: PackageNimble
+    of false:
+      discard
 
   Dependency* = object
     pkg*: Package

--- a/src/context.nim
+++ b/src/context.nim
@@ -52,9 +52,9 @@ type
     name*: PackageName
     repo*: PackageRepo
     url*: PackageUrl
+    path*: PackageDir
     case exists*: bool
     of true:
-      path*: PackageDir
       nimble*: PackageNimble
     of false:
       discard

--- a/src/context.nim
+++ b/src/context.nim
@@ -86,7 +86,6 @@ type
     ListVersions
     GlobalWorkspace
     AssertOnError
-    ExportNimbleLock
 
   MsgKind = enum
     Info = "[Info] ",

--- a/src/context.nim
+++ b/src/context.nim
@@ -53,11 +53,8 @@ type
     repo*: PackageRepo
     url*: PackageUrl
     path*: PackageDir
-    case exists*: bool
-    of true:
-      nimble*: PackageNimble
-    of false:
-      discard
+    exists*: bool
+    nimble*: PackageNimble
 
   Dependency* = object
     pkg*: Package
@@ -111,6 +108,11 @@ type
       step*: int
       mockupSuccess*: bool
     plugins*: PluginInfo
+
+proc nimble*(a: Package): PackageNimble =
+  assert a.exists == true
+  a.nimble
+
 
 proc `==`*(a, b: CfgPath): bool {.borrow.}
 

--- a/src/context.nim
+++ b/src/context.nim
@@ -92,7 +92,7 @@ type
     Warning = "[Warning] ",
     Error = "[Error] "
     Trace = "[Trace] "
-    ExtraDebug = "[ExtraDebug] "
+    Debug = "[Debug] "
 
   AtlasContext* = object
     projectDir*, workspace*, depsDir*, currentDir*: string
@@ -160,14 +160,14 @@ proc writeMessage(c: var AtlasContext; category: string; p: PackageRepo; arg: st
 
 proc writeMessage(c: var AtlasContext; k: MsgKind; p: PackageRepo; arg: string) =
   if k == Trace and c.verbosity < 1: return
-  elif k == ExtraDebug and c.verbosity < 2: return
+  elif k == Debug and c.verbosity < 2: return
 
   if NoColors in c.flags:
     writeMessage(c, $k, p, arg)
   else:
     let pn = p.string.relativePath(c.workspace)
     let color = case k
-                of ExtraDebug: fgDefault
+                of Debug: fgDefault
                 of Trace: fgWhite
                 of Info: fgGreen
                 of Warning: fgYellow
@@ -196,8 +196,8 @@ proc info*(c: var AtlasContext; p: PackageRepo; arg: string) =
 proc trace*(c: var AtlasContext; p: PackageRepo; arg: string) =
   c.message(Trace, p, arg)
 
-proc debugExtra*(c: var AtlasContext; p: PackageRepo; arg: string) =
-  c.message(ExtraDebug, p, arg)
+proc debug*(c: var AtlasContext; p: PackageRepo; arg: string) =
+  c.message(Debug, p, arg)
 
 proc warn*(c: var AtlasContext; p: Package; arg: string) =
   c.warn(p.repo, arg)
@@ -211,8 +211,8 @@ proc info*(c: var AtlasContext; p: Package; arg: string) =
 proc trace*(c: var AtlasContext; p: Package; arg: string) =
   c.trace(p.repo, arg)
 
-proc debugExtra*(c: var AtlasContext; p: Package; arg: string) =
-  c.debugExtra(p.repo, arg)
+proc debug*(c: var AtlasContext; p: Package; arg: string) =
+  c.debug(p.repo, arg)
 
 proc writePendingMessages*(c: var AtlasContext) =
   for i in 0..<c.messages.len:

--- a/src/lockfiles.nim
+++ b/src/lockfiles.nim
@@ -85,6 +85,7 @@ proc genLockEntry(c: var AtlasContext;
   let url = getRemoteUrl()
   let commit = getCurrentCommit()
   let name = pkg.name.string
+  infoNow c, pkg, "calculating nimble checksum"
   let chk = c.nimbleChecksum(pkg, cfg)
   lf.packages[name] = NimbleLockFileEntry(
     version: version,
@@ -155,7 +156,6 @@ proc pinProject*(c: var AtlasContext; lockFilePath: string, exportNimble = false
           genLockEntry c, lf, dir.relativePath(c.currentDir, '/')
 
           if exportNimble:
-            infoNow c, w.pkg, "finding nimble deps " & w.pkg.name.string & " " 
             for nx in g.nodes: # expensive, but eh
               if nx.active and i in nx.parents:
                 nimbleDeps.mgetOrPut(w.pkg.name,

--- a/src/lockfiles.nim
+++ b/src/lockfiles.nim
@@ -105,7 +105,7 @@ proc pinProject*(c: var AtlasContext; lockFilePath: string) =
       if g.nodes[i].active:
         let w = g.nodes[i]
         let dir = w.pkg.path.string
-        tryWithDir dir:
+        tryWithDir c, dir:
           genLockEntry c, lf, dir.relativePath(c.currentDir, '/')
 
     let nimcfgPath = c.currentDir / NimCfg

--- a/src/lockfiles.nim
+++ b/src/lockfiles.nim
@@ -79,7 +79,7 @@ proc pinWorkspace*(c: var AtlasContext; lockFilePath: string) =
 proc pinProject*(c: var AtlasContext; lockFilePath: string) =
   var lf = newLockFile()
 
-  let start = resolvePackage(c, PackageDir c.currentDir)
+  let start = resolvePackage(c, "file://" & c.currentDir)
   let url = getRemoteUrl()
   var g = createGraph(c, start)
 

--- a/src/lockfiles.nim
+++ b/src/lockfiles.nim
@@ -9,7 +9,7 @@
 ## Lockfile implementation.
 
 import std / [sequtils, strutils, algorithm, tables, os, json, jsonutils, sha1]
-import context, gitops, osutils, traversal, compilerversions, nameresolver
+import context, gitops, osutils, traversal, compilerversions, nameresolver, parse_requires
 
 type
   LockFileEntry* = object
@@ -163,9 +163,8 @@ proc pinProject*(c: var AtlasContext; lockFilePath: string, exportNimble = false
             trace c, w.pkg, "exporting nimble " & w.pkg.name.string
             let name = w.pkg.name
             let deps = nimbleDeps.getOrDefault(name)
-            var ver = versionKey(w.query)
-            if ver == "#head": ver = "0.1.0"
-            genLockEntry c, nlf, w.pkg, cfgs[name], ver, deps
+            let info = extractRequiresInfo(w.pkg.nimble.string)
+            genLockEntry c, nlf, w.pkg, cfgs[name], info.version, deps
 
     let nimcfgPath = c.currentDir / NimCfg
     if fileExists(nimcfgPath):

--- a/src/lockfiles.nim
+++ b/src/lockfiles.nim
@@ -149,6 +149,12 @@ proc pinProject*(c: var AtlasContext; lockFilePath: string, exportNimble = false
                                  initHashSet[PackageName]()).incl(nx.pkg.name)
     inc i
 
+  if exportNimble:
+    for (name, cfg) in cfgs.pairs():
+      warn c, startPkg, "CfgPath: name: " & name.string & " path: " & cfg.string
+    for (name, deps) in nimbleDeps.pairs():
+      warn c, startPkg, "deps: name: " & name.string & " deps: " & $deps
+
   if c.errors == 0:
     # topo-sort:
     for i in countdown(g.nodes.len-1, 1):
@@ -158,8 +164,10 @@ proc pinProject*(c: var AtlasContext; lockFilePath: string, exportNimble = false
         tryWithDir c, dir:
           genLockEntry c, lf, dir.relativePath(c.currentDir, '/')
           if exportNimble:
+            trace c, w.pkg, "exporting: " & w.pkg.name.string
             let name = w.pkg.name
-            genLockEntry c, nlf, w.pkg, cfgs[name], "0.1", nimbleDeps[name]
+            let deps = nimbleDeps.getOrDefault(name)
+            genLockEntry c, nlf, w.pkg, cfgs[name], "0.1", deps
 
     let nimcfgPath = c.currentDir / NimCfg
     if fileExists(nimcfgPath):

--- a/src/lockfiles.nim
+++ b/src/lockfiles.nim
@@ -149,12 +149,6 @@ proc pinProject*(c: var AtlasContext; lockFilePath: string, exportNimble = false
                                  initHashSet[PackageName]()).incl(nx.pkg.name)
     inc i
 
-  if exportNimble:
-    for (name, cfg) in cfgs.pairs():
-      warn c, startPkg, "CfgPath: name: " & name.string & " path: " & cfg.string
-    for (name, deps) in nimbleDeps.pairs():
-      warn c, startPkg, "deps: name: " & name.string & " deps: " & $deps
-
   if c.errors == 0:
     # topo-sort:
     for i in countdown(g.nodes.len-1, 1):
@@ -163,6 +157,7 @@ proc pinProject*(c: var AtlasContext; lockFilePath: string, exportNimble = false
         let dir = w.pkg.path.string
         tryWithDir c, dir:
           genLockEntry c, lf, dir.relativePath(c.currentDir, '/')
+
           if exportNimble:
             trace c, w.pkg, "exporting: " & w.pkg.name.string
             let name = w.pkg.name

--- a/src/lockfiles.nim
+++ b/src/lockfiles.nim
@@ -156,10 +156,10 @@ proc pinProject*(c: var AtlasContext; lockFilePath: string, exportNimble = false
           genLockEntry c, lf, dir.relativePath(c.currentDir, '/')
 
           if exportNimble:
-            trace c, w.pkg, "exporting: " & w.pkg.name.string
+            trace c, w.pkg, "exporting nimble " & w.pkg.name.string
             let name = w.pkg.name
             let deps = nimbleDeps.getOrDefault(name)
-            genLockEntry c, nlf, w.pkg, cfgs[name], "0.1", deps
+            genLockEntry c, nlf, w.pkg, cfgs[name], "0.1.0", deps
 
     let nimcfgPath = c.currentDir / NimCfg
     if fileExists(nimcfgPath):

--- a/src/lockfiles.nim
+++ b/src/lockfiles.nim
@@ -119,9 +119,7 @@ proc pinWorkspace*(c: var AtlasContext; lockFilePath: string) =
 proc pinProject*(c: var AtlasContext; lockFilePath: string, exportNimble = false) =
   var lf = newLockFile()
   var nlf = newNimbleLockFile()
-
   let startPkg = resolvePackage(c, "file://" & c.currentDir)
-  let url = getRemoteUrl()
   var g = createGraph(c, startPkg)
 
   var nimbleDeps = newTable[PackageName, HashSet[PackageName]]()
@@ -142,8 +140,7 @@ proc pinProject*(c: var AtlasContext; lockFilePath: string, exportNimble = false
       let cfgPath = collectNewDeps(c, g, i, w)
       cfgs[w.pkg.name] = cfgPath
       if exportNimble:
-        # expensive, but eh
-        for nx in g.nodes:
+        for nx in g.nodes: # expensive, but eh
           if i in nx.parents:
             nimbleDeps.mgetOrPut(w.pkg.name,
                                  initHashSet[PackageName]()).incl(nx.pkg.name)

--- a/src/lockfiles.nim
+++ b/src/lockfiles.nim
@@ -162,7 +162,9 @@ proc pinProject*(c: var AtlasContext; lockFilePath: string, exportNimble = false
             trace c, w.pkg, "exporting nimble " & w.pkg.name.string
             let name = w.pkg.name
             let deps = nimbleDeps.getOrDefault(name)
-            genLockEntry c, nlf, w.pkg, cfgs[name], "0.1.0", deps
+            var ver = versionKey(w.query)
+            if ver == "#head": ver = "0.1.0"
+            genLockEntry c, nlf, w.pkg, cfgs[name], ver, deps
 
     let nimcfgPath = c.currentDir / NimCfg
     if fileExists(nimcfgPath):

--- a/src/lockfiles.nim
+++ b/src/lockfiles.nim
@@ -79,9 +79,8 @@ proc pinWorkspace*(c: var AtlasContext; lockFilePath: string) =
 proc pinProject*(c: var AtlasContext; lockFilePath: string) =
   var lf = newLockFile()
 
-  let start = c.currentDir.lastPathComponent.toName()
-  let url = getRemoteUrl()
-  var g = createGraph(c, start, url, path=c.currentDir)
+  let start = resolvePackage(c, )
+  var g = createGraph(c, start)
 
   info c, start, "pinning lockfile: " & lockFilePath
 

--- a/src/lockfiles.nim
+++ b/src/lockfiles.nim
@@ -89,7 +89,7 @@ proc pinProject*(c: var AtlasContext; lockFilePath: string) =
   while i < g.nodes.len:
     let w = g.nodes[i]
 
-    info c, w.pkg, "pinning..."
+    info c, w.pkg, "pinning: " & $w.pkg
 
     if not w.pkg.exists:
       error c, w.pkg, "dependency does not exist"

--- a/src/lockfiles.nim
+++ b/src/lockfiles.nim
@@ -155,6 +155,7 @@ proc pinProject*(c: var AtlasContext; lockFilePath: string, exportNimble = false
           genLockEntry c, lf, dir.relativePath(c.currentDir, '/')
 
           if exportNimble:
+            infoNow c, w.pkg, "finding nimble deps " & w.pkg.name.string & " " 
             for nx in g.nodes: # expensive, but eh
               if nx.active and i in nx.parents:
                 nimbleDeps.mgetOrPut(w.pkg.name,

--- a/src/nameresolver.nim
+++ b/src/nameresolver.nim
@@ -112,10 +112,10 @@ proc dependencyDir*(c: var AtlasContext; pkg: Package): PackageDir =
   
   debug c, pkg, "dependencyDir: check: pth: " & pkg.path.string & " cd: " & getCurrentDir() & " ws: " & c.workspace
   if pkg.exists:
-    debug  c, pkg, "dependencyDir: exists: " & pkg.path.string
+    debug c, pkg, "dependencyDir: exists: " & pkg.path.string
     return PackageDir pkg.path.string.absolutePath
   if c.workspace.lastPathComponent == pkg.repo.string:
-    debug  c, pkg, "dependencyDir: workspace: " & c.workspace
+    debug c, pkg, "dependencyDir: workspace: " & c.workspace
     return PackageDir getCurrentDir()
 
   if pkg.path.string.len() > 0:
@@ -236,6 +236,14 @@ proc resolvePackageName(c: var AtlasContext; name: string): Package =
       result.url = getUrl newUrl
 
 proc resolvePackage*(c: var AtlasContext; rawHandle: string): Package =
+  ## Takes a raw handle which can be a name, a repo name, or a url
+  ## and resolves it into a package. If not found it will create
+  ## a new one.
+  ## 
+  ## Note that Package should be unique globally. This happens
+  ## by updating the packages list when new packages are added or
+  ## loaded from a packages.json.
+  ## 
   result.new()
 
   fillPackageLookupTable(c)
@@ -251,7 +259,6 @@ proc resolvePackage*(c: var AtlasContext; rawHandle: string): Package =
   let res = c.findNimbleFile(result, result.path)
   if res.isSome:
     let nimble = PackageNimble res.get()
-    # let path = PackageDir res.get().parentDir()
     result.exists = true
     result.nimble = nimble
     debug c, result, "resolvePackageName: nimble: found: " & $result
@@ -260,6 +267,13 @@ proc resolvePackage*(c: var AtlasContext; rawHandle: string): Package =
   
 
 proc resolveNimble*(c: var AtlasContext; pkg: Package) =
+  ## Try to resolve the nimble file for the given package.
+  ## 
+  ## This should be done after cloning a new repo. 
+  ## 
+
+  if pkg.exists:
+    return
 
   pkg.path = dependencyDir(c, pkg)
   let res = c.findNimbleFile(pkg)

--- a/src/nameresolver.nim
+++ b/src/nameresolver.nim
@@ -253,13 +253,15 @@ proc resolvePackage*(c: var AtlasContext; rawHandle: string): Package =
   let res = c.findNimbleFile(result)
   if res.isSome:
     let nimble = PackageNimble res.get()
-    let path = PackageDir res.get().parentDir()
-    result = Package(url: result.url,
-                     name: result.name,
-                     repo: result.repo,
-                     path: path,
-                     exists: true,
-                     nimble: nimble)
+    # let path = PackageDir res.get().parentDir()
+    result.exists = true
+    result.nimble = nimble
+    # result = Package(url: result.url,
+    #                  name: result.name,
+    #                  repo: result.repo,
+    #                  path: path,
+    #                  exists: true,
+    #                  nimble: nimble)
     debug c, result, "resolvePackageName: nimble: found: " & $result
   else:
     debug c, result, "resolvePackageName: nimble: not found: " & $result

--- a/src/nameresolver.nim
+++ b/src/nameresolver.nim
@@ -104,17 +104,17 @@ proc fillPackageLookupTable(c: var AtlasContext) =
 
 proc dependencyDir*(c: var AtlasContext; pkg: Package): PackageDir =
   template checkDir(dir: string) =
-    info c, pkg, "dependencyDir: test: " & dir
+    debug c, pkg, "dependencyDir: test: " & dir
     if dir.len() > 0 and dirExists(dir):
-      info c, pkg, "dependencyDir: found: " & dir 
+      debug c, pkg, "dependencyDir: found: " & dir 
       return PackageDir dir
   
-  info c, pkg, "dependencyDir: check: pth: " & pkg.path.string & " cd: " & getCurrentDir() & " ws: " & c.workspace
+  debug c, pkg, "dependencyDir: check: pth: " & pkg.path.string & " cd: " & getCurrentDir() & " ws: " & c.workspace
   if pkg.exists:
-    info c, pkg, "dependencyDir: exists: " & pkg.path.string
+    debug c, pkg, "dependencyDir: exists: " & pkg.path.string
     return pkg.path
   if c.workspace.lastPathComponent == pkg.repo.string:
-    info c, pkg, "dependencyDir: workspace: " & c.workspace
+    debug c, pkg, "dependencyDir: workspace: " & c.workspace
     return PackageDir getCurrentDir()
 
   if pkg.path.string.len() > 0:
@@ -127,7 +127,7 @@ proc dependencyDir*(c: var AtlasContext; pkg: Package): PackageDir =
   checkDir c.workspace / pkg.name.string
   checkDir c.depsDir / pkg.name.string
   result = PackageDir c.depsDir / pkg.repo.string
-  info c, pkg, "dependencyDir: failed: defaulting: " & result.string 
+  debug c, pkg, "dependencyDir: failed: defaulting: " & result.string 
 
 proc findNimbleFile*(c: var AtlasContext; pkg: Package): Option[string] =
   when MockupRun:
@@ -136,19 +136,19 @@ proc findNimbleFile*(c: var AtlasContext; pkg: Package): Option[string] =
   else:
     let dir = dependencyDir(c, pkg).string
     result = some dir / (pkg.name.string & ".nimble")
-    info c, pkg, "findNimbleFile: find: " & pkg.repo.string & " path: " & pkg.path.string & " dir: " & dir & " curr: " & result.get()
+    debug c, pkg, "findNimbleFile: find: " & pkg.repo.string & " path: " & pkg.path.string & " dir: " & dir & " curr: " & result.get()
     if not fileExists(result.get()):
-      info c, pkg, "findNimbleFile: not found: " & result.get()
+      debug c, pkg, "findNimbleFile: not found: " & result.get()
       result = none[string]()
       for x in walkFiles(dir / "*.nimble"):
         if result.isNone:
           result = some x
-          info c, pkg, "findNimbleFile: found: " & result.get()
+          debug c, pkg, "findNimbleFile: found: " & result.get()
         else:
           error c, pkg, "ambiguous .nimble file " & result.get()
           return none[string]()
     else:
-      info c, pkg, "findNimbleFile: found: " & result.get()
+      debug c, pkg, "findNimbleFile: found: " & result.get()
       discard
 
 proc resolvePackageUrl(c: var AtlasContext; url: string, checkOverrides = true): Package =
@@ -156,7 +156,7 @@ proc resolvePackageUrl(c: var AtlasContext; url: string, checkOverrides = true):
                    name: url.toRepo().PackageName,
                    repo: url.toRepo())
   
-  info c, result, "resolvePackageUrl: search: " & url
+  debug c, result, "resolvePackageUrl: search: " & url
 
   let isFile = result.url.scheme == "file"
   if not isFile and checkOverrides and UsesOverrides in c.flags:
@@ -181,20 +181,20 @@ proc resolvePackageUrl(c: var AtlasContext; url: string, checkOverrides = true):
                 result.name.string & " to " & pname
       result.repo = PackageRepo pname
       c.urlMapping["name:" & result.name.string] = result
-    info c, result, "resolvePackageUrl: found name: " & $result.name.string
+    debug c, result, "resolvePackageUrl: found name: " & $result.name.string
 
   elif not repoPkg.isNil:
-    info c, result, "resolvePackageUrl: found repo: " & $result.repo.string
+    debug c, result, "resolvePackageUrl: found repo: " & $result.repo.string
     result = repoPkg
   else:
     # package doesn't exit and doesn't conflict
     # set the url with package name as url name
     c.urlMapping["repo:" & result.name.string] = result
-    info c, result, "resolvePackageUrl: not found; set pkg: " & $result.repo.string
+    debug c, result, "resolvePackageUrl: not found; set pkg: " & $result.repo.string
   
   if result.url.scheme == "file":
     result.path = PackageDir result.url.hostname & result.url.path
-    info c, result, "resolvePackageUrl: setting manual path: " & $result.path.string
+    debug c, result, "resolvePackageUrl: setting manual path: " & $result.path.string
 
 proc resolvePackageName(c: var AtlasContext; name: string): Package =
   result = Package(name: PackageName name,
@@ -260,9 +260,9 @@ proc resolvePackage*(c: var AtlasContext; rawHandle: string): Package =
                      path: path,
                      exists: true,
                      nimble: nimble)
-    info c, result, "resolvePackageName: nimble: found: " & $result
+    debug c, result, "resolvePackageName: nimble: found: " & $result
   else:
-    info c, result, "resolvePackageName: nimble: not found: " & $result
+    debug c, result, "resolvePackageName: nimble: not found: " & $result
   
 
 # proc resolvePackage*(c: var AtlasContext; dir: PackageDir): Package =

--- a/src/nameresolver.nim
+++ b/src/nameresolver.nim
@@ -144,12 +144,12 @@ proc findNimbleFile*(c: var AtlasContext; pkg: Package): Option[string] =
       for x in walkFiles(dir / "*.nimble"):
         if result.isNone:
           result = some x
-          debug  c, pkg, "nimble file found " & result.get()
+          trace c, pkg, "nimble file found " & result.get()
         else:
           error c, pkg, "ambiguous .nimble file " & result.get()
           return none[string]()
     else:
-      debug  c, pkg, "nimble file found " & result.get()
+      trace c, pkg, "nimble file found " & result.get()
       discard
 
 proc resolvePackageUrl(c: var AtlasContext; url: string, checkOverrides = true): Package =
@@ -190,11 +190,11 @@ proc resolvePackageUrl(c: var AtlasContext; url: string, checkOverrides = true):
     # package doesn't exit and doesn't conflict
     # set the url with package name as url name
     c.urlMapping["repo:" & result.name.string] = result
-    debug c, result, "resolvePackageUrl: not found; set pkg: " & $result.repo.string
+    trace c, result, "resolvePackageUrl: not found; set pkg: " & $result.repo.string
   
   if result.url.scheme == "file":
     result.path = PackageDir result.url.hostname & result.url.path
-    debug c, result, "resolvePackageUrl: setting manual path: " & $result.path.string
+    trace c, result, "resolvePackageUrl: setting manual path: " & $result.path.string
 
 proc resolvePackageName(c: var AtlasContext; name: string): Package =
   result = Package(name: PackageName name,
@@ -231,7 +231,7 @@ proc resolvePackageName(c: var AtlasContext; name: string): Package =
   if UsesOverrides in c.flags:
     let newUrl = c.overrides.substitute($result.url)
     if newUrl.len > 0:
-      debug c, result, "resolvePackageName: not url: UsesOverrides: " & $newUrl
+      trace c, result, "resolvePackageName: not url: UsesOverrides: " & $newUrl
       result.url = getUrl newUrl
 
 proc resolvePackage*(c: var AtlasContext; rawHandle: string): Package =
@@ -239,7 +239,7 @@ proc resolvePackage*(c: var AtlasContext; rawHandle: string): Package =
 
   fillPackageLookupTable(c)
 
-  debug c, result, "resolvePackage: search: " & rawHandle
+  trace c, result, "resolvePackage: search: " & rawHandle
 
   if rawHandle.isUrl():
     result = c.resolvePackageUrl(rawHandle)

--- a/src/nameresolver.nim
+++ b/src/nameresolver.nim
@@ -113,7 +113,7 @@ proc resolvePackage*(c: var AtlasContext; rawHandle: string): Package =
 
   if rawHandle.isUrl():
     result.url = getUrl(rawHandle)
-    result.name = PackageName result.url.toRepo().string
+    result.name = result.url.toRepo().PackageName 
     result.repo = result.url.toRepo()
     echo "resolvePackage: ", "IS URL: ", $result.url
 

--- a/src/nameresolver.nim
+++ b/src/nameresolver.nim
@@ -103,7 +103,7 @@ proc fillPackageLookupTable(c: var AtlasContext) =
       c.urlMapping["name:" & pkg.name.string] = pkg
 
 proc dependencyDir*(c: AtlasContext; pkg: Package): PackageDir =
-  if pkg.path.string.len() != 0:
+  if pkg.exists:
     return pkg.path
   result = PackageDir c.workspace / pkg.repo.string
   if not dirExists(result.string):
@@ -127,8 +127,8 @@ proc findNimbleFile*(c: var AtlasContext; pkg: Package): Option[string] =
 
 proc resolvePackageUrl(c: var AtlasContext; url: string): Package =
   result = Package(url: getUrl(url),
-                   name: result.url.toRepo().PackageName,
-                   repo: result.url.toRepo())
+                   name: url.toRepo().PackageName,
+                   repo: url.toRepo())
   
   echo "resolvePackage: ", "IS URL: ", $result.url
 
@@ -213,9 +213,9 @@ proc resolvePackage*(c: var AtlasContext; rawHandle: string): Package =
   
   let res = c.findNimbleFile(result)
   if res.isSome:
+    result.exists = true
     result.nimble = PackageNimble res.get()
     result.path = PackageDir res.get().parentDir()
-    result.exists = true
 
 proc resolvePackage*(c: var AtlasContext; dir: PackageDir): Package =
 

--- a/src/nameresolver.nim
+++ b/src/nameresolver.nim
@@ -100,8 +100,6 @@ proc fillPackageLookupTable(c: var AtlasContext) =
                         url: url)
       c.urlMapping["name:" & pkg.name.string] = pkg
 
-import sequtils
-
 proc resolvePackage*(c: var AtlasContext; rawHandle: string): Package =
   result.new()
 

--- a/src/nameresolver.nim
+++ b/src/nameresolver.nim
@@ -94,7 +94,7 @@ proc fillPackageLookupTable(c: var AtlasContext) =
       if not fileExists(c.workspace / DefaultPackagesDir / "packages.json"):
         updatePackages(c)
     let plist = getPackageInfos(when MockupRun: TestsDir else: c.workspace)
-    debugExtra c, toRepo("fillPackageLookupTable"), "initializing..."
+    debug c, toRepo("fillPackageLookupTable"), "initializing..."
     for entry in plist:
       let url = getUrl(entry.url)
       let pkg = Package(name: PackageName unicode.toLower entry.name,
@@ -105,17 +105,17 @@ proc fillPackageLookupTable(c: var AtlasContext) =
 proc dependencyDir*(c: var AtlasContext; pkg: Package): PackageDir =
   template checkDir(dir: string) =
     if dir.len() > 0 and dirExists(dir):
-      debugExtra c, pkg, "dependencyDir: found: " & dir 
+      debug c, pkg, "dependencyDir: found: " & dir 
       return PackageDir dir
     else:
-      debugExtra c, pkg, "dependencyDir: not found: " & dir 
+      debug c, pkg, "dependencyDir: not found: " & dir 
   
-  debugExtra c, pkg, "dependencyDir: check: pth: " & pkg.path.string & " cd: " & getCurrentDir() & " ws: " & c.workspace
+  debug c, pkg, "dependencyDir: check: pth: " & pkg.path.string & " cd: " & getCurrentDir() & " ws: " & c.workspace
   if pkg.exists:
-    debugExtra  c, pkg, "dependencyDir: exists: " & pkg.path.string
+    debug  c, pkg, "dependencyDir: exists: " & pkg.path.string
     return PackageDir pkg.path.string.absolutePath
   if c.workspace.lastPathComponent == pkg.repo.string:
-    debugExtra  c, pkg, "dependencyDir: workspace: " & c.workspace
+    debug  c, pkg, "dependencyDir: workspace: " & c.workspace
     return PackageDir getCurrentDir()
 
   if pkg.path.string.len() > 0:
@@ -137,9 +137,9 @@ proc findNimbleFile*(c: var AtlasContext; pkg: Package): Option[string] =
   else:
     let dir = dependencyDir(c, pkg).string
     result = some dir / (pkg.name.string & ".nimble")
-    debugExtra  c, pkg, "findNimbleFile: searching: " & pkg.repo.string & " path: " & pkg.path.string & " dir: " & dir & " curr: " & result.get()
+    debug  c, pkg, "findNimbleFile: searching: " & pkg.repo.string & " path: " & pkg.path.string & " dir: " & dir & " curr: " & result.get()
     if not fileExists(result.get()):
-      debugExtra  c, pkg, "findNimbleFile: not found: " & result.get()
+      debug  c, pkg, "findNimbleFile: not found: " & result.get()
       result = none[string]()
       for x in walkFiles(dir / "*.nimble"):
         if result.isNone:
@@ -157,7 +157,7 @@ proc resolvePackageUrl(c: var AtlasContext; url: string, checkOverrides = true):
                    name: url.toRepo().PackageName,
                    repo: url.toRepo())
   
-  debugExtra c, result, "resolvePackageUrl: search: " & url
+  debug c, result, "resolvePackageUrl: search: " & url
 
   let isFile = result.url.scheme == "file"
   if not isFile and checkOverrides and UsesOverrides in c.flags:
@@ -182,9 +182,9 @@ proc resolvePackageUrl(c: var AtlasContext; url: string, checkOverrides = true):
                 result.name.string & " to " & pname
       result.repo = PackageRepo pname
       c.urlMapping["name:" & result.name.string] = result
-    debugExtra c, result, "resolvePackageUrl: found by name: " & $result.name.string
+    debug c, result, "resolvePackageUrl: found by name: " & $result.name.string
   elif not repoPkg.isNil:
-    debugExtra c, result, "resolvePackageUrl: found by repo: " & $result.repo.string
+    debug c, result, "resolvePackageUrl: found by repo: " & $result.repo.string
     result = repoPkg
   else:
     # package doesn't exit and doesn't conflict
@@ -211,14 +211,14 @@ proc resolvePackageName(c: var AtlasContext; name: string): Package =
   let namePkg = c.urlMapping.getOrDefault("name:" & result.name.string, nil)
   let repoPkg = c.urlMapping.getOrDefault("repo:" & result.name.string, nil)
 
-  debugExtra c, result, "resolvePackageName: searching for package name: " & result.name.string
+  debug c, result, "resolvePackageName: searching for package name: " & result.name.string
   if not namePkg.isNil:
     # great, found package!
-    debugExtra c, result, "resolvePackageName: found!"
+    debug c, result, "resolvePackageName: found!"
     result = namePkg
   elif not repoPkg.isNil:
     # check if rawHandle is a package repo name
-    debugExtra c, result, "resolvePackageName: found by repo!"
+    debug c, result, "resolvePackageName: found by repo!"
     result = repoPkg
   else:
     info c, result, "could not resolve by name or repo; searching GitHub"
@@ -253,9 +253,9 @@ proc resolvePackage*(c: var AtlasContext; rawHandle: string): Package =
     # let path = PackageDir res.get().parentDir()
     result.exists = true
     result.nimble = nimble
-    debugExtra c, result, "resolvePackageName: nimble: found: " & $result
+    debug c, result, "resolvePackageName: nimble: found: " & $result
   else:
-    debugExtra c, result, "resolvePackageName: nimble: not found: " & $result
+    debug c, result, "resolvePackageName: nimble: not found: " & $result
   
 
 proc resolveNimble*(c: var AtlasContext; pkg: Package) =

--- a/src/nameresolver.nim
+++ b/src/nameresolver.nim
@@ -150,7 +150,7 @@ proc resolvePackageUrl(c: var AtlasContext; url: string, checkOverrides = true):
     if url.len > 0:
       result.url = url.getUrl()
 
-  debug c, result, "resolvePackageUrl: search: " & $result.name.string
+  debug c, result, "resolvePackageUrl: search: " & url
 
   let namePkg = c.urlMapping.getOrDefault("name:" & result.name.string, nil)
   let repoPkg = c.urlMapping.getOrDefault("repo:" & result.repo.string, nil)
@@ -178,9 +178,11 @@ proc resolvePackageUrl(c: var AtlasContext; url: string, checkOverrides = true):
     # package doesn't exit and doesn't conflict
     # set the url with package name as url name
     c.urlMapping["repo:" & result.name.string] = result
+    debug c, result, "resolvePackageUrl: not found; set pkg: " & $result.repo.string
   
   if result.url.scheme == "file":
     result.path = PackageDir result.url.hostname & result.url.path
+  print result
 
 proc resolvePackageName(c: var AtlasContext; name: string): Package =
   result = Package(name: PackageName name,
@@ -248,7 +250,7 @@ proc resolvePackage*(c: var AtlasContext; rawHandle: string): Package =
   else:
     debug c, result, "resolvePackageName: nimble not found"
   
-  print result
+  # print result
 
 # proc resolvePackage*(c: var AtlasContext; dir: PackageDir): Package =
 

--- a/src/nameresolver.nim
+++ b/src/nameresolver.nim
@@ -216,9 +216,15 @@ proc resolvePackage*(c: var AtlasContext; rawHandle: string): Package =
   
   let res = c.findNimbleFile(result)
   if res.isSome:
-    result.nimblePath = res.get()
+    result.nimble = PackageNimble res.get()
     result.path = PackageDir res.get().parentDir()
     result.exists = true
 
-proc resolvePackage*(c: var AtlasContext; dir: string): Package =
+proc resolvePackage*(c: var AtlasContext; dir: PackageDir): Package =
+
+  # let destDir = toDestDir(w.pkg.name)
+  # let dir =
+  #   if destDir == start.string: c.currentDir
+  #   else: selectDir(c.workspace / destDir, c.depsDir / destDir)
   
+  discard

--- a/src/nameresolver.nim
+++ b/src/nameresolver.nim
@@ -112,7 +112,7 @@ proc dependencyDir*(c: var AtlasContext; pkg: Package): PackageDir =
   debug c, pkg, "dependencyDir: check: pth: " & pkg.path.string & " cd: " & getCurrentDir() & " ws: " & c.workspace
   if pkg.exists:
     debug c, pkg, "dependencyDir: exists: " & pkg.path.string
-    return pkg.path
+    return PackageDir pkg.path.string.absolutePath
   if c.workspace.lastPathComponent == pkg.repo.string:
     debug c, pkg, "dependencyDir: workspace: " & c.workspace
     return PackageDir getCurrentDir()

--- a/src/nameresolver.nim
+++ b/src/nameresolver.nim
@@ -102,8 +102,6 @@ proc fillPackageLookupTable(c: var AtlasContext) =
                         url: url)
       c.urlMapping["name:" & pkg.name.string] = pkg
 
-import pretty
-
 proc dependencyDir*(c: var AtlasContext; pkg: Package): PackageDir =
   template checkDir(dir: string) =
     if dir.len() > 0 and dirExists(dir):
@@ -182,7 +180,6 @@ proc resolvePackageUrl(c: var AtlasContext; url: string, checkOverrides = true):
   
   if result.url.scheme == "file":
     result.path = PackageDir result.url.hostname & result.url.path
-  print result
 
 proc resolvePackageName(c: var AtlasContext; name: string): Package =
   result = Package(name: PackageName name,

--- a/src/nameresolver.nim
+++ b/src/nameresolver.nim
@@ -94,7 +94,7 @@ proc fillPackageLookupTable(c: var AtlasContext) =
       if not fileExists(c.workspace / DefaultPackagesDir / "packages.json"):
         updatePackages(c)
     let plist = getPackageInfos(when MockupRun: TestsDir else: c.workspace)
-    debug c, toRepo("fillPackageLookupTable"), "initializing..."
+    debugExtra c, toRepo("fillPackageLookupTable"), "initializing..."
     for entry in plist:
       let url = getUrl(entry.url)
       let pkg = Package(name: PackageName unicode.toLower entry.name,
@@ -104,17 +104,18 @@ proc fillPackageLookupTable(c: var AtlasContext) =
 
 proc dependencyDir*(c: var AtlasContext; pkg: Package): PackageDir =
   template checkDir(dir: string) =
-    debug c, pkg, "dependencyDir: test: " & dir
     if dir.len() > 0 and dirExists(dir):
-      debug c, pkg, "dependencyDir: found: " & dir 
+      debugExtra c, pkg, "dependencyDir: found: " & dir 
       return PackageDir dir
+    else:
+      debugExtra c, pkg, "dependencyDir: not found: " & dir 
   
-  debug c, pkg, "dependencyDir: check: pth: " & pkg.path.string & " cd: " & getCurrentDir() & " ws: " & c.workspace
+  debugExtra c, pkg, "dependencyDir: check: pth: " & pkg.path.string & " cd: " & getCurrentDir() & " ws: " & c.workspace
   if pkg.exists:
-    debug c, pkg, "dependencyDir: exists: " & pkg.path.string
+    debugExtra  c, pkg, "dependencyDir: exists: " & pkg.path.string
     return PackageDir pkg.path.string.absolutePath
   if c.workspace.lastPathComponent == pkg.repo.string:
-    debug c, pkg, "dependencyDir: workspace: " & c.workspace
+    debugExtra  c, pkg, "dependencyDir: workspace: " & c.workspace
     return PackageDir getCurrentDir()
 
   if pkg.path.string.len() > 0:
@@ -127,7 +128,7 @@ proc dependencyDir*(c: var AtlasContext; pkg: Package): PackageDir =
   checkDir c.workspace / pkg.name.string
   checkDir c.depsDir / pkg.name.string
   result = PackageDir c.depsDir / pkg.repo.string
-  debug c, pkg, "dependencyDir: failed: defaulting: " & result.string 
+  info c, pkg, "finding dependency dir failed; defaulting to " & result.string 
 
 proc findNimbleFile*(c: var AtlasContext; pkg: Package): Option[string] =
   when MockupRun:
@@ -136,19 +137,19 @@ proc findNimbleFile*(c: var AtlasContext; pkg: Package): Option[string] =
   else:
     let dir = dependencyDir(c, pkg).string
     result = some dir / (pkg.name.string & ".nimble")
-    debug c, pkg, "findNimbleFile: find: " & pkg.repo.string & " path: " & pkg.path.string & " dir: " & dir & " curr: " & result.get()
+    debugExtra  c, pkg, "findNimbleFile: searching: " & pkg.repo.string & " path: " & pkg.path.string & " dir: " & dir & " curr: " & result.get()
     if not fileExists(result.get()):
-      debug c, pkg, "findNimbleFile: not found: " & result.get()
+      debugExtra  c, pkg, "findNimbleFile: not found: " & result.get()
       result = none[string]()
       for x in walkFiles(dir / "*.nimble"):
         if result.isNone:
           result = some x
-          debug c, pkg, "findNimbleFile: found: " & result.get()
+          debug  c, pkg, "nimble file found " & result.get()
         else:
           error c, pkg, "ambiguous .nimble file " & result.get()
           return none[string]()
     else:
-      debug c, pkg, "findNimbleFile: found: " & result.get()
+      debug  c, pkg, "nimble file found " & result.get()
       discard
 
 proc resolvePackageUrl(c: var AtlasContext; url: string, checkOverrides = true): Package =
@@ -156,7 +157,7 @@ proc resolvePackageUrl(c: var AtlasContext; url: string, checkOverrides = true):
                    name: url.toRepo().PackageName,
                    repo: url.toRepo())
   
-  debug c, result, "resolvePackageUrl: search: " & url
+  debugExtra c, result, "resolvePackageUrl: search: " & url
 
   let isFile = result.url.scheme == "file"
   if not isFile and checkOverrides and UsesOverrides in c.flags:
@@ -181,10 +182,9 @@ proc resolvePackageUrl(c: var AtlasContext; url: string, checkOverrides = true):
                 result.name.string & " to " & pname
       result.repo = PackageRepo pname
       c.urlMapping["name:" & result.name.string] = result
-    debug c, result, "resolvePackageUrl: found name: " & $result.name.string
-
+    debugExtra c, result, "resolvePackageUrl: found by name: " & $result.name.string
   elif not repoPkg.isNil:
-    debug c, result, "resolvePackageUrl: found repo: " & $result.repo.string
+    debugExtra c, result, "resolvePackageUrl: found by repo: " & $result.repo.string
     result = repoPkg
   else:
     # package doesn't exit and doesn't conflict
@@ -200,9 +200,6 @@ proc resolvePackageName(c: var AtlasContext; name: string): Package =
   result = Package(name: PackageName name,
                    repo: PackageRepo name)
                    
-
-  # debug c, result, "resolvePackageName: searching for package name: " & result.name.string
-
   # the project name can be overwritten too!
   if UsesOverrides in c.flags:
     let name = c.overrides.substitute(name)
@@ -214,20 +211,20 @@ proc resolvePackageName(c: var AtlasContext; name: string): Package =
   let namePkg = c.urlMapping.getOrDefault("name:" & result.name.string, nil)
   let repoPkg = c.urlMapping.getOrDefault("repo:" & result.name.string, nil)
 
-  # debug c, result, "resolvePackageName: searching for package name: " & result.name.string
+  debugExtra c, result, "resolvePackageName: searching for package name: " & result.name.string
   if not namePkg.isNil:
     # great, found package!
-    # debug c, result, "resolvePackageName: found!"
+    debugExtra c, result, "resolvePackageName: found!"
     result = namePkg
   elif not repoPkg.isNil:
     # check if rawHandle is a package repo name
-    # debug c, result, "resolvePackageName: found by repo!"
+    debugExtra c, result, "resolvePackageName: found by repo!"
     result = repoPkg
   else:
-    debug c, result, "resolvePackageName: not found by name or repo: " & result.name.string
+    info c, result, "could not resolve by name or repo; searching GitHub"
     let url = getUrlFromGithub(name)
     if url.len == 0:
-      error c, result, "resolvePackageName: package not found by github search"
+      error c, result, "package not found by github search"
     else:
       result.url = getUrl url
 
@@ -256,9 +253,9 @@ proc resolvePackage*(c: var AtlasContext; rawHandle: string): Package =
     # let path = PackageDir res.get().parentDir()
     result.exists = true
     result.nimble = nimble
-    debug c, result, "resolvePackageName: nimble: found: " & $result
+    debugExtra c, result, "resolvePackageName: nimble: found: " & $result
   else:
-    debug c, result, "resolvePackageName: nimble: not found: " & $result
+    debugExtra c, result, "resolvePackageName: nimble: not found: " & $result
   
 
 proc resolveNimble*(c: var AtlasContext; pkg: Package) =

--- a/src/nameresolver.nim
+++ b/src/nameresolver.nim
@@ -128,7 +128,7 @@ proc dependencyDir*(c: var AtlasContext; pkg: Package): PackageDir =
   checkDir c.workspace / pkg.name.string
   checkDir c.depsDir / pkg.name.string
   result = PackageDir c.depsDir / pkg.repo.string
-  trace c, pkg, "finding dependency dir failed; defaulting to " & result.string.relativePath(c.workspace)
+  trace c, pkg, "dependency not found using default"
 
 proc findNimbleFile*(c: var AtlasContext; pkg: Package, depDir = PackageDir ""): Option[string] =
   when MockupRun:

--- a/src/nameresolver.nim
+++ b/src/nameresolver.nim
@@ -44,7 +44,7 @@ proc cloneUrlImpl(c: var AtlasContext,
     # retry multiple times to avoid annoying github timeouts:
     for i in 0..4:
       os.sleep(4000)
-      infoNow c, toRepo($modUrl), "Cloning URL: " & $modUrl
+      infoNow c, toRepo($modUrl), "Check remote URL: " & $modUrl
       xcode = execCmdEx("git ls-remote --quiet --tags " & $modUrl)[1]
       if xcode == QuitSuccess: break
 
@@ -106,10 +106,10 @@ proc dependencyDir*(c: var AtlasContext; pkg: Package): PackageDir =
   template checkDir(dir: string) =
     info c, pkg, "dependencyDir: test: " & dir
     if dir.len() > 0 and dirExists(dir):
-      info c, pkg, "dependencyDir: " & dir 
+      info c, pkg, "dependencyDir: found: " & dir 
       return PackageDir dir
   
-  info c, pkg, "dependencyDir: check: " & pkg.path.string & " cd: " & getCurrentDir() & " ws: " & c.workspace
+  info c, pkg, "dependencyDir: check: pth: " & pkg.path.string & " cd: " & getCurrentDir() & " ws: " & c.workspace
   if pkg.exists:
     info c, pkg, "dependencyDir: exists: " & pkg.path.string
     return pkg.path
@@ -119,14 +119,15 @@ proc dependencyDir*(c: var AtlasContext; pkg: Package): PackageDir =
 
   if pkg.path.string.len() > 0:
     checkDir pkg.path.string
-  checkDir c.workspace / pkg.path.string
-  checkDir c.depsDir / pkg.path.string
+    checkDir c.workspace / pkg.path.string
+    checkDir c.depsDir / pkg.path.string
+  
   checkDir c.workspace / pkg.repo.string
   checkDir c.depsDir / pkg.repo.string
   checkDir c.workspace / pkg.name.string
   checkDir c.depsDir / pkg.name.string
-  info c, pkg, "dependencyDir: failed: defaulting: " & c.workspace
   result = PackageDir c.depsDir / pkg.repo.string
+  info c, pkg, "dependencyDir: failed: defaulting: " & result.string 
 
 proc findNimbleFile*(c: var AtlasContext; pkg: Package): Option[string] =
   when MockupRun:
@@ -135,7 +136,7 @@ proc findNimbleFile*(c: var AtlasContext; pkg: Package): Option[string] =
   else:
     let dir = dependencyDir(c, pkg).string
     result = some dir / (pkg.name.string & ".nimble")
-    info c, pkg, "findNimbleFile: find: " & pkg.repo.string & " path: " & pkg.path.string & " dir: " & dir
+    info c, pkg, "findNimbleFile: find: " & pkg.repo.string & " path: " & pkg.path.string & " dir: " & dir & " curr: " & result.get()
     if not fileExists(result.get()):
       info c, pkg, "findNimbleFile: not found: " & result.get()
       result = none[string]()

--- a/src/nameresolver.nim
+++ b/src/nameresolver.nim
@@ -262,7 +262,7 @@ proc resolvePackage*(c: var AtlasContext; rawHandle: string): Package =
     result.exists = true
     result.nimble = nimble
     # the nimble package name is <name>.nimble
-    result.name = PackageName nimble.string.splitFile().ext
+    result.name = PackageName nimble.string.splitFile().name
     debug c, result, "resolvePackageName: nimble: found: " & $result
   else:
     debug c, result, "resolvePackageName: nimble: not found: " & $result

--- a/src/nameresolver.nim
+++ b/src/nameresolver.nim
@@ -126,10 +126,10 @@ proc findNimbleFile*(c: var AtlasContext; pkg: Package): Option[string] =
           return none[string]()
 
 proc resolvePackageUrl(c: var AtlasContext; url: string): Package =
-  result.name = PackageName unicode.toLower(url)
-  result.url = getUrl(url)
-  result.name = result.url.toRepo().PackageName 
-  result.repo = result.url.toRepo()
+  result = Package(url: getUrl(url),
+                   name: result.url.toRepo().PackageName,
+                   repo: result.url.toRepo())
+  
   echo "resolvePackage: ", "IS URL: ", $result.url
 
   if UsesOverrides in c.flags:
@@ -163,7 +163,7 @@ proc resolvePackageUrl(c: var AtlasContext; url: string): Package =
     c.urlMapping["repo:" & result.name.string] = result
 
 proc resolvePackageName(c: var AtlasContext; name: string): Package =
-  result.name = PackageName name
+  result = Package(name: PackageName name)
 
   echo "resolvePackageName: not url"
   # the project name can be overwritten too!

--- a/src/nameresolver.nim
+++ b/src/nameresolver.nim
@@ -256,22 +256,21 @@ proc resolvePackage*(c: var AtlasContext; rawHandle: string): Package =
     # let path = PackageDir res.get().parentDir()
     result.exists = true
     result.nimble = nimble
-    # result = Package(url: result.url,
-    #                  name: result.name,
-    #                  repo: result.repo,
-    #                  path: path,
-    #                  exists: true,
-    #                  nimble: nimble)
     debug c, result, "resolvePackageName: nimble: found: " & $result
   else:
     debug c, result, "resolvePackageName: nimble: not found: " & $result
   
 
-# proc resolvePackage*(c: var AtlasContext; dir: PackageDir): Package =
+proc resolveNimble*(c: var AtlasContext; pkg: Package) =
 
-#   # let destDir = toDestDir(w.pkg.name)
-#   # let dir =
-#   #   if destDir == start.string: c.currentDir
-#   #   else: selectDir(c.workspace / destDir, c.depsDir / destDir)
-  
-#   discard
+  pkg.path = dependencyDir(c, pkg)
+  let res = c.findNimbleFile(pkg)
+  if res.isSome:
+    let nimble = PackageNimble res.get()
+    # let path = PackageDir res.get().parentDir()
+    pkg.exists = true
+    pkg.nimble = nimble
+    info c, pkg, "resolvePackageName: nimble: found: " & $pkg
+  else:
+    info c, pkg, "resolvePackageName: nimble: not found: " & $pkg
+

--- a/src/nameresolver.nim
+++ b/src/nameresolver.nim
@@ -142,9 +142,9 @@ proc findNimbleFile*(c: var AtlasContext; pkg: Package, depDir = PackageDir ""):
     if not fileExists(result.get()):
       debug  c, pkg, "findNimbleFile: not found: " & result.get()
       result = none[string]()
-      for x in walkFiles(dir / "*.nimble"):
+      for file in walkFiles(dir / "*.nimble"):
         if result.isNone:
-          result = some x
+          result = some file
           trace c, pkg, "nimble file found " & result.get()
         else:
           error c, pkg, "ambiguous .nimble file " & result.get()
@@ -261,6 +261,8 @@ proc resolvePackage*(c: var AtlasContext; rawHandle: string): Package =
     let nimble = PackageNimble res.get()
     result.exists = true
     result.nimble = nimble
+    # the nimble package name is <name>.nimble
+    result.name = PackageName nimble.string.splitFile().ext
     debug c, result, "resolvePackageName: nimble: found: " & $result
   else:
     debug c, result, "resolvePackageName: nimble: not found: " & $result

--- a/src/nameresolver.nim
+++ b/src/nameresolver.nim
@@ -172,7 +172,7 @@ proc resolvePackageName(c: var AtlasContext; name: string): Package =
     if name.len > 0:
       result.name = PackageName name
 
-  echo "URL MAP: ", repr c.urlMapping.keys().toSeq()
+  # echo "URL MAP: ", repr c.urlMapping.keys().toSeq()
   let namePkg = c.urlMapping.getOrDefault("name:" & result.name.string, nil)
   let repoPkg = c.urlMapping.getOrDefault("repo:" & result.name.string, nil)
 

--- a/src/nimenv.nim
+++ b/src/nimenv.nim
@@ -80,7 +80,7 @@ proc setupNimEnv*(c: var AtlasContext; nimVersion: string) =
     let pkg = Package(name: PackageName "nim",
                       repo: toRepo(nimDest),
                       url: getUrl "https://github.com/nim-lang/nim",
-                      dir: PackageDir nimDest)
+                      path: PackageDir nimDest)
     let dep = Dependency(pkg: pkg, commit: nimVersion, self: 0,
                          algo: c.defaultAlgo,
                          query: createQueryEq(if nimVersion.isDevel: Version"#head" else: Version(nimVersion)))

--- a/src/nimenv.nim
+++ b/src/nimenv.nim
@@ -80,6 +80,7 @@ proc setupNimEnv*(c: var AtlasContext; nimVersion: string) =
     let pkg = Package(name: PackageName "nim",
                       repo: toRepo(nimDest),
                       url: getUrl "https://github.com/nim-lang/nim",
+                      exists: true,
                       path: PackageDir nimDest)
     let dep = Dependency(pkg: pkg, commit: nimVersion, self: 0,
                          algo: c.defaultAlgo,

--- a/src/nimenv.nim
+++ b/src/nimenv.nim
@@ -26,9 +26,9 @@ const
 
 proc infoAboutActivation(c: var AtlasContext; nimDest, nimVersion: string) =
   when defined(windows):
-    info c, toName(nimDest), "RUN\nnim-" & nimVersion & "\\activate.bat"
+    info c, toRepo(nimDest), "RUN\nnim-" & nimVersion & "\\activate.bat"
   else:
-    info c, toName(nimDest), "RUN\nsource nim-" & nimVersion & "/activate.sh"
+    info c, toRepo(nimDest), "RUN\nsource nim-" & nimVersion & "/activate.sh"
 
 proc setupNimEnv*(c: var AtlasContext; nimVersion: string) =
   template isDevel(nimVersion: string): bool = nimVersion == "devel"
@@ -36,13 +36,13 @@ proc setupNimEnv*(c: var AtlasContext; nimVersion: string) =
   template exec(c: var AtlasContext; command: string) =
     let cmd = command # eval once
     if os.execShellCmd(cmd) != 0:
-      error c, toName("nim-" & nimVersion), "failed: " & cmd
+      error c, toRepo("nim-" & nimVersion), "failed: " & cmd
       return
 
   let nimDest = "nim-" & nimVersion
   if dirExists(c.workspace / nimDest):
     if not fileExists(c.workspace / nimDest / ActivationFile):
-      info c, toName(nimDest), "already exists; remove or rename and try again"
+      info c, toRepo(nimDest), "already exists; remove or rename and try again"
     else:
       infoAboutActivation c, nimDest, nimVersion
     return
@@ -50,7 +50,7 @@ proc setupNimEnv*(c: var AtlasContext; nimVersion: string) =
   var major, minor, patch: int
   if nimVersion != "devel":
     if not scanf(nimVersion, "$i.$i.$i", major, minor, patch):
-      error c, toName("nim"), "cannot parse version requirement"
+      error c, toRepo("nim"), "cannot parse version requirement"
       return
   let csourcesVersion =
     if nimVersion.isDevel or (major == 1 and minor >= 9) or major >= 2:
@@ -78,7 +78,7 @@ proc setupNimEnv*(c: var AtlasContext; nimVersion: string) =
     let nimExe = "bin" / "nim".addFileExt(ExeExt)
     copyFileWithPermissions nimExe0, nimExe
     let pkg = Package(name: PackageName "nim",
-                      repo: toName(nimDest),
+                      repo: toRepo(nimDest),
                       url: getUrl "https://github.com/nim-lang/nim",
                       dir: PackageDir nimDest)
     let dep = Dependency(pkg: pkg, commit: nimVersion, self: 0,
@@ -87,7 +87,7 @@ proc setupNimEnv*(c: var AtlasContext; nimVersion: string) =
     if not nimVersion.isDevel:
       let commit = versionToCommit(c, dep)
       if commit.len == 0:
-        error c, toName(nimDest), "cannot resolve version to a commit"
+        error c, toRepo(nimDest), "cannot resolve version to a commit"
         return
       checkoutGitCommit(c, dep.pkg.repo, commit)
     exec c, nimExe & " c --noNimblePath --skipUserCfg --skipParentCfg --hints:off koch"

--- a/src/osutils.nim
+++ b/src/osutils.nim
@@ -34,10 +34,6 @@ proc readableFile*(s: string): string =
   else:
     s
 
-proc selectDir*(a, b: string): string =
-  ## selects the first dir that exists
-  ## 
-  if dirExists(a): a else: b
 
 proc absoluteDepsDir*(workspace, value: string): string =
   if value == ".":
@@ -47,14 +43,6 @@ proc absoluteDepsDir*(workspace, value: string): string =
   else:
     result = workspace / value
 
-template tryWithDir*(dir: string; body: untyped) =
-  let oldDir = getCurrentDir()
-  try:
-    if dirExists(dir):
-      setCurrentDir(dir)
-      body
-  finally:
-    setCurrentDir(oldDir)
 
 proc silentExec*(cmd: string; args: openArray[string]): (string, int) =
   var cmdLine = cmd

--- a/src/parse_requires.nim
+++ b/src/parse_requires.nim
@@ -9,6 +9,7 @@ type
   NimbleFileInfo* = object
     requires*: seq[string]
     srcDir*: string
+    version*: string
     tasks*: seq[(string, string)]
     hasInstallHooks*: bool
 
@@ -49,6 +50,11 @@ proc extract(n: PNode; conf: ConfigRef; result: var NimbleFileInfo) =
         result.srcDir = n[1].strVal
       else:
         localError(conf, n[1].info, "assignments to 'srcDir' must be string literals")
+    elif n[0].kind == nkIdent and cmpIgnoreCase(n[0].ident.s, "version") == 0:
+      if n[1].kind in {nkStrLit..nkTripleStrLit}:
+        result.version = n[1].strVal
+      else:
+        localError(conf, n[1].info, "assignments to 'version' must be string literals")
   else:
     discard
 

--- a/src/runners.nim
+++ b/src/runners.nim
@@ -92,7 +92,7 @@ proc runBuildSteps*(c: var AtlasContext; g: var DepGraph) =
       let dir = selectDir(c.workspace / destDir, c.depsDir / destDir)
       tryWithDir dir:
         if g.nodes[i].hasInstallHooks:
-          let nf = findNimbleFile(c, g.nodes[i])
+          let nf = findNimbleFile(c, g.nodes[i].pkg)
           if nf.len > 0:
             runNimScriptInstallHook c, nf, g.nodes[i].pkg
         for p in mitems c.plugins.builderPatterns:

--- a/src/runners.nim
+++ b/src/runners.nim
@@ -88,7 +88,7 @@ proc runBuildSteps*(c: var AtlasContext; g: var DepGraph) =
   # `countdown` suffices to give us some kind of topological sort:
   for i in countdown(g.nodes.len-1, 0):
     if g.nodes[i].active:
-      let destDir = g.nodes[i].pkg.dir.string
+      let destDir = g.nodes[i].pkg.path.string
       let dir = selectDir(c.workspace / destDir, c.depsDir / destDir)
       tryWithDir dir:
         if g.nodes[i].hasInstallHooks:

--- a/src/runners.nim
+++ b/src/runners.nim
@@ -78,8 +78,8 @@ proc runNimScript*(c: var AtlasContext; scriptContent: string; name: Package) =
   else:
     removeFile buildNims
 
-proc runNimScriptInstallHook*(c: var AtlasContext; nimbleFile: string; name: Package) =
-  runNimScript c, InstallHookTemplate % [nimbleFile.escape], name
+proc runNimScriptInstallHook*(c: var AtlasContext; nimble: PackageNimble; name: Package) =
+  runNimScript c, InstallHookTemplate % [nimble.string.escape], name
 
 proc runNimScriptBuilder*(c: var AtlasContext; p: (string, string); name: Package) =
   runNimScript c, BuilderScriptTemplate % [p[0].escape, p[1].escape], name
@@ -92,9 +92,8 @@ proc runBuildSteps*(c: var AtlasContext; g: var DepGraph) =
       let dir = selectDir(c.workspace / destDir, c.depsDir / destDir)
       tryWithDir dir:
         if g.nodes[i].hasInstallHooks:
-          let nf = findNimbleFile(c, g.nodes[i].pkg)
-          if nf.len > 0:
-            runNimScriptInstallHook c, nf, g.nodes[i].pkg
+          let nf = g.nodes[i].pkg.nimble
+          runNimScriptInstallHook c, nf, g.nodes[i].pkg
         for p in mitems c.plugins.builderPatterns:
           let f = p[0] % dir.lastPathComponent
           if fileExists(f):

--- a/src/runners.nim
+++ b/src/runners.nim
@@ -6,7 +6,7 @@
 #    distribution, for details about the copyright.
 #
 
-import context, osutils
+import context
 
 import std / [strutils, os, osproc]
 

--- a/src/traversal.nim
+++ b/src/traversal.nim
@@ -8,8 +8,8 @@
 
 ## Helpers for the graph traversal.
 
-import std / [strutils, os]
-import context, nameresolver
+import std / [strutils, os, sha1, algorithm]
+import context, nameresolver, gitops
 
 proc createGraph*(c: var AtlasContext; start: Package): DepGraph =
   let dep = Dependency(pkg: start, commit: "",
@@ -106,3 +106,51 @@ proc collectNewDeps*(
   else:
     warn c, dep.pkg, "collecting deps: no nimble skipping deps'"
     result = CfgPath dep.pkg.path.string
+
+proc updateSecureHash(
+    checksum: var Sha1State,
+    c: var AtlasContext;
+    pkg: Package,
+    name: string
+) =
+  let path = pkg.path.string / name
+  if not path.fileExists(): return
+  checksum.update(name)
+
+  if symlinkExists(path):
+    # checksum file path (?)
+    try:
+      let path = expandSymlink(path)
+      checksum.update(path)
+    except OSError:
+      error c, pkg, "cannot follow symbolic link " & path
+  else:
+    # checksum file contents
+    var file: File
+    try:
+      file = path.open(fmRead)
+      const bufferSize = 8192
+      var buffer = newString(bufferSize)
+      while true:
+        var bytesRead = readChars(file, buffer)
+        if bytesRead == 0: break
+        checksum.update(buffer.toOpenArray(0, bytesRead - 1))
+    except IOError:
+      error c, pkg, "error opening file " & path
+    finally:
+      file.close()
+
+proc nimbleChecksum*(c: var AtlasContext, pkg: Package, cfg: CfgPath): string =
+  ## calculate a nimble style checksum from a `CfgPath`.
+  ##
+  ## Useful for exporting a Nimble sync file.
+  ##
+  let res = c.listFiles(pkg)
+  if res.isNone:
+    error c, pkg, "couldn't list files"
+  else:
+    var files = res.get().sorted()
+    var checksum = newSha1State()
+    for file in files:
+      checksum.updateSecureHash(c, pkg, file)
+    result = toLowerAscii($SecureHash(checksum.finalize()))

--- a/src/traversal.nim
+++ b/src/traversal.nim
@@ -75,10 +75,8 @@ proc collectDeps*(
     var i = 0
     while i < r.len and r[i] notin {'#', '<', '=', '>'} + Whitespace: inc i
     let name = r.substr(0, i-1)
-    # print name
     let pkg = c.resolvePackage(name)
-    debug c, dep.pkg, "collect deps: " & name & " pkg: " & $dep.pkg
-    # print "collectDeps: ", pkg
+    debugExtra c, dep.pkg, "collect deps: " & name & " pkg: " & $dep.pkg
 
     var err = pkg.name.string.len == 0
     if len($pkg.url) == 0:
@@ -105,7 +103,7 @@ proc collectNewDeps*(
   debug c, dep.pkg, "collecting deps: pkg: " & $dep.pkg
   if dep.pkg.exists:
     let nimble = dep.pkg.nimble
-    debug c, dep.pkg, "collecting deps: nimble file: '" & nimble.string & "'"
+    debugExtra c, dep.pkg, "collecting deps: using nimble file: '" & nimble.string & "'"
     result = collectDeps(c, g, parent, dep)
   else:
     warn c, dep.pkg, "collecting deps: no nimble skipping deps'"

--- a/src/traversal.nim
+++ b/src/traversal.nim
@@ -103,7 +103,7 @@ proc collectNewDeps*(
 ): CfgPath =
   if dep.pkg.exists:
     let nimble = dep.pkg.nimble
-    info c, dep.pkg, "collecting deps: nimble file: '" & nimble.string & "'"
+    infoNow c, dep.pkg, "collecting deps: nimble file: '" & nimble.string & "'"
     result = collectDeps(c, g, parent, dep)
   else:
     warn c, dep.pkg, "collecting deps: no nimble skipping deps'"

--- a/src/traversal.nim
+++ b/src/traversal.nim
@@ -87,8 +87,8 @@ proc collectDeps*(c: var AtlasContext; g: var DepGraph; parent: int;
 proc collectNewDeps*(c: var AtlasContext; g: var DepGraph; parent: int;
                     dep: Dependency): CfgPath =
   let nimbleFile = findNimbleFile(c, dep)
-  debug c, dep.name, "collecting deps; nimble file: '" & nimbleFile & "'"
+  debug c, dep.pkg, "collecting deps; nimble file: '" & nimbleFile & "'"
   if nimbleFile != "":
     result = collectDeps(c, g, parent, dep, nimbleFile)
   else:
-    result = CfgPath toDestDir(dep.name)
+    result = CfgPath toDestDir(dep.pkg)

--- a/src/traversal.nim
+++ b/src/traversal.nim
@@ -100,7 +100,7 @@ proc collectNewDeps*(
     parent: int;
     dep: Dependency
 ): CfgPath =
-  debug c, dep.pkg, "collecting deps: pkg: " & $dep.pkg
+  trace c, dep.pkg, "collecting deps: pkg: " & $dep.pkg
   if dep.pkg.exists:
     let nimble = dep.pkg.nimble
     debugExtra c, dep.pkg, "collecting deps: using nimble file: '" & nimble.string & "'"

--- a/src/traversal.nim
+++ b/src/traversal.nim
@@ -8,6 +8,8 @@
 
 ## Helpers for the graph traversal.
 
+import pretty
+
 import std / [strutils, os]
 import context, osutils, gitops, nameresolver
 
@@ -73,7 +75,9 @@ proc collectDeps*(
     var i = 0
     while i < r.len and r[i] notin {'#', '<', '=', '>'} + Whitespace: inc i
     let name = r.substr(0, i-1)
+    # print name
     let pkg = c.resolvePackage(name)
+    # print "collectDeps: ", pkg
 
     var err = pkg.name.string.len == 0
     if len($pkg.url) == 0:

--- a/src/traversal.nim
+++ b/src/traversal.nim
@@ -101,10 +101,10 @@ proc collectNewDeps*(
     parent: int;
     dep: Dependency
 ): CfgPath =
-  # let nimbleFile = findNimbleFile(c, dep)
   if dep.pkg.exists:
     let nimble = dep.pkg.nimble
-    debug c, dep.pkg, "collecting deps; nimble file: '" & nimble.string & "'"
+    info c, dep.pkg, "collecting deps: nimble file: '" & nimble.string & "'"
     result = collectDeps(c, g, parent, dep)
   else:
+    warn c, dep.pkg, "collecting deps: no nimble skipping deps'"
     result = CfgPath dep.pkg.path.string

--- a/src/traversal.nim
+++ b/src/traversal.nim
@@ -8,8 +8,6 @@
 
 ## Helpers for the graph traversal.
 
-import pretty
-
 import std / [strutils, os]
 import context, osutils, gitops, nameresolver
 

--- a/src/traversal.nim
+++ b/src/traversal.nim
@@ -77,6 +77,7 @@ proc collectDeps*(
     let name = r.substr(0, i-1)
     # print name
     let pkg = c.resolvePackage(name)
+    debug c, dep.pkg, "collect deps: " & name & " pkg: " & $dep.pkg
     # print "collectDeps: ", pkg
 
     var err = pkg.name.string.len == 0
@@ -101,10 +102,10 @@ proc collectNewDeps*(
     parent: int;
     dep: Dependency
 ): CfgPath =
-  info c, dep.pkg, "collecting deps: pkg: " & $dep.pkg
+  debug c, dep.pkg, "collecting deps: pkg: " & $dep.pkg
   if dep.pkg.exists:
     let nimble = dep.pkg.nimble
-    info c, dep.pkg, "collecting deps: nimble file: '" & nimble.string & "'"
+    debug c, dep.pkg, "collecting deps: nimble file: '" & nimble.string & "'"
     result = collectDeps(c, g, parent, dep)
   else:
     warn c, dep.pkg, "collecting deps: no nimble skipping deps'"

--- a/src/traversal.nim
+++ b/src/traversal.nim
@@ -100,7 +100,7 @@ proc collectNewDeps*(
     parent: int;
     dep: Dependency
 ): CfgPath =
-  trace c, dep.pkg, "collecting deps: pkg: " & $dep.pkg
+  trace c, dep.pkg, "collecting dependencies"
   if dep.pkg.exists:
     let nimble = dep.pkg.nimble
     debug c, dep.pkg, "collecting deps: using nimble file: '" & nimble.string & "'"

--- a/src/traversal.nim
+++ b/src/traversal.nim
@@ -73,12 +73,15 @@ proc collectDeps*(
     var i = 0
     while i < r.len and r[i] notin {'#', '<', '=', '>'} + Whitespace: inc i
     let name = r.substr(0, i-1)
-    let pkg = c.resolvePackage(name) # don't use pkgName in case it's a URL
+    let pkg = c.resolvePackage(name)
+
     var err = pkg.name.string.len == 0
     if len($pkg.url) == 0:
       error c, pkg, "invalid pkgUrl in nimble file: " & name
       err = true
-    let query = parseVersionInterval(r, i, err)
+    
+    let query = parseVersionInterval(r, i, err) # update err
+
     if err:
       error c, pkg, "invalid 'requires' syntax in nimble file: " & r
     else:

--- a/src/traversal.nim
+++ b/src/traversal.nim
@@ -22,7 +22,7 @@ proc createGraph*(c: var AtlasContext;
   let dep = Dependency(pkg: pkg, commit: "", path: path,
                        self: 0, algo: c.defaultAlgo)
   result = DepGraph(nodes: @[dep])
-  result.byName.mgetOrPut(start, @[]).add 0
+  result.byName.mgetOrPut(start, @[]).add(0)
 
 proc selectNode*(c: var AtlasContext; g: var DepGraph; w: Dependency) =
   # all other nodes of the same project name are not active

--- a/src/traversal.nim
+++ b/src/traversal.nim
@@ -103,4 +103,4 @@ proc collectNewDeps*(
     debug c, dep.pkg, "collecting deps; nimble file: '" & nimble.string & "'"
     result = collectDeps(c, g, parent, dep)
   else:
-    result = CfgPath toDestDir(dep.pkg)
+    result = CfgPath dep.pkg.path.string

--- a/src/traversal.nim
+++ b/src/traversal.nim
@@ -12,14 +12,14 @@ import std / [strutils, os]
 import context, osutils, gitops, nameresolver
 
 proc createGraph*(c: var AtlasContext; start: Package): DepGraph =
-  let dep = Dependency(pkg: start, commit: "", path: path,
+  let dep = Dependency(pkg: start, commit: "",
                        self: 0, algo: c.defaultAlgo)
   result = DepGraph(nodes: @[dep])
   result.byName.mgetOrPut(start.name, @[]).add(0)
 
 proc selectNode*(c: var AtlasContext; g: var DepGraph; w: Dependency) =
   # all other nodes of the same project name are not active
-  for e in items g.byName[w.name]:
+  for e in items g.byName[w.pkg.name]:
     g.nodes[e].active = e == w.self
   if w.status != Ok:
     g.nodes[w.self].active = false
@@ -28,23 +28,21 @@ proc addUnique*[T](s: var seq[T]; elem: sink T) =
   if not s.contains(elem): s.add elem
 
 proc addUniqueDep(c: var AtlasContext; g: var DepGraph; parent: int;
-                  pkgName: PackageName, pkgUrl: PackageUrl;
-                  query: VersionInterval) =
+                  pkg: Package, query: VersionInterval) =
   let commit = versionKey(query)
   let oldErrors = c.errors
-  let url = pkgUrl
-  let name = pkgName
   if oldErrors != c.errors:
-    warn c, pkgName, "cannot resolve package name"
+    warn c, pkg, "cannot resolve package name"
   else:
-    let key = url / commit
+    let key = pkg.url / commit
     if g.processed.hasKey($key):
       g.nodes[g.processed[$key]].parents.addUnique parent
     else:
       let self = g.nodes.len
-      g.byName.mgetOrPut(name, @[]).add self
+      g.byName.mgetOrPut(pkg.name, @[]).add self
       g.processed[$key] = self
-      g.nodes.add Dependency(name: name, url: url, commit: commit,
+      g.nodes.add Dependency(pkg: pkg,
+                             commit: commit,
                              self: self,
                              query: query,
                              parents: @[parent],
@@ -71,20 +69,20 @@ proc collectDeps*(c: var AtlasContext; g: var DepGraph; parent: int;
     var i = 0
     while i < r.len and r[i] notin {'#', '<', '=', '>'} + Whitespace: inc i
     let name = r.substr(0, i-1)
-    let (pkgName, pkgUrl) = c.resolvePackage(name) # don't use pkgName in case it's a URL
-    var err = pkgName.string.len == 0
-    if len($pkgUrl) == 0:
-      error c, toName(nimbleFile), "invalid pkgUrl: " & name
+    let pkg = c.resolvePackage(name) # don't use pkgName in case it's a URL
+    var err = pkg.name.string.len == 0
+    if len($pkg.url) == 0:
+      error c, pkg, "invalid pkgUrl in nimble file: " & name
       err = true
     let query = parseVersionInterval(r, i, err)
     if err:
-      error c, toName(nimbleFile), "invalid 'requires' syntax: " & r
+      error c, pkg, "invalid 'requires' syntax in nimble file: " & r
     else:
-      if cmpIgnoreCase(pkgName.string, "nim") != 0:
-        c.addUniqueDep g, parent, pkgName, pkgUrl, query
+      if cmpIgnoreCase(pkg.name.string, "nim") != 0:
+        c.addUniqueDep g, parent, pkg, query
       else:
         rememberNimVersion g, query
-  result = CfgPath(toDestDir(dep.name) / nimbleInfo.srcDir)
+  result = CfgPath(toDestDir(dep.pkg).string / nimbleInfo.srcDir)
 
 proc collectNewDeps*(c: var AtlasContext; g: var DepGraph; parent: int;
                     dep: Dependency): CfgPath =

--- a/src/traversal.nim
+++ b/src/traversal.nim
@@ -9,7 +9,7 @@
 ## Helpers for the graph traversal.
 
 import std / [strutils, os]
-import context, osutils, gitops, nameresolver
+import context, nameresolver
 
 proc createGraph*(c: var AtlasContext; start: Package): DepGraph =
   let dep = Dependency(pkg: start, commit: "",

--- a/src/traversal.nim
+++ b/src/traversal.nim
@@ -76,7 +76,7 @@ proc collectDeps*(
     while i < r.len and r[i] notin {'#', '<', '=', '>'} + Whitespace: inc i
     let name = r.substr(0, i-1)
     let pkg = c.resolvePackage(name)
-    debugExtra c, dep.pkg, "collect deps: " & name & " pkg: " & $dep.pkg
+    debug c, dep.pkg, "collect deps: " & name & " pkg: " & $dep.pkg
 
     var err = pkg.name.string.len == 0
     if len($pkg.url) == 0:
@@ -103,7 +103,7 @@ proc collectNewDeps*(
   trace c, dep.pkg, "collecting deps: pkg: " & $dep.pkg
   if dep.pkg.exists:
     let nimble = dep.pkg.nimble
-    debugExtra c, dep.pkg, "collecting deps: using nimble file: '" & nimble.string & "'"
+    debug c, dep.pkg, "collecting deps: using nimble file: '" & nimble.string & "'"
     result = collectDeps(c, g, parent, dep)
   else:
     warn c, dep.pkg, "collecting deps: no nimble skipping deps'"

--- a/src/traversal.nim
+++ b/src/traversal.nim
@@ -11,18 +11,11 @@
 import std / [strutils, os]
 import context, osutils, gitops, nameresolver
 
-proc createGraph*(c: var AtlasContext;
-                  start: PackageRepo,
-                  url: PackageUrl,
-                  path = ""): DepGraph =
-  let pkg = Package(name: PackageName "",
-                    repo: start,
-                    url: url,
-                    dir: PackageDir path)
-  let dep = Dependency(pkg: pkg, commit: "", path: path,
+proc createGraph*(c: var AtlasContext; start: Package): DepGraph =
+  let dep = Dependency(pkg: start, commit: "", path: path,
                        self: 0, algo: c.defaultAlgo)
   result = DepGraph(nodes: @[dep])
-  result.byName.mgetOrPut(start, @[]).add(0)
+  result.byName.mgetOrPut(start.name, @[]).add(0)
 
 proc selectNode*(c: var AtlasContext; g: var DepGraph; w: Dependency) =
   # all other nodes of the same project name are not active

--- a/src/traversal.nim
+++ b/src/traversal.nim
@@ -101,9 +101,10 @@ proc collectNewDeps*(
     parent: int;
     dep: Dependency
 ): CfgPath =
+  info c, dep.pkg, "collecting deps: pkg: " & $dep.pkg
   if dep.pkg.exists:
     let nimble = dep.pkg.nimble
-    infoNow c, dep.pkg, "collecting deps: nimble file: '" & nimble.string & "'"
+    info c, dep.pkg, "collecting deps: nimble file: '" & nimble.string & "'"
     result = collectDeps(c, g, parent, dep)
   else:
     warn c, dep.pkg, "collecting deps: no nimble skipping deps'"

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -197,7 +197,7 @@ proc integrationTest() =
   # won't disappear in the near or far future. Turns out `nitter` has
   # quite some dependencies so it suffices:
   echo "\n## Integration Test: Nitter\n"
-  exec atlasExe & " use https://github.com/zedeus/nitter"
+  exec atlasExe & " --verbose use https://github.com/zedeus/nitter"
   discard sameDirContents("expected", ".")
 
 proc cleanupIntegrationTest() =

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -197,7 +197,7 @@ proc integrationTest() =
   # won't disappear in the near or far future. Turns out `nitter` has
   # quite some dependencies so it suffices:
   echo "\n## Integration Test: Nitter\n"
-  exec atlasExe & " --verbose use https://github.com/zedeus/nitter"
+  exec atlasExe & " --verbosity:2 use https://github.com/zedeus/nitter"
   discard sameDirContents("expected", ".")
 
 proc cleanupIntegrationTest() =

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -9,7 +9,7 @@ if execShellCmd("nim c -r tests/unittests.nim") != 0:
 var failures = 0
 
 let atlasExe = absolutePath("bin" / "atlas".addFileExt(ExeExt))
-if execShellCmd("nim c -o:$# src/atlas.nim" % [atlasExe]) != 0:
+if execShellCmd("nim c -d:debug -o:$# src/atlas.nim" % [atlasExe]) != 0:
   quit("FAILURE: compilation of atlas failed")
 
 proc exec(cmd: string) =
@@ -158,7 +158,7 @@ proc testSemVer2() =
 
   createDir "myproject"
   withDir "myproject":
-    let (outp, status) = execCmdEx(atlasExe & " --list use proj_a")
+    let (outp, status) = execCmdEx(atlasExe & " --list use proj_a", {poStdErrToStdOut})
     if status == 0:
       if outp.contains SemVer2ExpectedResult:
         discard "fine"
@@ -166,7 +166,10 @@ proc testSemVer2() =
         echo "expected ", SemVer2ExpectedResult, " but got ", outp
         raise newException(AssertionDefect, "Test failed!")
     else:
-      assert false, outp
+      echo "atlas error:\n"
+      for line in outp.splitLines:
+        echo "> " & line
+      raise newException(Exception, "myproject: atlas exec error: " & $status)
 
 withDir "tests/ws_semver2":
   try:

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -100,12 +100,13 @@ when false:
   testWsConflict()
 
 const
-  SemVer2ExpectedResult = """selected:
-[ ] (proj_a, 1.0.0)
-[x] (proj_a, 1.1.0)
-[x] (proj_b, 1.1.0)
-[x] (proj_c, 1.2.0)
-"""
+  SemVer2ExpectedResult = dedent"""
+    [Info] (../resolve) selected:
+    [Info] (proj_a) [ ] (proj_a, 1.0.0)
+    [Info] (proj_a) [x] (proj_a, 1.1.0)
+    [Info] (proj_b) [x] (proj_b, 1.1.0)
+    [Info] (proj_c) [x] (proj_c, 1.2.0)
+    """
 
 proc testSemVer2() =
   createDir "source"
@@ -159,7 +160,7 @@ proc testSemVer2() =
 
   createDir "myproject"
   withDir "myproject":
-    let (outp, status) = execCmdEx(atlasExe & " --list use proj_a", {poStdErrToStdOut})
+    let (outp, status) = execCmdEx(atlasExe & " --colors=off --list use proj_a", {poStdErrToStdOut})
     if status == 0:
       if outp.contains SemVer2ExpectedResult:
         discard "fine"

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -195,6 +195,7 @@ proc integrationTest() =
   # Test installation of some "important_packages" which we are sure
   # won't disappear in the near or far future. Turns out `nitter` has
   # quite some dependencies so it suffices:
+  echo "\n## Integration Test: Nitter\n"
   exec atlasExe & " use https://github.com/zedeus/nitter"
   discard sameDirContents("expected", ".")
 
@@ -209,8 +210,10 @@ proc cleanupIntegrationTest() =
 
 withDir "tests/ws_integration":
   try:
+    cleanupIntegrationTest()
     integrationTest()
   finally:
-    cleanupIntegrationTest()
+    if getEnv("KEEP_TEST_DIRS") == "":
+      cleanupIntegrationTest()
 
 if failures > 0: quit($failures & " failures occurred.")

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -174,6 +174,7 @@ proc testSemVer2() =
       raise newException(Exception, "myproject: atlas exec error: " & $status)
 
 withDir "tests/ws_semver2":
+  echo "\n## Integration Test: SemVer2\n"
   proc cleanupDirs() =
     removeDir "does_not_exist"
     removeDir "myproject"

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -197,7 +197,7 @@ proc integrationTest() =
   # won't disappear in the near or far future. Turns out `nitter` has
   # quite some dependencies so it suffices:
   echo "\n## Integration Test: Nitter\n"
-  exec atlasExe & " --verbosity:2 use https://github.com/zedeus/nitter"
+  exec atlasExe & " --verbosity:trace use https://github.com/zedeus/nitter"
   discard sameDirContents("expected", ".")
 
 proc cleanupIntegrationTest() =

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -54,6 +54,7 @@ proc createNode(name: string, versions: seq[string], deps: seq[string]): Node =
 template withDir(dir: string; body: untyped) =
   let old = getCurrentDir()
   try:
+    echo "setting dir: ", dir
     setCurrentDir(dir)
     body
   finally:
@@ -172,9 +173,7 @@ proc testSemVer2() =
       raise newException(Exception, "myproject: atlas exec error: " & $status)
 
 withDir "tests/ws_semver2":
-  try:
-    testSemVer2()
-  finally:
+  proc cleanupDirs() =
     removeDir "does_not_exist"
     removeDir "myproject"
     removeDir "source"
@@ -182,6 +181,14 @@ withDir "tests/ws_semver2":
     removeDir "proj_b"
     removeDir "proj_c"
     removeDir "proj_d"
+  
+  try:
+    cleanupDirs()
+    testSemVer2()
+  finally:
+    if getEnv("KEEP_TEST_DIRS") == "":
+      echo "cleaning up directory"
+      cleanupDirs()
 
 proc integrationTest() =
   # Test installation of some "important_packages" which we are sure

--- a/tests/unittests.nim
+++ b/tests/unittests.nim
@@ -26,8 +26,6 @@ let
     )
   }
 
-import sequtils, tables
-
 proc initBasicWorkspace(typ: type AtlasContext): AtlasContext =
   result.workspace = currentSourcePath().parentDir / "ws_basic"
 

--- a/tests/ws_integration/expected/nim.cfg
+++ b/tests/ws_integration/expected/nim.cfg
@@ -14,5 +14,5 @@
 --path:"flatty/src"
 --path:"jsony/src"
 --path:"ws/src"
---path:"dotenv/src"
+--path:"dotenv.nim/src"
 ############# end Atlas config section   ##########


### PR DESCRIPTION
This depends on https://github.com/nim-lang/atlas/pull/49. 

I needed the ability to export Nimble lockfiles. This makes it possible to maintain a Nimble lockfile with Atlas.