### PR TITLE
Move `packages` to `depsDir` from workspace root

### DIFF
--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -639,7 +639,7 @@ proc main(c: var AtlasContext) =
   of "search", "list":
     if c.workspace.len != 0:
       updatePackages(c)
-      let pkgInfos = getPackageInfos(c.workspace)
+      let pkgInfos = getPackageInfos(c.depsDir)
       search c, pkgInfos, args
     else:
       search c, @[], args

--- a/src/lockfiles.nim
+++ b/src/lockfiles.nim
@@ -37,7 +37,7 @@ proc convertKeyToArray(jsonTree: var JsonNode, path: varargs[string]) =
       parent = content
       content = parent[key]
     else:
-      return 
+      return
 
   if content.kind == JString:
     var contents = newJArray()
@@ -89,7 +89,7 @@ proc genLockEntry(c: var AtlasContext; lf: var LockFile; pkg: Package) =
 proc genLockEntriesForDir(c: var AtlasContext; lf: var LockFile; dir: string) =
   for k, f in walkDir(dir):
     if k == pcDir and dirExists(f / ".git"):
-      if f.absolutePath == c.workspace / "packages":
+      if f.absolutePath == c.depsDir / "packages":
         # skipping this gives us the locking behavior for a project
         # TODO: is this what we want?
         # we could just create a fake Package item here
@@ -171,7 +171,7 @@ proc pinWorkspace*(c: var AtlasContext; lockFilePath: string) =
   write lf, lockFilePath
 
 proc pinProject*(c: var AtlasContext; lockFilePath: string, exportNimble = false) =
-  ## Pin project using deps starting from the current project directory. 
+  ## Pin project using deps starting from the current project directory.
   ##
   info c, toRepo("pin"), "pinning project"
   var lf = newLockFile()
@@ -242,7 +242,7 @@ proc compareVersion(c: var AtlasContext; key, wanted, got: string) =
 
 proc convertNimbleLock*(c: var AtlasContext; nimblePath: string): LockFile =
   ## converts nimble lock file into a Atlas lockfile
-  ## 
+  ##
   let jsonAsStr = readFile(nimblePath)
   let jsonTree = parseJson(jsonAsStr)
 
@@ -274,10 +274,10 @@ proc convertAndSaveNimbleLock*(c: var AtlasContext; nimblePath, lockFilePath: st
 
 proc listChanged*(c: var AtlasContext; lockFilePath: string) =
   ## replays the given lockfile by cloning and updating all the deps
-  ## 
+  ##
   ## this also includes updating the nim.cfg and nimble file as well
   ## if they're included in the lockfile
-  ## 
+  ##
   let lf = if lockFilePath == "nimble.lock": convertNimbleLock(c, lockFilePath)
            else: readLockFile(lockFilePath)
 
@@ -295,7 +295,7 @@ proc listChanged*(c: var AtlasContext; lockFilePath: string) =
         warn c, toRepo(v.dir), "remote URL has been changed;" &
                                   " found: " & url &
                                   " lockfile has: " & v.url
-      
+
       let commit = gitops.getCurrentCommit()
       if commit != v.commit:
         let pkg = c.resolvePackage("file://" & dir)
@@ -314,10 +314,10 @@ proc listChanged*(c: var AtlasContext; lockFilePath: string) =
 
 proc replay*(c: var AtlasContext; lockFilePath: string) =
   ## replays the given lockfile by cloning and updating all the deps
-  ## 
+  ##
   ## this also includes updating the nim.cfg and nimble file as well
   ## if they're included in the lockfile
-  ## 
+  ##
   let lf = if lockFilePath == "nimble.lock": convertNimbleLock(c, lockFilePath)
            else: readLockFile(lockFilePath)
 
@@ -334,7 +334,7 @@ proc replay*(c: var AtlasContext; lockFilePath: string) =
   if lf.nimbleFile.filename.len > 0:
     writeFile(lfBase / lf.nimbleFile.filename,
               lf.nimbleFile.content.join("\n"))
-  
+
   # update the the dependencies
   var paths: seq[CfgPath]
   for _, v in pairs(lf.items):

--- a/src/nameresolver.nim
+++ b/src/nameresolver.nim
@@ -78,22 +78,22 @@ proc cloneUrl*(c: var AtlasContext;
       echo "cloned ", url, " into ", dest
 
 proc updatePackages*(c: var AtlasContext) =
-  if dirExists(c.workspace / DefaultPackagesDir):
-    withDir(c, c.workspace / DefaultPackagesDir):
-      gitPull(c, PackageRepo DefaultPackagesDir)
+  if dirExists(c.depsDir / DefaultPackagesSubDir):
+    withDir(c, c.depsDir / DefaultPackagesSubDir):
+      gitPull(c, PackageRepo DefaultPackagesSubDir)
   else:
-    withDir c, c.workspace:
-      let (status, err) = cloneUrl(c, getUrl "https://github.com/nim-lang/packages", DefaultPackagesDir, false)
+    withDir c, c.depsDir:
+      let (status, err) = cloneUrl(c, getUrl "https://github.com/nim-lang/packages", DefaultPackagesSubDir, false)
       if status != Ok:
-        error c, PackageRepo(DefaultPackagesDir), err
+        error c, PackageRepo(DefaultPackagesSubDir), err
 
 proc fillPackageLookupTable(c: var AtlasContext) =
   if not c.hasPackageList:
     c.hasPackageList = true
     when not MockupRun:
-      if not fileExists(c.workspace / DefaultPackagesDir / "packages.json"):
+      if not fileExists(c.depsDir / DefaultPackagesSubDir / "packages.json"):
         updatePackages(c)
-    let plist = getPackageInfos(when MockupRun: TestsDir else: c.workspace)
+    let plist = getPackageInfos(when MockupRun: TestsDir else: c.depsDir)
     debug c, toRepo("fillPackageLookupTable"), "initializing..."
     for entry in plist:
       let url = getUrl(entry.url)
@@ -105,11 +105,11 @@ proc fillPackageLookupTable(c: var AtlasContext) =
 proc dependencyDir*(c: var AtlasContext; pkg: Package): PackageDir =
   template checkDir(dir: string) =
     if dir.len() > 0 and dirExists(dir):
-      debug c, pkg, "dependencyDir: found: " & dir 
+      debug c, pkg, "dependencyDir: found: " & dir
       return PackageDir dir
     else:
-      debug c, pkg, "dependencyDir: not found: " & dir 
-  
+      debug c, pkg, "dependencyDir: not found: " & dir
+
   debug c, pkg, "dependencyDir: check: pth: " & pkg.path.string & " cd: " & getCurrentDir() & " ws: " & c.workspace
   if pkg.exists:
     debug c, pkg, "dependencyDir: exists: " & pkg.path.string
@@ -122,7 +122,7 @@ proc dependencyDir*(c: var AtlasContext; pkg: Package): PackageDir =
     checkDir pkg.path.string
     checkDir c.workspace / pkg.path.string
     checkDir c.depsDir / pkg.path.string
-  
+
   checkDir c.workspace / pkg.repo.string
   checkDir c.depsDir / pkg.repo.string
   checkDir c.workspace / pkg.name.string
@@ -157,7 +157,7 @@ proc resolvePackageUrl(c: var AtlasContext; url: string, checkOverrides = true):
   result = Package(url: getUrl(url),
                    name: url.toRepo().PackageName,
                    repo: url.toRepo())
-  
+
   debug c, result, "resolvePackageUrl: search: " & url
 
   let isFile = result.url.scheme == "file"
@@ -184,7 +184,7 @@ proc resolvePackageUrl(c: var AtlasContext; url: string, checkOverrides = true):
       let host = purl.hostname
       let org = purl.path.parentDir.lastPathPart
       let rname = purl.path.lastPathPart
-      let pname = [rname, org, host].join(".") 
+      let pname = [rname, org, host].join(".")
       warn c, result,
               "conflicting url's for package; renaming package: " &
                 result.name.string & " to " & pname
@@ -200,7 +200,7 @@ proc resolvePackageUrl(c: var AtlasContext; url: string, checkOverrides = true):
     # set the url with package name as url name
     c.urlMapping["repo:" & result.name.string] = result
     trace c, result, "resolvePackageUrl: not found; set pkg: " & $result.repo.string
-  
+
   if result.url.scheme == "file":
     result.path = PackageDir result.url.hostname & result.url.path
     trace c, result, "resolvePackageUrl: setting manual path: " & $result.path.string
@@ -208,7 +208,7 @@ proc resolvePackageUrl(c: var AtlasContext; url: string, checkOverrides = true):
 proc resolvePackageName(c: var AtlasContext; name: string): Package =
   result = Package(name: PackageName name,
                    repo: PackageRepo name)
-                   
+
   # the project name can be overwritten too!
   if UsesOverrides in c.flags:
     let name = c.overrides.substitute(name)
@@ -249,11 +249,11 @@ proc resolvePackage*(c: var AtlasContext; rawHandle: string): Package =
   ## Takes a raw handle which can be a name, a repo name, or a url
   ## and resolves it into a package. If not found it will create
   ## a new one.
-  ## 
+  ##
   ## Note that Package should be unique globally. This happens
   ## by updating the packages list when new packages are added or
   ## loaded from a packages.json.
-  ## 
+  ##
   result.new()
 
   fillPackageLookupTable(c)
@@ -264,7 +264,7 @@ proc resolvePackage*(c: var AtlasContext; rawHandle: string): Package =
     result = c.resolvePackageUrl(rawHandle)
   else:
     result = c.resolvePackageName(unicode.toLower(rawHandle))
-  
+
   result.path = dependencyDir(c, result)
   let res = c.findNimbleFile(result, result.path)
   if res.isSome:
@@ -276,13 +276,13 @@ proc resolvePackage*(c: var AtlasContext; rawHandle: string): Package =
     debug c, result, "resolvePackageName: nimble: found: " & $result
   else:
     debug c, result, "resolvePackageName: nimble: not found: " & $result
-  
+
 
 proc resolveNimble*(c: var AtlasContext; pkg: Package) =
   ## Try to resolve the nimble file for the given package.
-  ## 
-  ## This should be done after cloning a new repo. 
-  ## 
+  ##
+  ## This should be done after cloning a new repo.
+  ##
 
   if pkg.exists:
     return
@@ -297,4 +297,3 @@ proc resolveNimble*(c: var AtlasContext; pkg: Package) =
     info c, pkg, "resolvePackageName: nimble: found: " & $pkg
   else:
     info c, pkg, "resolvePackageName: nimble: not found: " & $pkg
-

--- a/src/packagesjson.nim
+++ b/src/packagesjson.nim
@@ -54,13 +54,13 @@ proc fromJson*(obj: JSonNode): PackageInfo =
   result.description = obj.requiredField("description")
   result.web = obj.optionalField("web")
 
-const DefaultPackagesDir* = "packages"
+const DefaultPackagesSubDir* = "packages"
 
-proc getPackageInfos*(workspaceDir: string): seq[PackageInfo] =
+proc getPackageInfos*(depsDir: string): seq[PackageInfo] =
   result = @[]
   var uniqueNames = initHashSet[string]()
   var jsonFiles = 0
-  for kind, path in walkDir(workspaceDir / DefaultPackagesDir):
+  for kind, path in walkDir(depsDir / DefaultPackagesSubDir):
     if kind == pcFile and path.endsWith(".json"):
       inc jsonFiles
       let packages = json.parseFile(path)
@@ -113,7 +113,7 @@ proc singleGithubSearch(c: var AtlasContext, term: string, fullSearch = false): 
           if langs.hasKey("Nim"):
             filtered.add item
         result = filtered
-      
+
       if result.len() == 0:
         if not fullSearch:
           trace c, toRepo("github search"), "no results found by Github quick search; doing full search"

--- a/tests/unittests.nim
+++ b/tests/unittests.nim
@@ -28,6 +28,7 @@ let
 
 proc initBasicWorkspace(typ: type AtlasContext): AtlasContext =
   result.workspace = currentSourcePath().parentDir / "ws_basic"
+  result.depsDir = result.workspace
 
 suite "urls and naming":
 


### PR DESCRIPTION
This allows moving all the dependencies to a location outside of the workspace, so that it contains only user files and atlas configuration.

FR/TODO: make the `packages` directory configurable