### PR TITLE
Make 'atlas install myfile.nimble' work

### DIFF
--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -211,7 +211,9 @@ proc traverse(c: var AtlasContext; nc: var NimbleContext; start: string): seq[Cf
 proc installDependencies(c: var AtlasContext; nc: var NimbleContext; nimbleFile: string) =
   # 1. find .nimble file in CWD
   # 2. install deps from .nimble
-  let (dir, pkgname, _) = splitFile(nimbleFile)
+  var (dir, pkgname, _) = splitFile(nimbleFile)
+  if dir == "":
+    dir = "."
   info c, pkgname, "installing dependencies for " & pkgname & ".nimble"
   var g = createGraph(c, createUrlSkipPatterns(dir))
   let paths = traverseLoop(c, nc, g)


### PR DESCRIPTION
When first trying out atlas on an existing project, I was confused why this didn't work:

```
atlas install myfile.nimble
```

Apparently it was expecting:

```
atlas install ./myfile.nimble
```

But the error didn't make that obvious. This change lets you specify the file without `./`