### PR TITLE
Specify binary directory and executable in atlas.nimble

### DIFF
--- a/atlas.nimble
+++ b/atlas.nimble
@@ -5,6 +5,7 @@ description = "Atlas is a simple package cloner tool. It manages an isolated pro
 license = "MIT"
 srcDir = "src"
 skipDirs = @["doc"]
+binDir = "bin"
 bin = @["atlas"]
 
 # Dependencies


### PR DESCRIPTION
Adds consistency for binary output between `nim build` via `config.nims` and `nimble build`.