### PR TITLE
Switch packages to github url

### DIFF
--- a/atlas.nimble
+++ b/atlas.nimble
@@ -1,5 +1,5 @@
 # Package
-version = "0.9.5"
+version = "0.9.6"
 author = "Araq"
 description = "Atlas is a simple package cloner tool. It manages an isolated project."
 license = "MIT"

--- a/config.nims
+++ b/config.nims
@@ -6,6 +6,7 @@ when defined(nimPreviewSlimSystem):
 --path:"$nim"
 --path:"../sat/src/"
 --nimcache:".nimcache"
+--d:ssl
 
 task build, "Build local atlas":
   exec "nim c -d:debug -o:bin/atlas src/atlas.nim"
@@ -14,6 +15,7 @@ task unitTests, "Runs unit tests":
   exec "nim c -d:debug -r tests/tbasics.nim"
   exec "nim c -d:debug -r tests/tserde.nim"
   exec "nim c -d:debug -r tests/tgitops.nim"
+  exec "nim c -d:debug -r tests/tpackageinfos.nim"
   exec "nim c -d:debug -r tests/tnimbleparser.nim"
   exec "nim c -d:debug -r tests/testtraverse.nim"
   exec "nim c -d:debug -r tests/testsemverUnit.nim"

--- a/doc/atlas.md
+++ b/doc/atlas.md
@@ -60,6 +60,8 @@ Atlas uses URLs internally; Nimble package names are translated to URLs
 via Nimble's  `packages.json` file. Atlas uses "shortnames" for known URLs from
 packages. Unofficial URLs, including forks, using a name triplet of the form
 `projectName.author.host`. For example Atlas would be `atlas.nim-lang.github.com`. Packages can be added using `nameOverrides` in `atlas.config` which adds a new name to URL mapping.
+Atlas downloads `packages.json` into `deps/_packages` by default; pass
+`--packagesGit` to keep the git-clone behavior for the full packages repo.
 
 Atlas does not call the Nim compiler for a build, instead it creates/patches
 a `nim.cfg` file for the compiler. For example:

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -81,6 +81,7 @@ Options:
                         which resolution algorithm to use, default is semver
   --proxy=url           use the given proxy URL for all git operations
   --dumbProxy           use a dumb proxy without smart git protocol
+  --packagesRepo        use the nim-lang/packages git repo (legacy behavior)
   --showGraph           show the dependency graph
   --list                list all available and installed versions
   --version             show the version
@@ -470,6 +471,8 @@ proc parseAtlasOptions(params: seq[string], action: var string, args: var seq[st
         context().proxy = val.parseUri()
       of "dumbproxy":
         context().flags.incl DumbProxy
+      of "packagesrepo":
+        context().flags.incl PackagesGit
       of "dumpgraphs":
         context().flags.incl DumpGraphs
       of "forcegittophps":

--- a/src/basic/context.nim
+++ b/src/basic/context.nim
@@ -40,6 +40,7 @@ type
     AutoEnv
     NoExec
     UpdateRepos
+    PackagesGit
     ListVersions
     ListVersionsOff
     GlobalWorkspace

--- a/tests/tpackageinfos.nim
+++ b/tests/tpackageinfos.nim
@@ -1,0 +1,15 @@
+import std/[unittest, os, times, files, paths]
+import basic/packageinfos
+
+suite "packages list":
+  test "updatePackages downloads packages.json":
+    let pkgsDir = Path(getTempDir()) / Path("atlas_pkgs_" & $int(epochTime()))
+    let pkgsFile = pkgsDir / Path"packages.json"
+    defer:
+      if fileExists($pkgsFile):
+        removeFile($pkgsFile)
+      if dirExists($pkgsDir):
+        removeDir($pkgsDir)
+    updatePackages(pkgsDir)
+    check fileExists($pkgsFile)
+    check getFileSize($pkgsFile) > 0


### PR DESCRIPTION
This switches to downloading the packages.json directly from GitHub. This saves ~5s and a bit of storage. This speeds up the tests a fair bit too. 

There's a fallback switch `--packagesGit` for cases where `-d:ssl` might break.