### PR TITLE
CLI syntax unified; `testdata` include moved

### DIFF
--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -30,14 +30,15 @@ Command:
     --deps=DIR          use DIR as the directory for dependencies
                         (default: store directly in the workspace)
 
-  use url|pkgname       clone a package and all of its dependencies and make
+  use <url|pkgname>     clone a package and all of its dependencies and make
                         it importable for the current project
-  clone url|pkgname     clone a package and all of its dependencies
-  update url|pkgname    update a package and all of its dependencies
-  install proj.nimble   use the .nimble file to setup the project's dependencies
+  clone <url|pkgname>   clone a package and all of its dependencies
+  update <url|pkgname>  update a package and all of its dependencies
+  install <proj.nimble> use the .nimble file to setup the project's dependencies
   new <project>         init a new project directory
-  search keyw keywB...  search for package that contains the given keywords
-  extract file.nimble   extract the requirements and custom commands from
+  search <keyA> [keyB ...]
+                        search for package that contains the given keywords
+  extract <file.nimble> extract the requirements and custom commands from
                         the given Nimble file
   updateProjects [filter]
                         update every project that has a remote
@@ -77,10 +78,10 @@ Options:
   --showGraph           show the dependency graph
   --list                list all available and installed versions
   --version             show the version
-  --verbosity:normal|trace|debug
+  --verbosity=normal|trace|debug
                         set verbosity level to normal, trace, debug
-  --help                show this help
   --global              use global workspace in ~/.atlas
+  --help                show this help
 """
 
 proc writeHelp() =
@@ -92,9 +93,6 @@ proc writeVersion() =
   stdout.write(AtlasVersion & "\n")
   stdout.flushFile()
   quit(0)
-
-
-include testdata
 
 proc tag(c: var AtlasContext; tag: string) =
   gitTag(c, tag)

--- a/src/gitops.nim
+++ b/src/gitops.nim
@@ -42,6 +42,8 @@ proc extractVersion*(s: string): string =
   while i < s.len and s[i] notin {'0'..'9'}: inc i
   result = s.substr(i)
 
+include testdata # used in `exec` testing
+
 proc exec*(c: var AtlasContext;
            cmd: Command;
            args: openArray[string],


### PR DESCRIPTION
- CLI syntax unified per a mix of man/GNU/IBM command syntax guides.
- `include testdata` moved to gitops immediately prior to the `exec` - the only place that uses the consts.

I'm a bit confused as to how the `TestData` const is used. It lives only inside the `when MockupRun` which is, in turn, set by `atlasTests` define, which I don't see being set anywhere. Shouldn't `nim test` task set this define?