### PR TITLE
fix nimble install and lock replays

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,3 +132,7 @@ jobs:
         run: |
           cd atlas
           nim c -r tests/tester.nim
+
+      - name: Test install with Nimble
+        run: |
+          nimble install -y

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,4 @@ jobs:
       - name: Test install with Nimble
         run: |
           cd atlas
-          pwd
-          find .
           nimble install -y

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,4 +135,6 @@ jobs:
 
       - name: Test install with Nimble
         run: |
+          cd ../
+          find .
           nimble install -y

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,7 @@ jobs:
 
       - name: Test install with Nimble
         run: |
-          cd ../
+          cd atlas
+          pwd
           find .
           nimble install -y

--- a/atlas.nimble
+++ b/atlas.nimble
@@ -1,6 +1,5 @@
 # Package
-include src/pkgversion
-version = AtlasVersion
+version = "0.6.3"
 author = "Araq"
 description = "Atlas is a simple package cloner tool. It manages an isolated workspace."
 license = "MIT"

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -24,7 +24,7 @@ const
         if line.startsWith("version ="):
           ver = line.split("=")[1].replace("\"", "").replace(" ", "")
       assert ver != ""
-      ver
+      ver & " (sha: " & staticExec("git log -n 1 --format=%H") & ")"
 
 const
   LockFileName = "atlas.lock"
@@ -99,7 +99,7 @@ proc writeHelp() =
   quit(0)
 
 proc writeVersion() =
-  stdout.write(AtlasVersion & "\n")
+  stdout.write("version: " & AtlasVersion & "\n")
   stdout.flushFile()
   quit(0)
 

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -17,7 +17,16 @@ import context, runners, osutils, packagesjson, sat, gitops, nimenv, lockfiles,
 export osutils, context
 
 const
-  AtlasVersion = block: (include pkgversion; AtlasVersion)
+  AtlasVersion =
+    block:
+      var ver = ""
+      for line in staticRead("../atlas.nimble").splitLines():
+        if line.startsWith("version ="):
+          ver = line.split("=")[1].replace(" ", "")
+      assert ver != ""
+      ver
+
+const
   LockFileName = "atlas.lock"
   NimbleLockFileName = "nimble.lock"
   Usage = "atlas - Nim Package Cloner Version " & AtlasVersion & """

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -616,7 +616,7 @@ proc main(c: var AtlasContext) =
         c.workspace = detectWorkspace(c.currentDir)
       if c.workspace.len > 0:
         readConfig c
-        info c, toRepo(c.workspace.readableFile), "is the current workspace"
+        info c, toRepo(c.workspace.absolutePath), "is the current workspace"
       elif autoinit:
         c.workspace = autoWorkspace(c.currentDir)
         createWorkspaceIn c

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -22,7 +22,7 @@ const
       var ver = ""
       for line in staticRead("../atlas.nimble").splitLines():
         if line.startsWith("version ="):
-          ver = line.split("=")[1].replace(" ", "")
+          ver = line.split("=")[1].replace("\"", "").replace(" ", "")
       assert ver != ""
       ver
 

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -87,6 +87,7 @@ Options:
   --showGraph           show the dependency graph
   --list                list all available and installed versions
   --version             show the version
+  --ignoreUrls          don't error on mismatching urls
   --verbosity=normal|trace|debug
                         set verbosity level to normal, trace, debug
   --global              use global workspace in ~/.atlas
@@ -576,6 +577,7 @@ proc main(c: var AtlasContext) =
       of "full": c.flags.incl FullClones
       of "autoinit": autoinit = true
       of "showgraph": c.flags.incl ShowGraph
+      of "ignoreurls": c.flags.incl IgnoreUrls
       of "keep": c.flags.incl Keep
       of "autoenv": c.flags.incl AutoEnv
       of "noexec": c.flags.incl NoExec

--- a/src/context.nim
+++ b/src/context.nim
@@ -176,7 +176,9 @@ proc writeMessage(c: var AtlasContext; k: MsgKind; p: PackageRepo; arg: string) 
     writeMessage(c, $k, p, arg)
   else:
     let pn =
-      if c.depsDir != "" and p.string.isRelativeTo(c.depsDir):
+      if p.string == c.workspace:
+        p.string.absolutePath
+      elif c.depsDir != "" and p.string.isRelativeTo(c.depsDir):
         p.string.relativePath(c.depsDir)
       elif p.string.isRelativeTo(c.workspace):
         p.string.relativePath(c.workspace)

--- a/src/context.nim
+++ b/src/context.nim
@@ -90,6 +90,7 @@ type
     GlobalWorkspace
     AssertOnError
     FullClones
+    IgnoreUrls
 
   MsgKind = enum
     Info = "[Info] ",

--- a/src/lockfiles.nim
+++ b/src/lockfiles.nim
@@ -80,7 +80,7 @@ proc fromPrefixedPath*(c: var AtlasContext, path: string): string =
 
 proc genLockEntry(c: var AtlasContext; lf: var LockFile; pkg: Package) =
   let info = extractRequiresInfo(pkg.nimble.string)
-  let url = getRemoteUrl()
+  let url = $pkg.url
   let commit = getCurrentCommit()
   let name = pkg.name.string
   let pth = c.prefixedPath(pkg.path.string)
@@ -348,7 +348,11 @@ proc replay*(c: var AtlasContext; lockFilePath: string) =
     withDir c, dir:
       let url = $getRemoteUrl()
       if $v.url.getUrl() != url:
-        error c, toRepo(v.dir), "remote URL has been compromised: got: " &
+        if IgnoreUrls in c.flags:
+          warn c, toRepo(v.dir), "remote URL differs from expected: got: " &
+            url & " but expected: " & v.url
+        else:
+          error c, toRepo(v.dir), "remote URL has been compromised: got: " &
             url & " but wanted: " & v.url
       checkoutGitCommit(c, dir.PackageDir, v.commit)
 

--- a/src/lockfiles.nim
+++ b/src/lockfiles.nim
@@ -134,7 +134,6 @@ proc genLockEntry(c: var AtlasContext;
                   cfg: CfgPath,
                   deps: HashSet[PackageName]) =
   let info = extractRequiresInfo(pkg.nimble.string)
-  let url = getRemoteUrl()
   let commit = getCurrentCommit()
   let name = pkg.name.string
   infoNow c, pkg, "calculating nimble checksum"
@@ -142,7 +141,7 @@ proc genLockEntry(c: var AtlasContext;
   lf.packages[name] = NimbleLockFileEntry(
     version: info.version,
     vcsRevision: commit,
-    url: $url,
+    url: $pkg.url,
     downloadMethod: "git",
     dependencies: deps.mapIt(it.string),
     checksums: {"sha1": chk}.toTable

--- a/src/pkgversion.nim
+++ b/src/pkgversion.nim
@@ -1,1 +1,0 @@
-const AtlasVersion = "0.6.3"


### PR DESCRIPTION
Fixes installing Atlas using Nimble.

Testing by manually running `nimble install https://github.com/elcritch/atlas@\#fix-nimble-install`.

Note if you tried to install the previous version it can Corrupt the Nimble pkgs. In that case you need to do a `rm -Rf ~/.nimble/pkgs/atlas* ~/.nimble/pkgs2/atals*` to remove the old ones.

Also includes fixes for:
- adds test for installing with Nimble
- getting correct URL for repos with alternate URLs (e.g. `windy.elcritch.github.com`)
- fix `[Info] (/Users/jaremycreechley/projs/nims/figuro/vendor) is the current workspace` to log with absolute path
- add `--ignoreUrls` to ignore mismatch URLs when using `replay`

