### PR TITLE
Fix #head version not included bug

### DIFF
--- a/atlas.nimble
+++ b/atlas.nimble
@@ -1,5 +1,5 @@
 # Package
-version = "0.9.2"
+version = "0.9.3"
 author = "Araq"
 description = "Atlas is a simple package cloner tool. It manages an isolated project."
 license = "MIT"

--- a/src/basic/versions.nim
+++ b/src/basic/versions.nim
@@ -383,6 +383,10 @@ proc matches*(pattern: VersionInterval; x: VersionTag): bool =
   if pattern.isInterval:
     return matches(pattern.a, x.v) and matches(pattern.b, x.v)
 
+  # Special-case: query "#head" should match the repository tip.
+  if pattern.a.r == verEq and pattern.a.v.isHead:
+    return x.isTip
+
   if not result and pattern.a.r == verEq and pattern.a.v.isSpecial and pattern.a.v.string.len >= MinCommitLen:
     result = x.c.h.startsWith(pattern.a.v.string.substr(1))
   

--- a/src/depgraphs.nim
+++ b/src/depgraphs.nim
@@ -67,7 +67,7 @@ proc addVersionConstraints(b: var Builder; graph: var DepGraph, pkg: Package) =
 
       var hasCompatible = false
       for depVer, relVer in depNode.validVersions():
-        trace pkg.url.projectName, "checking dependnecy version:", $depVer, "query:", $query, "matches:", $query.matches(depVer)
+        trace pkg.url.projectName, "checking dependency version:", $depVer, "query:", $query, "matches:", $query.matches(depVer)
         if query.matches(depVer):
           hasCompatible = true
           trace pkg.url.projectName, "version matched requirements for the dependency version:", $depVer

--- a/tests/test_headtip.nim
+++ b/tests/test_headtip.nim
@@ -1,0 +1,23 @@
+import std/unittest
+import basic/versions
+
+template v(x): untyped = Version(x)
+
+proc p(s: string): VersionInterval =
+  var err = false
+  result = parseVersionInterval(s, 0, err)
+
+suite "#head matching against tip":
+  test "#head matches VersionTag at tip":
+    let interval = p"#head"
+    let commit = initCommitHash("88f634b9", FromGitTag)
+    var tag = VersionTag(c: commit, v: v"0.26.3")
+    tag.isTip = true
+    check interval.matches(tag) == true
+
+  test "#head does not match non-tip":
+    let interval = p"#head"
+    let commit = initCommitHash("88f634b9", FromGitTag)
+    let tag = VersionTag(c: commit, v: v"0.26.3")
+    check interval.matches(tag) == false
+


### PR DESCRIPTION
Fixes https://forum.nim-lang.org/t/13435

Note that httpbeast doesn't tag the last release 0.4.2. You need to include:

```
requires "httpbeast#head"
```
