### PR TITLE
build universal macos and linux arm / arm64 binaries

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -23,9 +23,9 @@ jobs:
           # - os: linux
           #   triple: i686-linux-musl
           #   name: linux_i386
-          # - os: linux
-          #   triple: aarch64-linux-musl
-          #   name: linux_arm64
+          - os: linux
+            triple: aarch64-linux-gnu
+            name: linux_arm64
           # - os: linux
           #   triple: armv7l-linux-musleabihf
           #   name: linux_arm
@@ -68,6 +68,12 @@ jobs:
       - name: build
         run: |
           nim buildRelease
+
+      - name: build
+        if: ${{ matrix.target.name }} == "linux_arm64"
+        run: |
+          sudo apt install gcc make gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu
+          nim buildRelease -d:${{matrix.target.name}}
 
       - name: Compress the Nim Language Server binaries
         run: |

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -27,9 +27,9 @@ jobs:
             triple: aarch64-linux-gnu
             arch: aarch64
             name: linux_arm64
-          # - os: linux
-          #   triple: armv7l-linux-musleabihf
-          #   name: linux_arm
+          - os: linux
+            triple: arm-linux-gnueabihf
+            name: linux_arm
           - os: macosx
             triple: x86_64-apple-darwin14
             name: apple_universal

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -25,6 +25,7 @@ jobs:
           #   name: linux_i386
           - os: linux
             triple: aarch64-linux-gnu
+            arch: aarch64
             name: linux_arm64
           # - os: linux
           #   triple: armv7l-linux-musleabihf
@@ -65,15 +66,15 @@ jobs:
         with:
           nim-version: "stable"
 
-      - name: build
+      - name: setup build
+        if: ${{ matrix.target.name }} == "arm" || ${{ matrix.target.name }} == "arm64"
         run: |
-          nim buildRelease
+          sudo apt install gcc make gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu \
+                                    gcc-arm-linux-gnueabihf binutils-arm-linux-gnueabihf
 
       - name: build
-        if: ${{ matrix.target.name }} == "linux_arm64"
         run: |
-          sudo apt install gcc make gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu
-          nim buildRelease -d:${{matrix.target.name}}
+          OS=${{ matrix.target.os }} ARCH=${{ matrix.target.arch }} nim buildRelease
 
       - name: Compress the Nim Language Server binaries
         run: |

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -32,19 +32,13 @@ jobs:
             arch: amd64
             triple: x86_64-w64-mingw32
             name: windows_x86_64
-          # - os: windows
-          #   triple: i686-w64-mingw32
-          #   name: windows_i386
         include:
           - target:
               os: linux
-            builder: ubuntu-20.04
+            builder: ubuntu-latest
           - target:
               os: macosx
-            builder: macos-11
-          - target:
-              os: windows
-            builder: windows-2019
+            builder: macos-latest
     defaults:
       run:
         shell: bash
@@ -60,6 +54,7 @@ jobs:
           nim-version: "stable"
 
       - name: setup build
+        if: ${{ matrix.builder }} == "ubuntu-latest"
         run: |
           sudo apt install gcc make gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu \
                                     gcc-arm-linux-gnueabihf binutils-arm-linux-gnueabihf \

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -60,10 +60,10 @@ jobs:
           nim-version: "stable"
 
       - name: setup build
-        if: ${{ matrix.target.name }} == "arm" || ${{ matrix.target.name }} == "arm64"
         run: |
           sudo apt install gcc make gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu \
-                                    gcc-arm-linux-gnueabihf binutils-arm-linux-gnueabihf
+                                    gcc-arm-linux-gnueabihf binutils-arm-linux-gnueabihf \
+                                    mingw-w64
 
       - name: build
         run: |

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -31,7 +31,7 @@ jobs:
           #   name: linux_arm
           - os: macosx
             triple: x86_64-apple-darwin14
-            name: apple_x86_64
+            name: apple_universal
           - os: windows
             triple: x86_64-w64-mingw32
             name: windows_x86_64
@@ -67,7 +67,7 @@ jobs:
 
       - name: build
         run: |
-          nim release
+          nim buildRelease
 
       - name: Compress the Nim Language Server binaries
         run: |

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -13,32 +13,25 @@ jobs:
       matrix:
         target:
           - os: linux
+            arch: amd64
             triple: x86_64-linux-gnu
             name: linux_x86_64
-          ## these triples don't actually work (yet) 
-          ## TODO: add cross compilation for arm targets
-          # - os: linux
-          #   triple: i686-linux-musl
-          #   name: linux_i686
-          # - os: linux
-          #   triple: i686-linux-musl
-          #   name: linux_i386
           - os: linux
-            triple: aarch64-linux-gnu
             arch: aarch64
+            triple: aarch64-linux-gnu
             name: linux_arm64
           - os: linux
+            arch: arm
             triple: arm-linux-gnueabihf
             name: linux_arm
           - os: macosx
+            arch: universal
             triple: x86_64-apple-darwin14
             name: apple_universal
           - os: windows
+            arch: amd64
             triple: x86_64-w64-mingw32
             name: windows_x86_64
-          # - os: windows
-          #   triple: i686-w64-mingw32
-          #   name: windows_i686
           # - os: windows
           #   triple: i686-w64-mingw32
           #   name: windows_i386

--- a/config.nims
+++ b/config.nims
@@ -17,6 +17,8 @@ task buildRelease, "Build release":
     exec "lipo -create -output atlas atlas_x86_64 atlas_arm64"
     rmFile("atlas_x86_64")
     rmFile("atlas_arm64")
+  elif defined(windows):
+    exec "nim c -d:mingw -d:release -o:./atlas src/atlas.nim"
   else:
     let os = getEnv("OS")
     let arch = getEnv("ARCH")

--- a/config.nims
+++ b/config.nims
@@ -18,7 +18,7 @@ task buildRelease, "Build release":
     rmFile("atlas_x86_64")
     rmFile("atlas_arm64")
   else:
-    exec "nim c -d:release -o:./atlas -r src/atlas.nim"
+    exec "nim c -d:release -o:./atlas src/atlas.nim"
 
 task test, "Runs all tests":
   # unitTestsTask() # tester runs both

--- a/config.nims
+++ b/config.nims
@@ -18,7 +18,12 @@ task buildRelease, "Build release":
     rmFile("atlas_x86_64")
     rmFile("atlas_arm64")
   else:
-    exec "nim c -d:release -o:./atlas src/atlas.nim"
+    let os = getEnv("OS")
+    let arch = getEnv("ARCH")
+    if os != "" and arch != "":
+      exec "nim c -d:release --cpu:" & arch & " --os:" & os & " -o:./atlas src/atlas.nim"
+    else:
+      exec "nim c -d:release -o:./atlas src/atlas.nim"
 
 task test, "Runs all tests":
   # unitTestsTask() # tester runs both

--- a/config.nims
+++ b/config.nims
@@ -17,13 +17,14 @@ task buildRelease, "Build release":
     exec "lipo -create -output atlas atlas_x86_64 atlas_arm64"
     rmFile("atlas_x86_64")
     rmFile("atlas_arm64")
-  elif defined(windows):
-    exec "nim c -d:mingw -d:release -o:./atlas src/atlas.nim"
   else:
     let os = getEnv("OS")
     let arch = getEnv("ARCH")
     if os != "" and arch != "":
-      exec "nim c -d:release --cpu:" & arch & " --os:" & os & " -o:./atlas src/atlas.nim"
+      if os == "windows":
+        exec "nim c -d:release -d:mingw --cpu:" & arch & " --os:" & os & " -o:./atlas src/atlas.nim"
+      else:
+        exec "nim c -d:release --cpu:" & arch & " --os:" & os & " -o:./atlas src/atlas.nim"
     else:
       exec "nim c -d:release -o:./atlas src/atlas.nim"
 

--- a/config.nims
+++ b/config.nims
@@ -8,6 +8,18 @@ task unitTests, "Runs unit tests":
 task tester, "Runs integration tests":
   exec "nim c -d:debug -r tests/tester.nim"
 
+task buildRelease, "Build release":
+  when defined(macosx):
+    let x86Args = "\"-target x86_64-apple-macos11 -arch x86_64 -DARCH=x86_64\""
+    exec "nim c -d:release --passC:" & x86args & " --passL:" & x86args & " -o:./atlas_x86_64 src/atlas.nim"
+    let armArgs = "\"-target arm64-apple-macos11 -arch arm64 -DARCH=arm64\""
+    exec "nim c -d:release --passC:" & armArgs & " --passL:" & armArgs & " -o:./atlas_arm64 src/atlas.nim"
+    exec "lipo -create -output atlas atlas_x86_64 atlas_arm64"
+    rmFile("atlas_x86_64")
+    rmFile("atlas_arm64")
+  else:
+    exec "nim c -d:release -o:./atlas -r src/atlas.nim"
+
 task test, "Runs all tests":
   # unitTestsTask() # tester runs both
   testerTask()

--- a/config.nims
+++ b/config.nims
@@ -22,7 +22,7 @@ task buildRelease, "Build release":
     let arch = getEnv("ARCH")
     if os != "" and arch != "":
       if os == "windows":
-        exec "nim c -d:release -d:mingw --cpu:" & arch & " --os:" & os & " -o:./atlas src/atlas.nim"
+        exec "nim c -d:release -d:mingw -o:./atlas src/atlas.nim"
       else:
         exec "nim c -d:release --cpu:" & arch & " --os:" & os & " -o:./atlas src/atlas.nim"
     else:


### PR DESCRIPTION
Adds a `buildRelease` task to config.nims for handling the cross xc builds. I tested both macos, linux, and windows builds to ensure they build the correct arch. I did not run them on all the platforms. 

I updated binaries.yml in the CI, but it is untested. Very likely to have things to fix, but the general structure should now be correct.