### PR TITLE
Various fixes

### DIFF
--- a/src/confighandler.nim
+++ b/src/confighandler.nim
@@ -16,6 +16,7 @@ proc parseOverridesFile(c: var AtlasContext; filename: string) =
   let path = c.workspace / filename
   var f: File
   if open(f, path):
+    info c, toRepo("overrides"), "loading file: " & path
     c.flags.incl UsesOverrides
     try:
       var lineCount = 1

--- a/src/context.nim
+++ b/src/context.nim
@@ -21,9 +21,11 @@ const
 const
   AtlasWorkspace* = "atlas.workspace"
 
-proc getUrl*(x: string): PackageUrl =
+proc getUrl*(input: string): PackageUrl =
   try:
-    let u = parseUri(x).PackageUrl
+    var input = input
+    input.removeSuffix(".git")
+    let u = PackageUrl(parseUri(input))
     if u.scheme in ["git", "https", "http", "hg", "file"]:
       result = u
   except UriParseError:

--- a/src/lockfiles.nim
+++ b/src/lockfiles.nim
@@ -208,7 +208,7 @@ proc convertNimbleLock*(c: var AtlasContext; nimblePath: string): LockFile =
     let dir = c.depsDir / pkg.repo.string
     result.items[name] = LockFileEntry(
       dir: dir.relativePath(c.projectDir),
-      url: info["url"].getStr,
+      url: $pkg.url,
       commit: info["vcsRevision"].getStr,
     )
 

--- a/src/lockfiles.nim
+++ b/src/lockfiles.nim
@@ -284,7 +284,7 @@ proc replay*(c: var AtlasContext; lockFilePath: string): tuple[hasCfg: bool] =
         continue
     withDir c, dir:
       let url = $getRemoteUrl()
-      if v.url != url:
+      if $v.url.getUrl() != url:
         error c, toRepo(v.dir), "remote URL has been compromised: got: " &
             url & " but wanted: " & v.url
       checkoutGitCommit(c, toRepo(dir), v.commit)

--- a/src/lockfiles.nim
+++ b/src/lockfiles.nim
@@ -198,16 +198,18 @@ proc convertNimbleLock*(c: var AtlasContext; nimblePath: string): LockFile =
     return
 
   result = newLockFile()
-  for (name, pkg) in jsonTree["packages"].pairs:
+  for (name, info) in jsonTree["packages"].pairs:
     if name == "nim":
-      result.nimVersion = pkg["version"].getStr
+      result.nimVersion = info["version"].getStr
       continue
+    # lookup package using url
+    let pkg = c.resolvePackage(info["url"].getStr)
     info c, toRepo(name), " imported "
-    let dir = c.depsDir / name
+    let dir = c.depsDir / pkg.repo.string
     result.items[name] = LockFileEntry(
       dir: dir.relativePath(c.projectDir),
-      url: pkg["url"].getStr,
-      commit: pkg["vcsRevision"].getStr,
+      url: info["url"].getStr,
+      commit: info["vcsRevision"].getStr,
     )
 
 

--- a/src/nameresolver.nim
+++ b/src/nameresolver.nim
@@ -165,7 +165,7 @@ proc resolvePackageUrl(c: var AtlasContext; url: string, checkOverrides = true):
   if not isFile and checkOverrides and UsesOverrides in c.flags:
     let url = c.overrides.substitute($result.url)
     if url.len > 0:
-      info c, result, "resolvePackageUrl: url override found: " & $url
+      warn c, result, "resolvePackageUrl: url override found: " & $url
       result.url = url.getUrl()
       isUrlOverriden = true
 

--- a/src/nameresolver.nim
+++ b/src/nameresolver.nim
@@ -175,7 +175,7 @@ proc resolvePackageUrl(c: var AtlasContext; url: string, checkOverrides = true):
   if not namePkg.isNil:
     debug c, result, "resolvePackageUrl: found by name: " & $result.name.string
     if namePkg.url != result.url and isUrlOverriden:
-      namePkg.url = result.url # update package url to match 
+      namePkg.url = result.url # update package url to match
       result = namePkg
     elif namePkg.url != result.url:
       # package conflicts

--- a/src/nameresolver.nim
+++ b/src/nameresolver.nim
@@ -161,16 +161,23 @@ proc resolvePackageUrl(c: var AtlasContext; url: string, checkOverrides = true):
   debug c, result, "resolvePackageUrl: search: " & url
 
   let isFile = result.url.scheme == "file"
+  var isUrlOverriden = false
   if not isFile and checkOverrides and UsesOverrides in c.flags:
-    let url = c.overrides.substitute(url)
+    let url = c.overrides.substitute($result.url)
     if url.len > 0:
+      info c, result, "resolvePackageUrl: url override found: " & $url
       result.url = url.getUrl()
+      isUrlOverriden = true
 
   let namePkg = c.urlMapping.getOrDefault("name:" & result.name.string, nil)
   let repoPkg = c.urlMapping.getOrDefault("repo:" & result.repo.string, nil)
 
   if not namePkg.isNil:
-    if namePkg.url != result.url:
+    debug c, result, "resolvePackageUrl: found by name: " & $result.name.string
+    if namePkg.url != result.url and isUrlOverriden:
+      namePkg.url = result.url # update package url to match 
+      result = namePkg
+    elif namePkg.url != result.url:
       # package conflicts
       # change package repo to `repo.user.host`
       let purl = result.url
@@ -183,7 +190,8 @@ proc resolvePackageUrl(c: var AtlasContext; url: string, checkOverrides = true):
                 result.name.string & " to " & pname
       result.repo = PackageRepo pname
       c.urlMapping["name:" & result.name.string] = result
-    debug c, result, "resolvePackageUrl: found by name: " & $result.name.string
+    else:
+      result = namePkg
   elif not repoPkg.isNil:
     debug c, result, "resolvePackageUrl: found by repo: " & $result.repo.string
     result = repoPkg


### PR DESCRIPTION
- `getUrl` normalizes all url's ending in `.git` to prevent false duplicates
- `nimbleConverLock` uses now resolves packages and uses repo name for path
-  improvement to urlOverride logic to properly set updated url's