### PR TITLE
`detectWorkspace` now returns the first ws-subdir

### DIFF
--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -427,7 +427,7 @@ proc detectWorkspace(currentDir: string): string =
   # alternatively check for "sub-directory" workspace
   for kind, file in walkDir(currentDir):
     if kind == pcDir and fileExists(file / AtlasWorkspace):
-      result = file
+      return file
 
 proc autoWorkspace(currentDir: string): string =
   result = currentDir


### PR DESCRIPTION
While falling back to traversing subdirectories, `detectWorkspace` now returns immediately when a workspace is found.

Why does atlas look there anyway? It was a bit confusing when I tried to `atlas use` outside my workspace and it worked.
Outputting `(.)` in info for a workspace path doesn't help.