### PR TITLE
Tweaks to convert, install, and replay

### DIFF
--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -439,8 +439,8 @@ proc installDependencies(c: var AtlasContext; nimbleFile: string; startIsDep: bo
   # 1. find .nimble file in CWD
   # 2. install deps from .nimble
   var g = DepGraph(nodes: @[])
-  let (dir, pkgname, _) = splitFile(nimbleFile)
-  let pkg = c.resolvePackage("file://" & dir.lastPathComponent)
+  let (_, pkgname, _) = splitFile(nimbleFile.absolutePath)
+  let pkg = c.resolvePackage("file://" & nimbleFile.absolutePath)
   info c, pkg, "installing dependencies for " & pkgname & ".nimble"
   let dep = Dependency(pkg: pkg, commit: "", self: 0, algo: c.defaultAlgo)
   g.byName.mgetOrPut(pkg.name, @[]).add(0)
@@ -710,7 +710,7 @@ proc main(c: var AtlasContext) =
       for x in walkPattern("*.nimble"):
         nimbleFile = x
         break
-    if nimbleFile.len == 0:
+    if nimbleFile.len == 0 or not nimbleFile.fileExists():
       fatal "could not find a .nimble file"
     else:
       installDependencies(c, nimbleFile, startIsDep = true)

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -696,8 +696,8 @@ proc main(c: var AtlasContext) =
       pinProject c, args[0], exportNimble
   of "rep", "replay", "reproduce":
     optSingleArg(LockFileName)
-    replay c, args[0]
-    if CfgHere in c.flags:
+    let res = replay(c, args[0])
+    if CfgHere in c.flags or res.hasCfg == false:
       let nimbleFile = findCurrentNimble()
       installDependencies(c, nimbleFile, startIsDep = true)
   of "convert":

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -439,8 +439,8 @@ proc installDependencies(c: var AtlasContext; nimbleFile: string; startIsDep: bo
   # 1. find .nimble file in CWD
   # 2. install deps from .nimble
   var g = DepGraph(nodes: @[])
-  let (_, pkgname, _) = splitFile(nimbleFile.absolutePath)
-  let pkg = c.resolvePackage("file://" & nimbleFile.absolutePath)
+  let (dir, pkgname, _) = splitFile(nimbleFile)
+  let pkg = c.resolvePackage("file://" & dir.lastPathComponent)
   info c, pkg, "installing dependencies for " & pkgname & ".nimble"
   let dep = Dependency(pkg: pkg, commit: "", self: 0, algo: c.defaultAlgo)
   g.byName.mgetOrPut(pkg.name, @[]).add(0)
@@ -710,7 +710,7 @@ proc main(c: var AtlasContext) =
       for x in walkPattern("*.nimble"):
         nimbleFile = x
         break
-    if nimbleFile.len == 0 or not nimbleFile.fileExists():
+    if nimbleFile.len == 0:
       fatal "could not find a .nimble file"
     else:
       installDependencies(c, nimbleFile, startIsDep = true)

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -440,7 +440,7 @@ proc installDependencies(c: var AtlasContext; nimbleFile: string; startIsDep: bo
   # 2. install deps from .nimble
   var g = DepGraph(nodes: @[])
   let (dir, pkgname, _) = splitFile(nimbleFile)
-  let pkg = c.resolvePackage("file://" & dir.lastPathComponent)
+  let pkg = c.resolvePackage("file://" & dir.absolutePath)
   info c, pkg, "installing dependencies for " & pkgname & ".nimble"
   let dep = Dependency(pkg: pkg, commit: "", self: 0, algo: c.defaultAlgo)
   g.byName.mgetOrPut(pkg.name, @[]).add(0)

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -565,6 +565,10 @@ proc main(c: var AtlasContext) =
     if c.projectDir == c.workspace or c.projectDir == c.depsDir:
       fatal action & " command must be executed in a project, not in the workspace"
 
+  proc findCurrentNimble(): string =
+    for x in walkPattern("*.nimble"):
+      return x
+  
   var autoinit = false
   var explicitProjectOverride = false
   var explicitDepsDirOverride = false
@@ -693,6 +697,9 @@ proc main(c: var AtlasContext) =
   of "rep", "replay", "reproduce":
     optSingleArg(LockFileName)
     replay c, args[0]
+    if CfgHere in c.flags:
+      let nimbleFile = findCurrentNimble()
+      installDependencies(c, nimbleFile, startIsDep = true)
   of "convert":
     if args.len < 1:
       fatal "convert command takes a nimble lockfile argument"
@@ -707,9 +714,7 @@ proc main(c: var AtlasContext) =
     if args.len == 1:
       nimbleFile = args[0]
     else:
-      for x in walkPattern("*.nimble"):
-        nimbleFile = x
-        break
+      nimbleFile = findCurrentNimble()
     if nimbleFile.len == 0:
       fatal "could not find a .nimble file"
     else:

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -706,7 +706,7 @@ proc main(c: var AtlasContext) =
     let lfn = if args.len == 1: LockFileName
               else: args[1]
     convertAndSaveNimbleLock c, args[0], lfn
-  of "install":
+  of "install", "setup":
     # projectCmd()
     if args.len > 1:
       fatal "install command takes a single argument"

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -48,8 +48,9 @@ Command:
                         add and push a new tag, input must be one of:
                         ['major'|'minor'|'patch'] or a SemVer tag like ['1.0.3']
                         or a letter ['a'..'z']: a.b.c.d.e.f.g
-  pin [atlas.lock]      pin the current checkouts and store them in the lock
-  rep [atlas.lock]      replay the state of the projects according to the lock
+  pin [atlas.lock]      pin the current checkouts and store them in the lock file
+  rep [atlas.lock]      replay the state of the projects according to the lock file
+  changed <atlack.lock> list any packages that differ from the lock file
   convert <nimble.lock> [atlas.lock]
                         convert Nimble lockfile into an Atlas one
   outdated              list the packages that are outdated
@@ -700,6 +701,9 @@ proc main(c: var AtlasContext) =
     if CfgHere in c.flags or res.hasCfg == false:
       let nimbleFile = findCurrentNimble()
       installDependencies(c, nimbleFile, startIsDep = true)
+  of "changed":
+    optSingleArg(LockFileName)
+    listChanged(c, args[0])
   of "convert":
     if args.len < 1:
       fatal "convert command takes a nimble lockfile argument"

--- a/src/context.nim
+++ b/src/context.nim
@@ -187,7 +187,7 @@ proc message(c: var AtlasContext; k: MsgKind; p: PackageRepo; arg: string) =
 
 proc warn*(c: var AtlasContext; p: PackageRepo; arg: string) =
   c.message(Warning, p, arg)
-  writeMessage c, Warning, p, arg
+  # writeMessage c, Warning, p, arg
   inc c.warnings
 
 proc error*(c: var AtlasContext; p: PackageRepo; arg: string) =

--- a/src/lockfiles.nim
+++ b/src/lockfiles.nim
@@ -199,6 +199,9 @@ proc convertNimbleLock*(c: var AtlasContext; nimblePath: string): LockFile =
 
   result = newLockFile()
   for (name, pkg) in jsonTree["packages"].pairs:
+    if name == "nim":
+      result.nimVersion = pkg["version"].getStr
+      continue
     info c, toRepo(name), " imported "
     let dir = c.depsDir / name
     result.items[name] = LockFileEntry(
@@ -206,6 +209,7 @@ proc convertNimbleLock*(c: var AtlasContext; nimblePath: string): LockFile =
       url: pkg["url"].getStr,
       commit: pkg["vcsRevision"].getStr,
     )
+
 
 proc convertAndSaveNimbleLock*(c: var AtlasContext; nimblePath, lockFilePath: string) =
   ## convert and save a nimble.lock into an Atlast lockfile

--- a/src/lockfiles.nim
+++ b/src/lockfiles.nim
@@ -205,7 +205,7 @@ proc convertNimbleLock*(c: var AtlasContext; nimblePath: string): LockFile =
     info c, toRepo(name), " imported "
     let dir = c.depsDir / name
     result.items[name] = LockFileEntry(
-      dir: dir,
+      dir: dir.relativePath(getCurrentDir()),
       url: pkg["url"].getStr,
       commit: pkg["vcsRevision"].getStr,
     )

--- a/src/lockfiles.nim
+++ b/src/lockfiles.nim
@@ -216,6 +216,45 @@ proc convertAndSaveNimbleLock*(c: var AtlasContext; nimblePath, lockFilePath: st
   let lf = convertNimbleLock(c, nimblePath)
   write lf, lockFilePath
 
+proc listChanged*(c: var AtlasContext; lockFilePath: string) =
+  ## replays the given lockfile by cloning and updating all the deps
+  ## 
+  ## this also includes updating the nim.cfg and nimble file as well
+  ## if they're included in the lockfile
+  ## 
+  let lf = if lockFilePath == "nimble.lock": convertNimbleLock(c, lockFilePath)
+           else: readLockFile(lockFilePath)
+
+  let base = splitPath(lockFilePath).head
+
+  # update the the dependencies
+  for _, v in pairs(lf.items):
+    let dir = base / v.dir
+    if not dirExists(dir):
+      warn c, toRepo(dir), "repo missing!"
+      continue
+    withDir c, dir:
+      let url = $getRemoteUrl()
+      if v.url != url:
+        warn c, toRepo(v.dir), "remote URL has been changed;" &
+                                  " found: " & url &
+                                  " lockfile has: " & v.url
+      
+      let commit = gitops.getCurrentCommit()
+      if commit != v.commit:
+        let pkg = c.resolvePackage("file://" & dir)
+        c.resolveNimble(pkg)
+        let info = extractRequiresInfo(c, pkg.nimble)
+        warn c, toRepo(dir), "commit differs;" &
+                                            " found: " & commit &
+                                            " (" & info.version & ")" &
+                                            " lockfile has: " & v.commit
+
+  if lf.hostOS == system.hostOS and lf.hostCPU == system.hostCPU:
+    compareVersion c, "nim", lf.nimVersion, detectNimVersion()
+    compareVersion c, "gcc", lf.gccVersion, detectGccVersion()
+    compareVersion c, "clang", lf.clangVersion, detectClangVersion()
+
 proc replay*(c: var AtlasContext; lockFilePath: string): tuple[hasCfg: bool] =
   ## replays the given lockfile by cloning and updating all the deps
   ## 

--- a/src/lockfiles.nim
+++ b/src/lockfiles.nim
@@ -205,7 +205,7 @@ proc convertNimbleLock*(c: var AtlasContext; nimblePath: string): LockFile =
     info c, toRepo(name), " imported "
     let dir = c.depsDir / name
     result.items[name] = LockFileEntry(
-      dir: dir.relativePath(getCurrentDir()),
+      dir: dir.relativePath(c.projectDir),
       url: pkg["url"].getStr,
       commit: pkg["vcsRevision"].getStr,
     )

--- a/src/lockfiles.nim
+++ b/src/lockfiles.nim
@@ -216,7 +216,7 @@ proc convertAndSaveNimbleLock*(c: var AtlasContext; nimblePath, lockFilePath: st
   let lf = convertNimbleLock(c, nimblePath)
   write lf, lockFilePath
 
-proc replay*(c: var AtlasContext; lockFilePath: string) =
+proc replay*(c: var AtlasContext; lockFilePath: string): tuple[hasCfg: bool] =
   ## replays the given lockfile by cloning and updating all the deps
   ## 
   ## this also includes updating the nim.cfg and nimble file as well
@@ -229,6 +229,7 @@ proc replay*(c: var AtlasContext; lockFilePath: string) =
   # update the nim.cfg file
   if lf.nimcfg.len > 0:
     writeFile(base / NimCfg, lf.nimcfg)
+    result.hasCfg = true
   # update the nimble file
   if lf.nimbleFile.filename.len > 0:
     writeFile(base / lf.nimbleFile.filename, lf.nimbleFile.content)

--- a/src/nameresolver.nim
+++ b/src/nameresolver.nim
@@ -153,11 +153,6 @@ proc findNimbleFile*(c: var AtlasContext; pkg: Package, depDir = PackageDir ""):
       trace c, pkg, "nimble file found " & result.get()
       discard
 
-proc checkIfNimble(url: PackageUrl): bool =
-  if url.scheme == "file":
-    let fl = url.hostname & url.path
-    result = fl.fileExists()
-
 proc resolvePackageUrl(c: var AtlasContext; url: string, checkOverrides = true): Package =
   result = Package(url: getUrl(url),
                    name: url.toRepo().PackageName,
@@ -192,19 +187,13 @@ proc resolvePackageUrl(c: var AtlasContext; url: string, checkOverrides = true):
   elif not repoPkg.isNil:
     debug c, result, "resolvePackageUrl: found by repo: " & $result.repo.string
     result = repoPkg
-  elif isFile and checkIfNimble(result.url):
-    result.path = PackageDir (result.url.hostname & result.url.path).parentDir
-    result.repo = PackageRepo result.path.string.lastPathComponent
-    debug c, result, "resolvePackageUrl: found by nimble file " & $result.repo.string
-    c.urlMapping["repo:" & result.name.string] = result
-    trace c, result, "resolvePackageUrl: not found; set pkg: " & $result.repo.string
   else:
     # package doesn't exit and doesn't conflict
     # set the url with package name as url name
     c.urlMapping["repo:" & result.name.string] = result
     trace c, result, "resolvePackageUrl: not found; set pkg: " & $result.repo.string
   
-  if isFile and not result.url.checkIfNimble():
+  if result.url.scheme == "file":
     result.path = PackageDir result.url.hostname & result.url.path
     trace c, result, "resolvePackageUrl: setting manual path: " & $result.path.string
 


### PR DESCRIPTION
- fix `atlas install` where the nimble path wasn't being used correctly
- `atlas replay` will now call `atlas install` to setup nim.cfg if empty or `--cfghere` passed
- `atlas convert` imports the Nim version if found in the nimble.lock
- add `atlas changed` command to print out deps that have changed
- `atlas convert` to use paths relative to current project