### PR TITLE
Using error logging level causes atlas to return non-zero even if sat runs fine

### DIFF
--- a/src/dependencies.nim
+++ b/src/dependencies.nim
@@ -145,7 +145,7 @@ proc addRelease(
 
     result = true
   except CatchableError as e:
-    error pkg.url.projectName, "addRelease error processing nimble release:", $vtag, "error:", $e.msg
+    info pkg.url.projectName, "error processing nimble release:", $vtag, "error:", $e.msg
     return false
 
 proc traverseDependency*(


### PR DESCRIPTION
Small tweak but it's annoying and breaks scripts to return a non-zero code on a parse error