### PR TITLE
improve duplicate package handling

### DIFF
--- a/src/depgraphs.nim
+++ b/src/depgraphs.nim
@@ -455,6 +455,73 @@ proc toPretty*(v: uint64): string =
   elif v == IsInvalid: "!"
   else: ""
 
+proc chooseDuplicatePackage(graph: DepGraph; name: string; dupePkgs: seq[Package]): Package =
+  proc sortedFirst(pkgs: seq[Package]): Package =
+    if pkgs.len == 0:
+      return nil
+    var sortedPkgs = pkgs
+    sortedPkgs.sort(proc (a, b: Package): int = cmp(a.url.projectName, b.url.projectName))
+    sortedPkgs[0]
+
+  proc isRootRequested(url: PkgUrl): bool =
+    if graph.root.isNil:
+      return false
+
+    let rel = graph.root.activeNimbleRelease()
+    if rel.isNil:
+      return false
+
+    for (depUrl, _) in rel.requirements:
+      if depUrl == url:
+        return true
+
+    for feature in graph.root.activeFeatures:
+      if feature in rel.features:
+        for (depUrl, _) in rel.features[feature]:
+          if depUrl == url:
+            return true
+
+  var rootMatches: seq[Package]
+  var explicitRootMatches: seq[Package]
+  var explicitMatches: seq[Package]
+  var remoteIds: HashSet[string]
+  var allSameRemote = true
+
+  for pkg in dupePkgs:
+    if isRootRequested(pkg.url):
+      rootMatches.add pkg
+      if not pkg.url.hasShortName:
+        explicitRootMatches.add pkg
+
+    if not pkg.url.hasShortName:
+      explicitMatches.add pkg
+
+    if pkg.url.url.scheme in ["file", "link", "atlas", "error"]:
+      allSameRemote = false
+    else:
+      let remoteId = remoteNameFromGitUrl($pkg.url.url)
+      if remoteId.len == 0:
+        allSameRemote = false
+      else:
+        remoteIds.incl(remoteId)
+
+  if explicitRootMatches.len == 1:
+    return explicitRootMatches[0]
+  if rootMatches.len == 1:
+    return rootMatches[0]
+
+  if allSameRemote and remoteIds.len == 1:
+    result = sortedFirst(explicitRootMatches)
+    if not result.isNil:
+      return
+    result = sortedFirst(rootMatches)
+    if not result.isNil:
+      return
+    result = sortedFirst(explicitMatches)
+    if not result.isNil:
+      return
+    return sortedFirst(dupePkgs)
+
 proc checkDuplicateModules(graph: var DepGraph) =
   # Check for duplicate module names
   var moduleNames: Table[string, HashSet[Package]]
@@ -465,6 +532,16 @@ proc checkDuplicateModules(graph: var DepGraph) =
 
   var unhandledDuplicates: seq[string]
   for name, dupePkgs in moduleNames:
+    let dupeList = dupePkgs.toSeq()
+    let preferredPkg = chooseDuplicatePackage(graph, name, dupeList)
+    if not preferredPkg.isNil:
+      notice "atlas:resolved", "selecting duplicate package:", name, "with:", preferredPkg.url.projectName
+      for pkg in dupeList:
+        if pkg != preferredPkg:
+          notice "atlas:resolved", "deactivating duplicate package:", pkg.url.projectName
+          pkg.active = false
+      continue
+
     if not context().pkgOverrides.hasKey(name):
       error "atlas:resolved", "duplicate module name:", name, "with pkgs:", dupePkgs.mapIt(it.url.projectName).join(", ")
       notice "atlas:resolved", "please add an entry to `pkgOverrides` to the current project config to select one of: "

--- a/tests/testtraverse.nim
+++ b/tests/testtraverse.nim
@@ -531,10 +531,7 @@ suite "test forked dep selection":
     context().depsDir = Path "deps"
     setAtlasErrorsColor(fgMagenta)
 
-  test "does not activate official and fork together":
-    ## This test is expected to fail: Atlas currently treats fork and official
-    ## URLs as distinct packages, so it can mark both active even though they
-    ## map to the same shortName folder and should be switchable via git remotes.
+  test "prefers explicit root dependency over duplicate shortname":
     withDir "tests/ws_fork_dupe":
       removeDir("deps")
       project(paths.getCurrentDir())
@@ -544,20 +541,13 @@ suite "test forked dep selection":
       nc.put("asynctools", toPkgUriRaw(parseUri "https://example.com/cheatfate/asynctools", true))
 
       let dir = paths.getCurrentDir().absolutePath
-      var sawDuplicateError = false
-      var errorMsg = ""
-      try:
-        discard dir.loadWorkspace(nc, AllReleases, onClone=DoClone, doSolve=true)
-        checkpoint "expected duplicate module error when solving forked packages"
-        check false
-      except AtlasFatalError as e:
-        errorMsg = e.msg
-        sawDuplicateError = "duplicate module name" in e.msg
-        checkpoint "duplicate module error message: " & errorMsg
+      let graph = dir.loadWorkspace(nc, AllReleases, onClone=DoClone, doSolve=true)
+      let activePkgs = graph.pkgs.values().toSeq().filterIt(it.active and it.url.shortName() == "asynctools")
 
-      if not sawDuplicateError:
-        checkpoint "unexpected assertion error while testing forked dep selection: " & errorMsg
-      check sawDuplicateError
+      checkpoint "active duplicate candidates: " & activePkgs.mapIt(it.url.projectName).join(", ")
+      check activePkgs.len == 1
+      if activePkgs.len == 1:
+        check $activePkgs[0].url == "https://example.com/timotheecour/asynctools"
 
 infoNow "tester", "All tests run successfully"
 


### PR DESCRIPTION
Fix duplicate package resolution for explicit root URLs and shared remotes
  ## Summary

  This fixes duplicate-package errors introduced by lazy deps when Atlas sees the
  same module through both:

  - a short package name from the package DB, and
  - an explicit URL declared by the root package

  Atlas now prefers the root package’s explicit dependency URL. It also stops
  treating duplicates as an error when they resolve to the same git remote
  identity, while still preserving the existing error path for genuinely ambiguous
  duplicates.

  ## Changes

  - prefer an explicit root dependency when duplicate packages share the same
    module name
  - collapse duplicate packages automatically when they normalize to the same git
    remote
  - keep pkgOverrides / duplicate errors for cases that are still ambiguous
  - add a regression test covering the root-explicit-URL duplicate case

  ## Why

  After adding lazy deps, Atlas could end up activating both the short-name package
  and the explicit URL variant for the same module, then fail with a duplicate-
  module error. This was incorrect in cases where the root project had already made
  the selection explicitly, or where the duplicates were just different references
  to the same remote.

  ## Testing

  - nim c -r tests/testtraverse.nim
  - nim build

 
