### PR TITLE
Add support for shorthand syntax

### DIFF
--- a/doc/atlas.md
+++ b/doc/atlas.md
@@ -65,6 +65,33 @@ Atlas downloads `packages.json` into `deps/_packages` by default; pass
 If dependency URLs use `git://`, pass `--forceGitToHttps` to rewrite them to
 `https://` before cloning.
 
+In addition to full URLs and package names, Atlas supports a shorthand
+**forge alias** syntax of the form `<alias>:<user>/<repo>`. The supported
+aliases are:
+
+| Alias         | Expands to               |
+|---------------|--------------------------|
+| `gh` / `github`   | `https://github.com/<user>/<repo>`   |
+| `gl` / `gitlab`   | `https://gitlab.com/<user>/<repo>`   |
+| `srht` / `sourcehut` | `https://git.sr.ht/~<user>/<repo>` |
+| `cb` / `cberg` / `codeberg` | `https://codeberg.org/<user>/<repo>` |
+
+For example:
+
+```
+atlas use gh:zedeus/nitter
+atlas use gl:someuser/somepkg
+atlas use srht:~someuser/somepkg
+atlas use cb:someuser/somepkg
+```
+
+Forge aliases can also be used in Nimble `require` statements:
+
+```nim
+require "gh:user/repo"
+require "gl:user/repo >= 1.0"
+```
+
 Atlas does not call the Nim compiler for a build, instead it creates/patches
 a `nim.cfg` file for the compiler. For example:
 
@@ -89,9 +116,9 @@ version. Thanks to this design, lock files are much less important.
 Some commonly used commands:
 
 
-### Use <url> / <package name>
+### Use <url> / <package name> / <forge alias>
 
-Clone the package behind `url` or `package name` and its dependencies into
+Clone the package behind `url`, `package name`, or `forge alias` and its dependencies into
 the `deps` directory and make it available for your current project.
 Atlas will create or patch the files `$project.nimble` and `nim.cfg` for you so that you can simply
 import the required modules.
@@ -103,6 +130,8 @@ For example:
   cd newproject
   git init
   atlas use lexim
+  # or using a forge alias:
+  atlas use gh:zedeus/nitter
   # add `import lexim` to your example.nim file
   nim c example.nim
 

--- a/src/basic/pkgurls.nim
+++ b/src/basic/pkgurls.nim
@@ -6,7 +6,7 @@
 #    distribution, for details about the copyright.
 #
 
-import std / [hashes, uri, os, strutils, files, dirs, sequtils, pegs]
+import std / [hashes, uri, os, strutils, files, dirs, sequtils, pegs, tables]
 import gitops, reporters, context
 
 export uri
@@ -22,7 +22,51 @@ type
 
 proc isFileProtocol*(s: PkgUrl): bool = s.u.scheme == "file"
 proc isEmpty*(s: PkgUrl): bool = s.qualifiedName[0].len() == 0 or $s.u == ""
-proc isUrl*(s: string): bool = s.startsWith("git@") or "://" in s
+type
+  ForgeKind = enum
+    ForgeGitHub, ForgeGitLab, ForgeSourceHut, ForgeCodeberg
+
+const
+  forgePrefixes = {
+    "gh": ForgeGitHub, "github": ForgeGitHub,
+    "gl": ForgeGitLab, "gitlab": ForgeGitLab,
+    "srht": ForgeSourceHut, "sourcehut": ForgeSourceHut, "shart": ForgeSourceHut,
+    "cb": ForgeCodeberg, "cberg": ForgeCodeberg, "codeberg": ForgeCodeberg
+  }.toTable()
+
+proc isForgeAlias*(s: string): bool =
+  let colon = s.find(':')
+  if colon < 0: return false
+  if "://" in s: return false
+  let prefix = s.substr(0, colon - 1).toLowerAscii()
+  prefix in forgePrefixes
+
+proc expandForgeAlias*(s: string): string =
+  let colon = s.find(':')
+  doAssert colon >= 0
+  let prefix = s.substr(0, colon - 1).toLowerAscii()
+  let rest = s.substr(colon + 1)
+  let slash = rest.find('/')
+  if slash < 0:
+    raise newException(ValueError, "Invalid forge alias format, expected <alias>:<user>/<repo>: " & s)
+  let user = rest.substr(0, slash - 1)
+  let repo = rest.substr(slash + 1)
+  if user.len == 0 or repo.len == 0:
+    raise newException(ValueError, "Invalid forge alias format, expected <alias>:<user>/<repo>: " & s)
+  let kind = forgePrefixes.getOrDefault(prefix)
+  result = "https://"
+  case kind
+  of ForgeGitHub:
+    result &= "github.com/" & user & "/" & repo
+  of ForgeGitLab:
+    result &= "gitlab.com/" & user & "/" & repo
+  of ForgeSourceHut:
+    let tildeUser = if user.startsWith('~'): user else: '~' & user
+    result &= "git.sr.ht/" & tildeUser & "/" & repo
+  of ForgeCodeberg:
+    result &= "codeberg.org/" & user & "/" & repo
+
+proc isUrl*(s: string): bool = s.startsWith("git@") or "://" in s or isForgeAlias(s)
 
 proc fullName*(u: PkgUrl): string =
   if u.qualifiedName.host.len() > 0 or u.qualifiedName.user.len() > 0:  
@@ -186,7 +230,10 @@ proc createUrlSkipPatterns*(raw: string, skipDirTest = false, forceWindows: bool
 
     u.path = u.path.strip(leading=false, trailing=true, {'/'})
 
-  if not raw.isUrl():
+  if raw.isForgeAlias():
+    let expanded = expandForgeAlias(raw)
+    result = createUrlSkipPatterns(expanded, skipDirTest, forceWindows)
+  elif not raw.isUrl():
     if dirExists(raw) or skipDirTest:
       var raw: string = raw
       if isGitDir(raw):

--- a/tests/tbasics.nim
+++ b/tests/tbasics.nim
@@ -135,6 +135,56 @@ suite "urls and naming":
     check upkg.toDirectoryPath() == ws / Path"deps" / Path("knutella")
     check upkg.toLinkPath() == ws / Path"deps" / Path("knutella.nimble-link")
 
+  test "forge alias gh shorthand":
+    let upkg = nc.createUrl("gh:disruptek/balls")
+    check upkg.url.hostname == "github.com"
+    check $upkg.url == "https://github.com/disruptek/balls"
+    check $upkg.projectName == "balls.disruptek.github.com"
+    check upkg.toDirectoryPath() == ws / Path"deps" / Path("balls")
+    check upkg.toLinkPath() == ws / Path"deps" / Path("balls.nimble-link")
+
+  test "forge alias github long form":
+    let upkg = nc.createUrl("github:disruptek/balls")
+    check upkg.url.hostname == "github.com"
+    check $upkg.url == "https://github.com/disruptek/balls"
+    check $upkg.projectName == "balls.disruptek.github.com"
+
+  test "forge alias gitlab":
+    let upkg = nc.createUrl("gl:someuser/somepkg")
+    check upkg.url.hostname == "gitlab.com"
+    check $upkg.url == "https://gitlab.com/someuser/somepkg"
+    check $upkg.projectName == "somepkg.someuser.gitlab.com"
+
+  test "forge alias sourcehut":
+    let upkg = nc.createUrl("srht:~someuser/somepkg")
+    check upkg.url.hostname == "git.sr.ht"
+    check $upkg.url == "https://git.sr.ht/~someuser/somepkg"
+    check $upkg.projectName == "somepkg.~someuser.git.sr.ht"
+
+  test "forge alias sourcehut auto tilde":
+    let upkg = nc.createUrl("srht:someuser/somepkg")
+    check $upkg.url == "https://git.sr.ht/~someuser/somepkg"
+
+  test "forge alias codeberg":
+    let upkg = nc.createUrl("cb:someuser/somepkg")
+    check upkg.url.hostname == "codeberg.org"
+    check $upkg.url == "https://codeberg.org/someuser/somepkg"
+
+  test "forge alias isUrl":
+    check isForgeAlias("gh:user/repo")
+    check isForgeAlias("github:user/repo")
+    check isForgeAlias("gl:user/repo")
+    check isForgeAlias("srht:~user/repo")
+    check isForgeAlias("cb:user/repo")
+    check not isForgeAlias("notAForge:user/repo")
+    check pkgurls.isUrl("gh:user/repo")
+    check pkgurls.isUrl("https://github.com/user/repo")
+
+  test "forge alias extractRequirementName":
+    check extractRequirementName("gh:user/repo") == ("gh:user/repo", @[], 12)
+    check extractRequirementName("gh:user/repo >= 1.0") == ("gh:user/repo", @[], 12)
+    check extractRequirementName("github:user/repo") == ("github:user/repo", @[], 16)
+
   test "proj_a file url":
     let pth = "file://" & "." & DirSep & "buildGraph" & DirSep & "proj_a"
     echo "PATH: ", pth


### PR DESCRIPTION
Implements #198

Based on the original PR https://github.com/nim-lang/nimble/pull/1222.

Was able to successfully run `atlas add gh:ire4ever1190/scrolls` (tests both a direct package with forge synax, and a package that has a dependency with forge syntax)