### PR TITLE
Run graffiti when atlas.nimble changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
 
       - name: Install graffiti
         run: |
-          nimble install -y https://github.com/beef331/graffiti.git
+          nimble install -y https://github.com/beef331/graffiti.git@\#d5a16033b84d223ec65da2a68f88607ca9ab61e9
 
       - name: Run graffiti
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
     name: 'Run graffiti on atlas.nimble changes'
     runs-on: ubuntu-latest
     needs: build
-    if: contains(github.event.head_commit.modified, 'atlas.nimble') || contains(github.event.head_commit.added, 'atlas.nimble')
+    if: github.ref == 'refs/heads/master' && (contains(github.event.head_commit.modified, 'atlas.nimble') || contains(github.event.head_commit.added, 'atlas.nimble'))
     env:
       NIM_BRANCH: devel
       NIM_ARCH: amd64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,3 +153,39 @@ jobs:
         run: |
           cd atlas
           nimble install -y
+
+  tag-version-bumps:
+    name: 'Run graffiti on atlas.nimble changes'
+    runs-on: ubuntu-latest
+    needs: build
+    if: contains(github.event.head_commit.modified, 'atlas.nimble') || contains(github.event.head_commit.added, 'atlas.nimble')
+    env:
+      NIM_BRANCH: devel
+      NIM_ARCH: amd64
+    steps:
+      - name: set `core.autocrlf` to false
+        run: |
+          git config --global core.autocrlf false
+          git config --global init.defaultBranch master
+          git config --global user.email "atlasbot@nimlang.com"
+          git config --global user.name "atlasbot"
+
+      - name: Checkout atlas
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Setup Nim
+        uses: alaviss/setup-nim@0.1.1
+        with:
+          path: 'nim'
+          version: ${{ env.NIM_BRANCH }}
+          architecture: ${{ env.NIM_ARCH }}
+
+      - name: Install graffiti
+        run: |
+          nimble install -y https://github.com/beef331/graffiti.git
+
+      - name: Run graffiti
+        run: |
+          graffiti atlas.nimble


### PR DESCRIPTION
This adds a job to the CI github action to run @beef331's `graffiti` on the master branch.

I'm not sure if this is a good idea, but it would be convenient.

- automatically adds tags for version bumps (e.g. less back and forth)
- make new versions installable by tags
- potential to merge a PR with a bad version bump, but accidental tags can be deleted
- pins to a specific graffiti git hash for sanity reasons

