### PR TITLE
improve `update` command

### DIFF
--- a/atlas.nimble
+++ b/atlas.nimble
@@ -1,5 +1,5 @@
 # Package
-version = "0.9.1"
+version = "0.9.2"
 author = "Araq"
 description = "Atlas is a simple package cloner tool. It manages an isolated project."
 license = "MIT"

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -305,7 +305,7 @@ proc listOutdated() =
   for pkg in allNodes(graph):
     if pkg.isRoot:
       continue
-    let res = gitops.isOutdated(pkg.ondisk)
+    let res = gitops.hasOutdatedTags(pkg.ondisk)
     if res.isNone:
       warn pkg.url.projectName, "no remote version tags found, updating origin instead"
       gitops.updateRepo(pkg.ondisk, onlyOrigin = false)
@@ -346,7 +346,7 @@ proc update(filter: string) =
       warn pkg.url.projectName, "filter not matched; skipping..."
       continue
 
-    let res = gitops.isOutdated(pkg.ondisk)
+    let res = gitops.hasOutdatedTags(pkg.ondisk)
     if res.isNone:
       warn pkg.url.projectName, "no remote version tags found, updating origin instead"
       gitops.updateRepo(pkg.ondisk, onlyOrigin = false)

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -343,11 +343,11 @@ proc update(filter: string) =
     let (outdated, cnt) = gitops.isOutdated(pkg.ondisk)
     if outdated and cnt > 0:
       warn pkg.url.projectName, "outdated, updating... " & $cnt & " new tags available"
-      gitops.updateRepo(pkg.ondisk)
+      gitops.updateRepo(pkg.ondisk, onlyOrigin = false)
       needsUpdate = true
     elif cnt == -1:
       warn pkg.url.projectName, "no local tags found, updating..."
-      gitops.updateRepo(pkg.ondisk)
+      gitops.updateRepo(pkg.ondisk, onlyOrigin = false)
       needsUpdate = true
     else:
       notice pkg.url.projectName, "up to date"

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -349,13 +349,13 @@ proc update(filter: string) =
     let res = gitops.hasOutdatedTags(pkg.ondisk)
     if res.isNone:
       warn pkg.url.projectName, "no remote version tags found, updating origin instead"
-      gitops.updateRepo(pkg.ondisk, onlyOrigin = false)
+      gitops.updateRepo(pkg.ondisk, onlyTags = false)
       needsUpdate = true
     else:
       let (outdated, cnt) = res.get()
       if outdated and cnt > 0:
         warn pkg.url.projectName, "outdated, updating... " & $cnt & " new tags available"
-        gitops.updateRepo(pkg.ondisk, onlyOrigin = true)
+        gitops.updateRepo(pkg.ondisk, onlyTags = true)
         needsUpdate = true
       else:
         notice pkg.url.projectName, "up to date"

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -307,8 +307,7 @@ proc listOutdated() =
       continue
     let res = gitops.hasOutdatedTags(pkg.ondisk)
     if res.isNone:
-      warn pkg.url.projectName, "no remote version tags found, updating origin instead"
-      gitops.updateRepo(pkg.ondisk, onlyOrigin = false)
+      warn pkg.url.projectName, "no remote version tags found"
       inc updateable
     else:
       let (outdated, cnt) = res.get()

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -332,12 +332,15 @@ proc update(filter: string) =
       continue
     
     let url = gitops.getRemoteUrl(pkg.ondisk)
+    if url.len == 0:
+      warn pkg.url.projectName, "no remote URL found; skipping..."
+      continue
     if url.len == 0 or filter notin url or filter notin pkg.url.projectName:
       warn pkg.url.projectName, "filter not matched; skipping..."
       continue
 
     if gitops.isOutdated(pkg.ondisk):
-      warn pkg.url.projectName, "is outdated, updating..."
+      warn pkg.url.projectName, "outdated or no local tags found, updating..."
       gitops.updateRepo(pkg.ondisk)
       needsUpdate = true
     else:

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -305,7 +305,7 @@ proc listOutdated() =
   for pkg in allNodes(graph):
     if pkg.isRoot:
       continue
-    let res = gitops.hasOutdatedTags(pkg.ondisk)
+    let res = gitops.hasNewTags(pkg.ondisk)
     if res.isNone:
       warn pkg.url.projectName, "no remote version tags found"
       inc updateable
@@ -345,7 +345,7 @@ proc update(filter: string) =
       warn pkg.url.projectName, "filter not matched; skipping..."
       continue
 
-    let res = gitops.hasOutdatedTags(pkg.ondisk)
+    let res = gitops.hasNewTags(pkg.ondisk)
     if res.isNone:
       warn pkg.url.projectName, "no remote version tags found, updating origin instead"
       gitops.updateRepo(pkg.ondisk, onlyTags = false)

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -46,13 +46,13 @@ Command:
   install               use the nimble file to setup the project's dependencies
   link <path>           link an existing project into the current project
                         to share its dependencies
-  update <url|pkgname>  update a package and all of its dependencies
+  update [filter]       update every dependency that matches the filter
+                        whether by name or URL. All dependencies are updated
+                        if no filter is given.
   search <keyA> [keyB ...]
                         search for package that contains the given keywords
   extract <file.nimble> extract the requirements and custom commands from
                         the given Nimble file
-  updateDeps [filter]   update every dependency that has a remote
-                        URL that matches `filter` if a filter is given
   tag [major|minor|patch]
                         add and push a new tag, input must be one of:
                         ['major'|'minor'|'patch'] or a SemVer tag like ['1.0.3']
@@ -314,8 +314,8 @@ proc listOutdated() =
   if updateable == 0:
     info project(), "all packages are up to date"
 
-proc updateWorkspace(filter: string) =
-  ## update the workspace
+proc update(filter: string) =
+  ## update the dependencies
   ##
   ## this will update the workspace by checking for outdated packages and
   ## updating them if they are outdated
@@ -333,7 +333,7 @@ proc updateWorkspace(filter: string) =
     
     let url = gitops.getRemoteUrl(pkg.ondisk)
     if url.len == 0 or filter notin url or filter notin pkg.url.projectName:
-      warn pkg.url.projectName, "not checking for updates"
+      warn pkg.url.projectName, "filter not matched; skipping..."
       continue
 
     if gitops.isOutdated(pkg.ondisk):
@@ -556,7 +556,7 @@ proc atlasRun*(params: seq[string]) =
     installDependencies(nc, nimbleFile)
 
   of "update":
-    updateWorkspace(if args.len == 0: "" else: args[0])
+    update(if args.len == 0: "" else: args[0])
 
   of "use":
     singleArg()

--- a/src/basic/gitops.nim
+++ b/src/basic/gitops.nim
@@ -15,7 +15,7 @@ type
     GitRemoteUrl = "git -C $DIR config --get remote.origin.url",
     GitDiff = "git -C $DIR diff",
     GitFetch = "git -C $DIR fetch",
-    GitFetchAll = "git -C $DIR fetch origin \"refs/heads/*:refs/heads/*\"",
+    GitFetchAll = "git -C $DIR fetch origin " & quoteShell("refs/heads/*:refs/heads/*") & " " & quoteShell("refs/tags/*:refs/tags/*"),
     GitTag = "git -C $DIR tag",
     GitTags = "git -C $DIR show-ref --tags",
     GitLastTaggedRef = "git -C $DIR rev-list --tags --max-count=1",
@@ -406,6 +406,7 @@ proc isOutdated*(path: Path): (bool, int) =
   return (false, 0)
 
 proc updateRepo*(path: Path, onlyOrigin = false) =
+  ## updates the repo by 
   let url = getRemoteUrl(path)
   if url.len == 0:
     info path, "no remote URL found; cannot update"

--- a/src/basic/gitops.nim
+++ b/src/basic/gitops.nim
@@ -15,7 +15,7 @@ type
     GitRemoteUrl = "git -C $DIR config --get remote.origin.url",
     GitDiff = "git -C $DIR diff",
     GitFetch = "git -C $DIR fetch",
-    GitFetchAll = "git -C $DIR fetch origin refs/heads/*:refs/heads/*",
+    GitFetchAll = "git -C $DIR fetch origin 'refs/heads/*:refs/heads/*'",
     GitTag = "git -C $DIR tag",
     GitTags = "git -C $DIR show-ref --tags",
     GitLastTaggedRef = "git -C $DIR rev-list --tags --max-count=1",
@@ -411,13 +411,15 @@ proc updateRepo*(path: Path, onlyOrigin = false) =
     info path, "no remote URL found; cannot update"
     return
 
-  # TODO: maybe use `git fetch origin refs/heads/*:refs/heads/*` instead?
-  let cmd = if onlyOrigin: GitFetch else: GitFetchAll
-  let (outp, status) = exec(cmd, path, ["--tags", "origin"])
+  let (outp, status) =
+    if onlyOrigin:
+      exec(GitFetch, path, ["--tags", "origin"])
+    else:
+      exec(GitFetchAll, path, [])
   if status != RES_OK:
     error(path, "could not update repo: " & outp)
   else:
-    info(path, "successfully updated repo")
+    notice(path, "successfully updated repo")
 
 proc updateDir*(path: Path, filter: string) =
   let (remote, _) = osproc.execCmdEx("git remote -v")

--- a/src/basic/gitops.nim
+++ b/src/basic/gitops.nim
@@ -414,7 +414,7 @@ proc updateRepo*(path: Path, onlyTags = false) =
     return
 
   let (outp, status) =
-    if onlyOrigin:
+    if onlyTags:
       exec(GitFetch, path, ["--tags", "origin"])
     else:
       exec(GitFetchAll, path, [])

--- a/src/basic/gitops.nim
+++ b/src/basic/gitops.nim
@@ -406,7 +406,7 @@ proc hasOutdatedTags*(path: Path): Option[tuple[outdated: bool, newTags: int]] =
 
   return some((false, 0))
 
-proc updateRepo*(path: Path, onlyOrigin = false) =
+proc updateRepo*(path: Path, onlyTags = false) =
   ## updates the repo by 
   let url = getRemoteUrl(path)
   if url.len == 0:

--- a/src/basic/gitops.nim
+++ b/src/basic/gitops.nim
@@ -15,7 +15,7 @@ type
     GitRemoteUrl = "git -C $DIR config --get remote.origin.url",
     GitDiff = "git -C $DIR diff",
     GitFetch = "git -C $DIR fetch",
-    GitFetchAll = "git -C $DIR fetch origin 'refs/heads/*:refs/heads/*'",
+    GitFetchAll = "git -C $DIR fetch origin \"refs/heads/*:refs/heads/*\"",
     GitTag = "git -C $DIR tag",
     GitTags = "git -C $DIR show-ref --tags",
     GitLastTaggedRef = "git -C $DIR rev-list --tags --max-count=1",

--- a/src/basic/gitops.nim
+++ b/src/basic/gitops.nim
@@ -420,20 +420,3 @@ proc updateRepo*(path: Path, onlyOrigin = false) =
     error(path, "could not update repo: " & outp)
   else:
     notice(path, "successfully updated repo")
-
-proc updateDir*(path: Path, filter: string) =
-  let (remote, _) = osproc.execCmdEx("git remote -v")
-  if filter.len == 0 or filter in remote:
-    let diff = checkGitDiffStatus(path)
-    if diff.len > 0:
-      warn($path, "has uncommitted changes; skipped")
-    else:
-      let (branch, _) = exec(GitCurrentBranch, path, [])
-      if branch.strip.len > 0:
-        let (output, exitCode) = osproc.execCmdEx("git pull origin " & branch.strip)
-        if exitCode != 0:
-          error $path, output
-        else:
-          info($path, "successfully updated")
-      else:
-        error $path, "could not fetch current branch name"

--- a/src/basic/gitops.nim
+++ b/src/basic/gitops.nim
@@ -377,7 +377,7 @@ proc getRemoteUrl*(path: Path): string =
   else:
     return cc.strip()
 
-proc hasOutdatedTags*(path: Path): Option[tuple[outdated: bool, newTags: int]] =
+proc hasNewTags*(path: Path): Option[tuple[outdated: bool, newTags: int]] =
   ## determine if the given git repo `f` is updateable
   ## returns an option tuple with the outdated flag and the number of new tags
   ## the option is none if the repo doesn't have remote url or remote tags

--- a/src/basic/gitops.nim
+++ b/src/basic/gitops.nim
@@ -377,7 +377,7 @@ proc getRemoteUrl*(path: Path): string =
   else:
     return cc.strip()
 
-proc isOutdated*(path: Path): Option[tuple[outdated: bool, newTags: int]] =
+proc hasOutdatedTags*(path: Path): Option[tuple[outdated: bool, newTags: int]] =
   ## determine if the given git repo `f` is updateable
   ## returns an option tuple with the outdated flag and the number of new tags
   ## the option is none if the repo doesn't have remote url or remote tags

--- a/tests/tgitops.nim
+++ b/tests/tgitops.nim
@@ -1,5 +1,5 @@
 import unittest
-import std/[os, files, dirs, paths, osproc, strutils, uri]
+import std/[os, files, dirs, paths, osproc, strutils, uri, options]
 import basic/[reporters, osutils, versions, context]
 
 import basic/gitops
@@ -138,11 +138,10 @@ suite "Git Operations Tests":
       discard execCmd("git commit -m \"update commit\"")
 
       # Test if repo is outdated
-      let (outdated, cnt) = isOutdated(Path ".")
+      let outdated = isOutdated(Path ".")
       # Note: This might fail in isolated test environments
       # We're mainly testing the function structure
-      check(not outdated)  # Expected to be false in test environment
-      check(cnt == -1)  # Expected to be false in test environment
+      check(outdated.isNone)  # Expected to be false in test environment
 
   test "getRemoteUrl functionality":
     withDir testDir:

--- a/tests/tgitops.nim
+++ b/tests/tgitops.nim
@@ -123,7 +123,7 @@ suite "Git Operations Tests":
       discard execCmd("git commit -m \"initial commit\"")
       check(incrementLastTag(Path ".", 0) == "v0.0.1")
 
-  test "isOutdated detection":
+  test "hasOutdatedTags detection":
     withDir testDir:
       discard execCmd("git init")
       # Create initial commit and tag
@@ -138,7 +138,7 @@ suite "Git Operations Tests":
       discard execCmd("git commit -m \"update commit\"")
 
       # Test if repo is outdated
-      let outdated = isOutdated(Path ".")
+      let outdated = hasOutdatedTags(Path ".")
       # Note: This might fail in isolated test environments
       # We're mainly testing the function structure
       check(outdated.isNone)  # Expected to be false in test environment

--- a/tests/tgitops.nim
+++ b/tests/tgitops.nim
@@ -123,7 +123,7 @@ suite "Git Operations Tests":
       discard execCmd("git commit -m \"initial commit\"")
       check(incrementLastTag(Path ".", 0) == "v0.0.1")
 
-  test "hasOutdatedTags detection":
+  test "hasNewTags detection":
     withDir testDir:
       discard execCmd("git init")
       # Create initial commit and tag
@@ -138,7 +138,7 @@ suite "Git Operations Tests":
       discard execCmd("git commit -m \"update commit\"")
 
       # Test if repo is outdated
-      let outdated = hasOutdatedTags(Path ".")
+      let outdated = hasNewTags(Path ".")
       # Note: This might fail in isolated test environments
       # We're mainly testing the function structure
       check(outdated.isNone)  # Expected to be false in test environment

--- a/tests/tgitops.nim
+++ b/tests/tgitops.nim
@@ -138,10 +138,11 @@ suite "Git Operations Tests":
       discard execCmd("git commit -m \"update commit\"")
 
       # Test if repo is outdated
-      let outdated = isOutdated(Path ".")
+      let (outdated, cnt) = isOutdated(Path ".")
       # Note: This might fail in isolated test environments
       # We're mainly testing the function structure
       check(not outdated)  # Expected to be false in test environment
+      check(cnt == -1)  # Expected to be false in test environment
 
   test "getRemoteUrl functionality":
     withDir testDir:


### PR DESCRIPTION
Previously update would only look for new tags. This breaks on repos not using tags for versioning. This PR improves it to first looks for tags, if none are found it will update the repo directly.

The repo update command has also been changed to `git fetch origin "refs/heads/*:refs/heads/*" "refs/tags/*:refs/tags/*"` which will update origin as well as try to update any local branches. This should improve workflows. I left an option to only update the origin refs in case it causes trouble or it's wanted. Currently it's not plumbed out. 

Finally, fixed the documentation. There's only `atlas update`.