### PR TITLE
Lockfile and other improvements

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -11,3 +11,5 @@ task tester, "Runs integration tests":
 task test, "Runs all tests":
   # unitTestsTask() # tester runs both
   testerTask()
+
+--path:"$nim"

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -162,10 +162,10 @@ proc checkoutCommit(c: var AtlasContext; g: var DepGraph; w: Dependency) =
             if status == 0 and (mergeBase == currentCommit or mergeBase == requiredCommit):
               # conflict resolution: pick the later commit:
               if mergeBase == currentCommit:
-                checkoutGitCommit(c, w.pkg.repo, requiredCommit)
+                checkoutGitCommit(c, w.pkg.path, requiredCommit)
                 selectNode c, g, w
             else:
-              checkoutGitCommit(c, w.pkg.repo, requiredCommit)
+              checkoutGitCommit(c, w.pkg.path, requiredCommit)
               selectNode c, g, w
               when false:
                 warn c, w.pkg, "do not know which commit is more recent:",
@@ -302,7 +302,7 @@ proc resolve(c: var AtlasContext; g: var DepGraph) =
         let destDir = pkg.name.string
         debug c, pkg, "package satisfiable: " & $pkg
         withDir c, pkg:
-          checkoutGitCommit(c, toRepo(destDir), mapping[i - g.nodes.len][1])
+          checkoutGitCommit(c, PackageDir(destDir), mapping[i - g.nodes.len][1])
     if NoExec notin c.flags:
       runBuildSteps(c, g)
       #echo f

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -446,7 +446,7 @@ proc listOutdated(c: var AtlasContext; dir: string) =
   for k, f in walkDir(dir, relative=true):
     if k in {pcDir, pcLinkToDir} and isGitDir(dir / f):
       withDir c, dir / f:
-        if gitops.isOutdated(c, dir / f):
+        if gitops.isOutdated(c, PackageDir(dir / f)):
           inc updateable
 
   if updateable == 0:

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -446,7 +446,7 @@ proc listOutdated(c: var AtlasContext; dir: string) =
   for k, f in walkDir(dir, relative=true):
     if k in {pcDir, pcLinkToDir} and isGitDir(dir / f):
       withDir c, dir / f:
-        if gitops.isOutdated(c, f):
+        if gitops.isOutdated(c, dir / f):
           inc updateable
 
   if updateable == 0:

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -61,6 +61,7 @@ Command:
 
 Options:
   --keepCommits         do not perform any `git checkouts`
+  --full                perform full checkouts rather than the default shallow
   --cfgHere             also create/maintain a nim.cfg in the current
                         working directory
   --workspace=DIR       use DIR as workspace
@@ -521,7 +522,7 @@ proc main(c: var AtlasContext) =
         else:
           writeHelp()
       of "cfghere": c.flags.incl CfgHere
-      of "shallow": c.flags.incl ShallowClones
+      of "full": c.flags.incl FullClones
       of "autoinit": autoinit = true
       of "showgraph": c.flags.incl ShowGraph
       of "keep": c.flags.incl Keep

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -706,7 +706,9 @@ proc main(c: var AtlasContext) =
     optSingleArg(LockFileName)
     let res = replay(c, args[0])
     if CfgHere in c.flags or res.hasCfg == false:
+      info c, toRepo("replay"), "setting up nim.cfg"
       let nimbleFile = findCurrentNimble()
+      trace c, toRepo("replay"), "using nimble file: " & nimbleFile
       installDependencies(c, nimbleFile, startIsDep = true)
   of "changed":
     optSingleArg(LockFileName)

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -521,6 +521,7 @@ proc main(c: var AtlasContext) =
         else:
           writeHelp()
       of "cfghere": c.flags.incl CfgHere
+      of "shallow": c.flags.incl ShallowClones
       of "autoinit": autoinit = true
       of "showgraph": c.flags.incl ShowGraph
       of "keep": c.flags.incl Keep

--- a/src/configutils.nim
+++ b/src/configutils.nim
@@ -1,0 +1,57 @@
+import std/[os, strutils]
+import context, osutils, parse_requires
+
+export parse_requires
+
+const
+  configPatternBegin = "############# begin Atlas config section ##########\n"
+  configPatternEnd =   "############# end Atlas config section   ##########\n"
+
+proc parseNimble*(c: var AtlasContext; nimble: PackageNimble): NimbleFileInfo =
+  result = extractRequiresInfo(nimble.string)
+  when ProduceTest:
+    echo "nimble ", nimbleFile, " info ", result
+
+proc findCfgDir*(c: var AtlasContext): CfgPath =
+  for nimbleFile in walkPattern(c.currentDir / "*.nimble"):
+    let nimbleInfo = parseNimble(c, PackageNimble nimbleFile)
+    return CfgPath c.currentDir / nimbleInfo.srcDir
+  return CfgPath c.currentDir
+
+proc findCfgDir*(c: var AtlasContext, pkg: Package): CfgPath =
+  let nimbleInfo = parseNimble(c, pkg.nimble)
+  return CfgPath c.currentDir / nimbleInfo.srcDir
+
+proc patchNimCfg*(c: var AtlasContext; deps: seq[CfgPath]; cfgPath: CfgPath) =
+  var paths = "--noNimblePath\n"
+  for d in deps:
+    let x = relativePath(d.string, cfgPath.string, '/')
+    paths.add "--path:\"" & x & "\"\n"
+  var cfgContent = configPatternBegin & paths & configPatternEnd
+
+  when MockupRun:
+    assert readFile(TestsDir / "nim.cfg") == cfgContent
+    c.mockupSuccess = true
+  else:
+    let cfg = cfgPath.string / "nim.cfg"
+    assert cfgPath.string.len > 0
+    if cfgPath.string.len > 0 and not dirExists(cfgPath.string):
+      error(c, c.projectDir.toRepo, "could not write the nim.cfg")
+    elif not fileExists(cfg):
+      writeFile(cfg, cfgContent)
+      info(c, projectFromCurrentDir(), "created: " & cfg.readableFile)
+    else:
+      let content = readFile(cfg)
+      let start = content.find(configPatternBegin)
+      if start >= 0:
+        cfgContent = content.substr(0, start-1) & cfgContent
+        let theEnd = content.find(configPatternEnd, start)
+        if theEnd >= 0:
+          cfgContent.add content.substr(theEnd+len(configPatternEnd))
+      else:
+        cfgContent = content & "\n" & cfgContent
+      if cfgContent != content:
+        # do not touch the file if nothing changed
+        # (preserves the file date information):
+        writeFile(cfg, cfgContent)
+        info(c, projectFromCurrentDir(), "updated: " & cfg.readableFile)

--- a/src/configutils.nim
+++ b/src/configutils.nim
@@ -94,8 +94,16 @@ proc patchNimbleFile*(c: var AtlasContext; dep: string): string =
       if result.len > 0:
         var oldContent = readFile(result).splitLines()
         var idx = oldContent.len()
+        var endsWithComma = false
         for i, line in oldContent:
-          if line.startsWith "requires": idx = i
+          if endsWithComma:
+            endsWithComma = line.strip().endsWith(",")
+            if not endsWithComma:
+              idx = i
+          if line.startsWith "requires":
+            idx = i
+            endsWithComma = line.strip().endsWith(",")
+
         oldContent.insert(line, idx+1)
         writeFile result, oldContent.join("\n")
         info(c, toRepo(thisProject), "updated: " & result.readableFile)

--- a/src/context.nim
+++ b/src/context.nim
@@ -89,6 +89,7 @@ type
     ListVersions
     GlobalWorkspace
     AssertOnError
+    ShallowClones
 
   MsgKind = enum
     Info = "[Info] ",

--- a/src/context.nim
+++ b/src/context.nim
@@ -174,7 +174,6 @@ proc writeMessage(c: var AtlasContext; k: MsgKind; p: PackageRepo; arg: string) 
   if NoColors in c.flags:
     writeMessage(c, $k, p, arg)
   else:
-    echo "P: ", p.string, " depsDir: ", c.depsDir, " ws: ", c.workspace, " deps: ", p.string.relativePath(c.depsDir)
     let pn =
       if c.depsDir != "" and p.string.isRelativeTo(c.depsDir):
         p.string.relativePath(c.depsDir)
@@ -182,7 +181,6 @@ proc writeMessage(c: var AtlasContext; k: MsgKind; p: PackageRepo; arg: string) 
         p.string.relativePath(c.workspace)
       else:
         p.string
-    echo "PN: ", pn
     let (color, style) = case k
                 of Debug: (fgWhite, styleDim)
                 of Trace: (fgBlue, styleBright)

--- a/src/context.nim
+++ b/src/context.nim
@@ -261,6 +261,9 @@ proc toRepo*(p: string): PackageRepo =
 proc toRepo*(p: Package): PackageRepo =
   result = p.repo
 
+proc toRepo*(p: PackageDir): PackageRepo =
+  result = PackageRepo p.string
+
 template projectFromCurrentDir*(): PackageRepo =
   PackageRepo(c.currentDir.absolutePath())
 

--- a/src/context.nim
+++ b/src/context.nim
@@ -89,7 +89,7 @@ type
     ListVersions
     GlobalWorkspace
     AssertOnError
-    ShallowClones
+    FullClones
 
   MsgKind = enum
     Info = "[Info] ",

--- a/src/gitops.nim
+++ b/src/gitops.nim
@@ -3,7 +3,7 @@ import context, osutils
 
 type
   Command* = enum
-    GitClone = "git clone",
+    GitClone = "git clone --depth=1",
     GitDiff = "git diff",
     GitTag = "git tag",
     GitTags = "git show-ref --tags",

--- a/src/gitops.nim
+++ b/src/gitops.nim
@@ -229,7 +229,7 @@ proc getRemoteUrl*(): PackageUrl =
 proc getCurrentCommit*(): string =
   result = execProcess("git log -1 --pretty=format:%H").strip()
 
-proc isOutdated*(c: var AtlasContext; path: string): bool =
+proc isOutdated*(c: var AtlasContext; path: PackageDir): bool =
   ## determine if the given git repo `f` is updateable
   ##
 

--- a/src/gitops.nim
+++ b/src/gitops.nim
@@ -229,9 +229,11 @@ proc getRemoteUrl*(): PackageUrl =
 proc getCurrentCommit*(): string =
   result = execProcess("git log -1 --pretty=format:%H").strip()
 
-proc isOutdated*(c: var AtlasContext; f: string): bool =
+proc isOutdated*(c: var AtlasContext; path: string): bool =
   ## determine if the given git repo `f` is updateable
   ##
+
+  info c, toRepo(path), "checking is package is up to date..."
 
   # TODO: does --update-shallow fetch tags on a shallow repo?
   let (outp, status) = exec(c, GitFetch, ["--update-shallow", "--tags"])
@@ -254,10 +256,10 @@ proc isOutdated*(c: var AtlasContext; f: string): bool =
           if status == 0 and mergeBase == currentCommit:
             let v = extractVersion gitDescribeRefTag(c, latestVersion)
             if v.len > 0:
-              info c, toRepo(f), "new version available: " & v
+              info c, toRepo(path), "new version available: " & v
               result = true
   else:
-    warn c, toRepo(f), "`git fetch` failed: " & outp
+    warn c, toRepo(path), "`git fetch` failed: " & outp
 
 proc updateDir*(c: var AtlasContext; file, filter: string) =
   withDir c, file:

--- a/src/gitops.nim
+++ b/src/gitops.nim
@@ -135,7 +135,8 @@ proc listFiles*(c: var AtlasContext; pkg: Package): Option[seq[string]] =
   if status == 0:
     result = some outp.splitLines().mapIt(it.strip())
 
-proc checkoutGitCommit*(c: var AtlasContext; p: PackageRepo; commit: string) =
+proc checkoutGitCommit*(c: var AtlasContext; p: PackageDir; commit: string) =
+  let p = p.string.PackageRepo
   var smExtraArgs: seq[string]
 
   if FullClones notin c.flags:

--- a/src/gitops.nim
+++ b/src/gitops.nim
@@ -229,7 +229,9 @@ proc getCurrentCommit*(): string =
 proc isOutdated*(c: var AtlasContext; f: string): bool =
   ## determine if the given git repo `f` is updateable
   ##
-  let (outp, status) = exec(c, GitFetch, ["--update-shallow"])
+
+  # TODO: does --update-shallow fetch tags on a shallow repo?
+  let (outp, status) = exec(c, GitFetch, ["--update-shallow", "--tags"])
   if status == 0:
     let (cc, status) = exec(c, GitLastTaggedRef, [])
     let latestVersion = strutils.strip(cc)

--- a/src/lockfiles.nim
+++ b/src/lockfiles.nim
@@ -301,7 +301,7 @@ proc replay*(c: var AtlasContext; lockFilePath: string): tuple[hasCfg: bool] =
   # update the nimble file
   if lf.nimbleFile.filename.len > 0:
     writeFile(lfBase / lf.nimbleFile.filename,
-              lf.nimbleFile.content.join($DirSep))
+              lf.nimbleFile.content.join("\n"))
   # update the the dependencies
   for _, v in pairs(lf.items):
     trace c, toRepo("replay"), "replaying: " & v.repr

--- a/src/lockfiles.nim
+++ b/src/lockfiles.nim
@@ -349,7 +349,7 @@ proc replay*(c: var AtlasContext; lockFilePath: string) =
       if $v.url.getUrl() != url:
         error c, toRepo(v.dir), "remote URL has been compromised: got: " &
             url & " but wanted: " & v.url
-      checkoutGitCommit(c, toRepo(dir), v.commit)
+      checkoutGitCommit(c, dir.PackageDir, v.commit)
 
       if genCfg:
         let pkg = resolvePackage(c, "file://" & c.currentDir)

--- a/src/lockfiles.nim
+++ b/src/lockfiles.nim
@@ -47,8 +47,8 @@ proc convertKeyToArray(jsonTree: var JsonNode, path: varargs[string]) =
 proc readLockFile(filename: string): LockFile =
   let jsonAsStr = readFile(filename)
   var jsonTree = parseJson(jsonAsStr)
-  # convert non-array content to JArray
 
+  # convert older non-array file contents to JArray
   jsonTree.convertKeyToArray("nimcfg")
   jsonTree.convertKeyToArray("nimbleFile", "content")
   result = jsonTo(jsonTree, LockFile,

--- a/src/lockfiles.nim
+++ b/src/lockfiles.nim
@@ -321,22 +321,19 @@ proc replay*(c: var AtlasContext; lockFilePath: string) =
            else: readLockFile(lockFilePath)
 
   let lfBase = splitPath(lockFilePath).head
-  var genCfg = true
+  var genCfg = CfgHere in c.flags
 
   # update the nim.cfg file
   if lf.nimcfg.len > 0:
     writeFile(lfBase / NimCfg, lf.nimcfg.join("\n"))
-    genCfg = false
+  else:
+    genCfg = true
+
   # update the nimble file
   if lf.nimbleFile.filename.len > 0:
     writeFile(lfBase / lf.nimbleFile.filename,
               lf.nimbleFile.content.join("\n"))
   
-  genCfg = CfgHere in c.flags or genCfg
-    # info c, toRepo("replay"), "setting up nim.cfg"
-    # let nimbleFile = findCurrentNimble()
-    # trace c, toRepo("replay"), "using nimble file: " & nimbleFile
-    # installDependencies(c, nimbleFile, startIsDep = true)
 
   # update the the dependencies
   var paths: seq[CfgPath]

--- a/src/lockfiles.nim
+++ b/src/lockfiles.nim
@@ -304,7 +304,8 @@ proc listChanged*(c: var AtlasContext; lockFilePath: string) =
         warn c, toRepo(dir), "commit differs;" &
                                             " found: " & commit &
                                             " (" & info.version & ")" &
-                                            " lockfile has: " & v.commit
+                                            " lockfile has: " & v.commit &
+                                            " (" & v.version & ")"
 
   if lf.hostOS == system.hostOS and lf.hostCPU == system.hostCPU:
     compareVersion c, "nim", lf.nimVersion, detectNimVersion()

--- a/src/lockfiles.nim
+++ b/src/lockfiles.nim
@@ -76,7 +76,7 @@ proc fromPrefixedPath*(c: var AtlasContext, path: string): string =
     path.removePrefix("$workspace")
     return c.workspace / path
   else:
-    return c.workspace / path
+    return c.depsDir / path
 
 proc genLockEntry(c: var AtlasContext; lf: var LockFile; pkg: Package) =
   let info = extractRequiresInfo(pkg.nimble.string)

--- a/src/lockfiles.nim
+++ b/src/lockfiles.nim
@@ -334,7 +334,6 @@ proc replay*(c: var AtlasContext; lockFilePath: string) =
     writeFile(lfBase / lf.nimbleFile.filename,
               lf.nimbleFile.content.join("\n"))
   
-
   # update the the dependencies
   var paths: seq[CfgPath]
   for _, v in pairs(lf.items):

--- a/src/nameresolver.nim
+++ b/src/nameresolver.nim
@@ -98,7 +98,7 @@ proc fillPackageLookupTable(c: var AtlasContext) =
     for entry in plist:
       let url = getUrl(entry.url)
       let pkg = Package(name: PackageName unicode.toLower entry.name,
-                        repo: url.toRepo(),
+                        repo: PackageRepo lastPathComponent($url),
                         url: url)
       c.urlMapping["name:" & pkg.name.string] = pkg
 

--- a/src/nimenv.nim
+++ b/src/nimenv.nim
@@ -90,7 +90,7 @@ proc setupNimEnv*(c: var AtlasContext; nimVersion: string) =
       if commit.len == 0:
         error c, toRepo(nimDest), "cannot resolve version to a commit"
         return
-      checkoutGitCommit(c, dep.pkg.repo, commit)
+      checkoutGitCommit(c, dep.pkg.path, commit)
     exec c, nimExe & " c --noNimblePath --skipUserCfg --skipParentCfg --hints:off koch"
     let kochExe = when defined(windows): "koch.exe" else: "./koch"
     exec c, kochExe & " boot -d:release --skipUserCfg --skipParentCfg --hints:off"

--- a/src/traversal.nim
+++ b/src/traversal.nim
@@ -9,7 +9,7 @@
 ## Helpers for the graph traversal.
 
 import std / [strutils, os, sha1, algorithm]
-import context, nameresolver, gitops
+import context, nameresolver, gitops, configutils
 
 proc createGraph*(c: var AtlasContext; start: Package): DepGraph =
   let dep = Dependency(pkg: start, commit: "",
@@ -52,11 +52,6 @@ proc rememberNimVersion(g: var DepGraph; q: VersionInterval) =
   let v = extractGeQuery(q)
   if v != Version"" and v > g.bestNimVersion: g.bestNimVersion = v
 
-proc extractRequiresInfo*(c: var AtlasContext; nimble: PackageNimble): NimbleFileInfo =
-  result = extractRequiresInfo(nimble.string)
-  when ProduceTest:
-    echo "nimble ", nimbleFile, " info ", result
-
 proc collectDeps*(
     c: var AtlasContext;
     g: var DepGraph,
@@ -65,7 +60,7 @@ proc collectDeps*(
 ): CfgPath =
   # If there is a .nimble file, return the dependency path & srcDir
   # else return "".
-  let nimbleInfo = extractRequiresInfo(c, dep.pkg.nimble)
+  let nimbleInfo = parseNimble(c, dep.pkg.nimble)
   if dep.self >= 0 and dep.self < g.nodes.len:
     g.nodes[dep.self].hasInstallHooks = nimbleInfo.hasInstallHooks
 

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -117,7 +117,8 @@ proc testSemVer2() =
   buildGraph()
   createDir "semproject"
   withDir "semproject":
-    let (outp, status) = execCmdEx(atlasExe & " --resolver=SemVer --colors:off --list use proj_a")
+    let cmd = atlasExe & " --full --resolver=SemVer --colors:off --list use proj_a"
+    let (outp, status) = execCmdEx(cmd)
     if status == 0:
       if outp.contains SemVerExpectedResult:
         discard "fine"
@@ -125,7 +126,12 @@ proc testSemVer2() =
         echo "expected ", SemVerExpectedResult, " but got ", outp
         raise newException(AssertionDefect, "Test failed!")
     else:
-      assert false, outp
+      echo "\n\n<<<<<<<<<<<<<<<< failed "
+      echo "testSemVer2:command: ", cmd
+      echo "testSemVer2:pwd: ", getCurrentDir()
+      echo "testSemVer2:failed command:\n", outp
+      echo ">>>>>>>>>>>>>>>> failed\n"
+      assert false, "testSemVer2"
 
 proc testMinVer() =
   buildGraph()


### PR DESCRIPTION
Changes:

- Add shallow cloning and fetching by default which speeds up cloning quite a bit (submodules are also shallow)
- Add `--full` option which will do a full clone and call `--unshallow` when needed on existing shallow clones
- Add "version" to lockfiles so `changed` can display versions diffs
- Change lockfiles to use `$deps/deps_path` or `$workspace/pkg` for dirs so that `atlas replay` works in scenarios where users have `depsDir` defined, otherwise lockfiles do weird things
- Change lockfile `nimCfg` and `nimble.contents` to use array of lines for better git diff's and ease of manual modifications / reviews (the previous format is automatically converted)
- `atlas replay --cfgHere` should actually work and not trample the commits by using the packages in the lockfile to create the `nim.cfg` with users local depsDirs

- Some logging fixes 

### Updated lockfile format example

```json
{
  "items": {
    "assume": {
      "dir": "$deps/assume",
      "url": "https://github.com/disruptek/assume",
      "commit": "ebed5f2b726134400a4aca489d39e54a2e6dcd95",
      "version": "0.7.2"
    },
    "pixie": {
      "dir": "$deps/pixie",
      "url": "https://github.com/treeform/pixie",
      "commit": "523b364fcaa288d23ecb3f34c795da97d3637117",
      "version": "5.0.6"
    },
  },
  "nimcfg": [],
  "nimbleFile": {
    "filename": "figuro.nimble",
    "content": [
      "version       = \"0.6.0\"",
      "author        = \"Jaremy Creechley\"",
      "description   = \"UI Engine for Nim\"",
      "license       = \"MIT\"",
      "srcDir        = \".\"",
      "",
      "# Dependencies",
      "",
      "requires \"nim >= 1.6.5\"",
      "requires \"pixie >= 5.0.1\"",
      ""
    ]
  },
  "hostOS": "macosx",
  "hostCPU": "arm64",
  "nimVersion": "2.0.0 a488067a4130f029000be4550a0fb1b39e0e9e7c",
  "gccVersion": "",
  "clangVersion": ""
}                                                                                          
```

