### PR TITLE
Add CLI feature preservation and dependency checks

### DIFF
--- a/atlas.nimble
+++ b/atlas.nimble
@@ -1,5 +1,5 @@
 # Package
-version = "0.11.2"
+version = "0.11.3"
 author = "Araq"
 description = "Atlas is a simple package cloner tool. It manages an isolated project."
 license = "MIT"

--- a/doc/atlas.md
+++ b/doc/atlas.md
@@ -178,7 +178,9 @@ If a when statement isn't supported consider using `feature` statements instead.
 
 Features in Nimble files enable optional requirements for things different scenarios. This is useful when dealing with scenarios like testing only dependencies.
 
-*Note*: Currently features aren't saved to the Atlas config you must always pass `atlas --feature=foobar` when doing any command. This simplifies configuration and state management in Atlas. It only does what you ask it to do.
+*Note*: Features aren't saved to the Atlas config. Pass `atlas --feature=foobar`
+when doing commands that should enable a feature, or pass `--keepFeatures`/`-k`
+to reuse feature defines from the current `nim.cfg`.
 
 ```nim
 require "normallib"

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -240,8 +240,11 @@ proc linkPackage(linkDir, linkedNimble: Path) =
   var nc = createNimbleContext()
 
   let nimbleFile = findProjectNimbleFile(writeNimbleFile = true)
-  info "atlas:link", "modifying nimble file to use package:", linkUri.projectName, "at:", $nimbleFile
-  patchNimbleFile(nc, nimbleFile, linkUri.projectName)
+  if hasNimbleRequirement(nimbleFile, linkUri):
+    info "atlas:link", "nimble file already depends on package:", linkUri.projectName, "at:", $nimbleFile
+  else:
+    info "atlas:link", "modifying nimble file to use package:", linkUri.projectName, "at:", $nimbleFile
+    patchNimbleFile(nc, nimbleFile, linkUri.projectName)
 
   writeConfig()
   info "atlas:link", "current project dir:", $project()

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -70,6 +70,7 @@ Options:
   --feature=<feature>   enables the given feature, pass multiple for multiple features
                         for project specific use: `<project>.<feature>`
                         (note always be passed when you want to use features)
+  --keepFeatures, -k    reuse feature defines from the current nim.cfg
   --resolver=minver|semver|maxver
                         which resolution algorithm to use, default is semver
   --list[=on|off]       list all available and installed versions
@@ -378,6 +379,7 @@ proc parseAtlasOptions(params: seq[string], action: var string, args: var seq[st
       of "help", "h": writeHelp(0)
       of "version", "v": writeVersion()
       of "keepcommits": context().flags.incl KeepCommits
+      of "keepfeatures", "k": context().flags.incl KeepFeatures
       of "project", "p":
         context().flags.incl(ManualProjectArg)
         if val == ".":
@@ -476,6 +478,9 @@ proc parseAtlasOptions(params: seq[string], action: var string, args: var seq[st
 
   if action notin ["tag", "search", "list"]:
     createDir(depsDir())
+    if KeepFeatures in context().flags:
+      for feature in parseNimCfgFeatures(CfgPath project()):
+        context().features.incl feature
 
 proc atlasRun*(params: seq[string]) =
   var action = ""

--- a/src/basic/configutils.nim
+++ b/src/basic/configutils.nim
@@ -53,3 +53,22 @@ proc patchNimCfg*(deps: seq[CfgPath]; cfgPath: CfgPath; features: seq[string] = 
       # (preserves the file date information):
       writeFile($cfg, cfgContent)
       info(project(), "updated: " & $cfg.readableFile(project()))
+
+proc parseNimCfgFeatures*(cfgPath: CfgPath): seq[string] =
+  let cfg = Path(cfgPath.string / "nim.cfg")
+  if not fileExists(cfg):
+    return
+
+  for line in readFile($cfg).splitLines():
+    var x = line.strip()
+    if x.startsWith("--define:"):
+      x = x["--define:".len .. ^1].strip()
+    elif x.startsWith("-d:"):
+      x = x["-d:".len .. ^1].strip()
+    else:
+      continue
+
+    if x.len >= 2 and x[0] == '"' and x[^1] == '"':
+      x = x[1 .. ^2]
+    if x.startsWith("feature.") and x notin result:
+      result.add x.toLowerAscii()

--- a/src/basic/context.nim
+++ b/src/basic/context.nim
@@ -53,6 +53,7 @@ type
     DumbProxy
     ForceGitToHttps
     NoLazyDeps
+    KeepFeatures
     IncludeTagsAndNimbleCommits # include nimble commits and tags in the solver
     NimbleCommitsMax # takes the newest commit for each version
 

--- a/src/basic/nimbleparser.nim
+++ b/src/basic/nimbleparser.nim
@@ -73,6 +73,26 @@ proc parseNimbleFile*(nc: var NimbleContext;
 proc genRequiresLine(u: string): string =
   result = "requires \"$1\"\n" % u.escape("", "")
 
+proc hasNimbleRequirement*(nimbleFile: Path; url: PkgUrl): bool =
+  doAssert nimbleFile.string.fileExists()
+
+  let names = [
+    url.shortName().toLowerAscii(),
+    url.projectName().toLowerAscii(),
+    url.fullName().toLowerAscii(),
+    url.requiresName().toLowerAscii()
+  ]
+
+  for req in extractRequiresInfo(nimbleFile).requires:
+    let (name, _, _) = extractRequirementName(req)
+    if name.toLowerAscii() in names:
+      return true
+    if name.isUrl():
+      let reqUrl = createUrlSkipPatterns(name)
+      if reqUrl.shortName().toLowerAscii() == url.shortName().toLowerAscii() or
+          reqUrl.projectName().toLowerAscii() == url.projectName().toLowerAscii():
+        return true
+
 proc patchNimbleFile*(nc: var NimbleContext;
                       nimbleFile: Path, name: string) =
   var url = nc.createUrl(name)  # This will handle both name and URL overrides internally

--- a/src/basic/nimbleparser.nim
+++ b/src/basic/nimbleparser.nim
@@ -105,13 +105,9 @@ proc patchNimbleFile*(nc: var NimbleContext;
 
   doAssert nimbleFile.string.fileExists()
 
-  let release = parseNimbleFile(nc, nimbleFile)
-  # see if we have this requirement already listed. If so, do nothing:
-  for (dep, ver) in release.requirements:
-    debug nimbleFile, "checking if dep url:", $url, "matches:", $dep
-    if url == dep:
-      info(nimbleFile, "nimble file up to date")
-      return
+  if hasNimbleRequirement(nimbleFile, url):
+    info(nimbleFile, "nimble file up to date")
+    return
 
   let name = if url.hasShortName: url.shortName() else: $url.url
   debug nimbleFile, "patching nimble file using:", $name

--- a/src/basic/packageinfos.nim
+++ b/src/basic/packageinfos.nim
@@ -75,6 +75,9 @@ proc fromJson*(obj: JsonNode): PackageInfo =
 
 proc `$`*(pkg: PackageInfo): string =
   result = pkg.name & ":\n"
+  if pkg.kind == pkAlias:
+    result &= "  alias:       " & pkg.alias & "\n"
+    return
   result &= "  url:         " & pkg.url & " (" & pkg.downloadMethod & ")\n"
   result &= "  tags:        " & pkg.tags.join(", ") & "\n"
   result &= "  description: " & pkg.description & "\n"

--- a/src/dependencies.nim
+++ b/src/dependencies.nim
@@ -267,6 +267,15 @@ proc traverseDependency*(
           else:
             error pkg.url.projectName, "traverseDependency skipping nimble commit:", $tag, "uniqueCommits:", $(tag.c in uniqueCommits), "nimbleVersions:", $(tag.v in nimbleVersions)
 
+        if not currentCommit.isEmpty() and not uniqueCommits.containsOrIncl(currentCommit):
+          # Existing checkouts can be detached or on a non-default branch.
+          # Include their current nimble version when remote-tip traversal misses it.
+          var vers: seq[(PackageVersion, NimbleRelease)]
+          let currentTag = VersionTag(v: Version"", c: currentCommit)
+          let added = vers.addRelease(nc, pkg, currentTag, deferChildDeps)
+          if added and not nimbleVersions.containsOrIncl(vers[0][0].vtag.v):
+            versions.add(vers)
+
       if versions.len() == 0:
         let vtag = VersionTag(v: Version"#head", c: initCommitHash(currentCommit, FromHead))
         debug pkg.url.projectName, "traverseDependency no versions found, using default #head", "at", $pkg.ondisk

--- a/src/depgraphs.nim
+++ b/src/depgraphs.nim
@@ -55,6 +55,33 @@ proc addAtLeastOneOf(b: var Builder; vars: seq[VarId]) =
       for v in vars:
         b.add v
 
+proc addCompatibleVersionChoice(
+    b: var Builder;
+    compatibleVersions: seq[VarId];
+    featureVersions: Table[VarId, seq[VarId]]) =
+  template addCompatibleVersion(compatVer: VarId) =
+    block:
+      if featureVersions.hasKey(compatVer):
+        withOpenBr(b, AndForm):
+          b.add(compatVer)
+          for featureVer in featureVersions[compatVer]:
+            b.add(featureVer)
+      else:
+        b.add(compatVer)
+
+  if compatibleVersions.len == 0:
+    b.add falseLit()
+  elif compatibleVersions.len == 1:
+    addCompatibleVersion(compatibleVersions[0])
+  else:
+    withOpenBr(b, ExactlyOneOfForm):
+      for compatVer in compatibleVersions:
+        addCompatibleVersion(compatVer)
+
+proc addCompatibleVersionChoice(b: var Builder; compatibleVersions: seq[VarId]) =
+  var featureVersions: Table[VarId, seq[VarId]]
+  b.addCompatibleVersionChoice(compatibleVersions, featureVersions)
+
 proc hasContextFeature(pkg: Package; feature: string): bool =
   if pkg.isRoot and feature in context().features:
     return true
@@ -216,16 +243,7 @@ proc addVersionConstraints(b: var Builder; graph: var DepGraph, pkg: Package) =
       # Add implication: if this version is selected, one of its compatible deps must be selected
       withOpenBr(b, OrForm):
         b.addNegated(ver.vid)  # not this version
-        withOpenBr(b, OrForm):
-          for compatVer in compatibleVersions:
-            if featureVersions.hasKey(compatVer):
-              withOpenBr(b, AndForm):
-                debug pkg.url.projectName, "adding compatVer requirement:", $compatVer, "featureVersions:", $featureVersions[compatVer].mapIt($it).join(", ")
-                b.add(compatVer)
-                for featureVer in featureVersions[compatVer]:
-                  b.add(featureVer)
-            else:
-              b.add(compatVer)
+        b.addCompatibleVersionChoice(compatibleVersions, featureVersions)
 
     # Add implications for each feature requirement
     for feature, reqs in rel.features:
@@ -258,9 +276,7 @@ proc addVersionConstraints(b: var Builder; graph: var DepGraph, pkg: Package) =
 
         withOpenBr(b, OrForm):
           b.addNegated(featureVarId) # not this feature
-          withOpenBr(b, OrForm):
-            for compatVer in compatibleVersions:
-              b.add(compatVer)
+          b.addCompatibleVersionChoice(compatibleVersions)
           debug pkg.url.projectName, "added compatVer feature dep variables:", $compatibleVersions.mapIt($it).join(", ")
         
         # Add implictations for globally set features
@@ -277,16 +293,7 @@ proc addVersionConstraints(b: var Builder; graph: var DepGraph, pkg: Package) =
           if true:
             withOpenBr(b, OrForm):
               b.addNegated(ver.vid)  # not this version
-              withOpenBr(b, OrForm):
-                for compatVer in compatibleVersions:
-                  if featureVersions.hasKey(compatVer):
-                    withOpenBr(b, AndForm):
-                      debug pkg.url.projectName, "adding compatVer requirement:", $compatVer, "featureVersions:", $featureVersions[compatVer].mapIt($it).join(", ")
-                      b.add(compatVer)
-                      for featureVer in featureVersions[compatVer]:
-                        b.add(featureVer)
-                  else:
-                    b.add(compatVer)
+              b.addCompatibleVersionChoice(compatibleVersions, featureVersions)
 
   if not anyReleaseSatisfied:
     warn pkg.url.projectName, "no versions satisfied for this package:", $pkg.url

--- a/src/depgraphs.nim
+++ b/src/depgraphs.nim
@@ -48,9 +48,12 @@ proc addAtMostOneOf(b: var Builder; vars: seq[VarId]) =
         b.addNegated(vars[j])
 
 proc addAtLeastOneOf(b: var Builder; vars: seq[VarId]) =
-  withOpenBr(b, OrForm):
-    for v in vars:
-      b.add v
+  if vars.len == 1:
+    b.add vars[0]
+  else:
+    withOpenBr(b, OrForm):
+      for v in vars:
+        b.add v
 
 proc hasContextFeature(pkg: Package; feature: string): bool =
   if pkg.isRoot and feature in context().features:

--- a/src/pkgsearch.nim
+++ b/src/pkgsearch.nim
@@ -17,6 +17,8 @@ proc determineCandidates*(pkgList: seq[PackageInfo];
   result[1] = @[]
   result[2] = @[]
   for pkg in pkgList:
+    if pkg.kind != pkPackage:
+      continue
     block termLoop:
       for term in terms:
         let word = term.toLower
@@ -116,6 +118,8 @@ proc search*(pkgList: seq[PackageInfo]; terms: seq[string]) =
     break forPackage
 
   for pkg in pkgList:
+    if pkg.kind != pkPackage:
+      continue
     if terms.len > 0:
       block forPackage:
         for term in terms:

--- a/tests/texplicit_history_leak.nim
+++ b/tests/texplicit_history_leak.nim
@@ -1,6 +1,6 @@
 import std/[os, osproc, strutils, terminal, unittest]
 
-import basic/[compiledpatterns, context, deptypes, nimblecontext, pkgurls, reporters, versions]
+import basic/[compiledpatterns, context, deptypes, gitops, nimblecontext, pkgurls, reporters, versions]
 import dependencies
 import depgraphs
 import integration_test_utils
@@ -26,6 +26,14 @@ proc writePackage(name, version: string; requires: openArray[string] = []) =
 proc commitAll(msg: string) =
   exec("git add .")
   exec("git commit -m \"" & msg & "\"")
+
+proc addOrigin(url: string) =
+  exec("git remote add origin " & url)
+
+proc setRemoteTip(url, branch, commit: string) =
+  let remote = remoteNameFromGitUrl(url)
+  exec("git update-ref refs/remotes/" & remote & "/" & branch & " " & commit)
+  exec("git symbolic-ref refs/remotes/" & remote & "/HEAD refs/remotes/" & remote & "/" & branch)
 
 suite "historical explicit transitive pins":
   setup:
@@ -243,3 +251,101 @@ suite "historical explicit transitive pins":
           check $graph.pkgs[bearsslUrl].activeVersion.version == "0.2.8"
           check graph.pkgs[bearsslUrl].activeVersion.commit.h == newBearsslCommit
           check graph.pkgs[bearsslUrl].activeVersion.commit.h != oldBearsslCommit
+
+  test "latest sarcophagus resolves jwt from current non-default nim-jwt checkout":
+    let ws = "tests/ws_explicit_history_leak"
+    removeDir(ws)
+    createDir(ws)
+
+    withDir ws:
+      project(paths.getCurrentDir())
+      context().flags = {KeepWorkspace, ListVersions}
+      context().defaultAlgo = SemVer
+
+      createDir("deps")
+
+      let sarcophagusUrlString = "https://example.invalid/elcritch/sarcophagus"
+      let jwtUrlString = "https://example.invalid/yglukhov/nim-jwt"
+      let mummyUrlString = "https://example.invalid/guzba/mummy"
+
+      var latestJwtCommit = ""
+
+      withDir "deps":
+        createDir("mummy")
+        withDir "mummy":
+          writePackage("mummy", "1.0.0")
+          initGitRepo()
+          addOrigin(mummyUrlString)
+          commitAll("mummy")
+          let mummyCommit = gitHead()
+          setRemoteTip(mummyUrlString, "main", mummyCommit)
+
+        createDir("nim-jwt")
+        withDir "nim-jwt":
+          writePackage("jwt", "0.0.1")
+          initGitRepo()
+          addOrigin(jwtUrlString)
+          commitAll("jwt-old")
+
+          writePackage("jwt", "0.2")
+          commitAll("jwt-remote-tip")
+          let remoteTipCommit = gitHead()
+          setRemoteTip(jwtUrlString, "master", remoteTipCommit)
+
+          exec("git checkout -b tmp")
+          writePackage("jwt", "0.3")
+          commitAll("jwt-new")
+          latestJwtCommit = gitHead()
+
+        createDir("sarcophagus")
+        withDir "sarcophagus":
+          writePackage("sarcophagus", "0.4.0", [
+            "mummy",
+            jwtUrlString
+          ])
+          initGitRepo()
+          addOrigin(sarcophagusUrlString)
+          commitAll("sarcophagus-old-explicit-nim-jwt")
+
+          writePackage("sarcophagus", "0.6.3", [
+            "mummy",
+            "jwt >= 0.3"
+          ])
+          commitAll("sarcophagus-latest-bare-jwt")
+          let sarcophagusCommit = gitHead()
+          setRemoteTip(sarcophagusUrlString, "main", sarcophagusCommit)
+
+      writeFile("ws_explicit_history_leak.nimble", [
+        "version = \"0.1.0\"",
+        "requires \"" & sarcophagusUrlString & " >= 0.6.3\"",
+        ""
+      ].join("\n"))
+
+      var nc = createUnfilledNimbleContext()
+      discard nc.put("mummy", createUrlSkipPatterns(mummyUrlString))
+
+      var canonicalJwtUrl = createUrlSkipPatterns(jwtUrlString)
+      canonicalJwtUrl.hasShortName = true
+      canonicalJwtUrl.qualifiedName.name = "jwt"
+      discard nc.put("jwt", canonicalJwtUrl)
+
+      var graph = loadWorkspace(project(), nc, AllReleases, DoClone, doSolve = true)
+
+      checkpoint "\tgraph:\n" & $graph.toJson()
+
+      let sarcophagusUrl = nc.createUrl(sarcophagusUrlString)
+
+      check graph.root.active
+      check sarcophagusUrl in graph.pkgs
+      check canonicalJwtUrl in graph.pkgs
+
+      if sarcophagusUrl in graph.pkgs:
+        check graph.pkgs[sarcophagusUrl].active
+        if graph.pkgs[sarcophagusUrl].active:
+          check $graph.pkgs[sarcophagusUrl].activeNimbleRelease.version == "0.6.3"
+
+      if canonicalJwtUrl in graph.pkgs:
+        check graph.pkgs[canonicalJwtUrl].active
+        if graph.pkgs[canonicalJwtUrl].active:
+          check $graph.pkgs[canonicalJwtUrl].activeNimbleRelease.version == "0.3"
+          check graph.pkgs[canonicalJwtUrl].activeVersion.commit.h == latestJwtCommit

--- a/tests/tfeatures.nim
+++ b/tests/tfeatures.nim
@@ -4,6 +4,7 @@ import std / [strutils, os, uri, jsonutils, json, tables, sequtils, sets, unitte
 import std/terminal
 
 import basic/[sattypes, context, reporters, pkgurls, compiledpatterns, versions]
+import basic/configutils
 import basic/[deptypes, nimblecontext, deptypesjson]
 import dependencies
 import depgraphs
@@ -303,6 +304,79 @@ suite "test global features":
           check featurePkgs[0].active
           check not featurePkgs[0].activeVersion.isNil
           check $featurePkgs[0].activeVersion.vtag.version == "1.0.0"
+
+  test "parse features from nim.cfg":
+      withDir "tests/ws_features_global":
+        writeFile("nim.cfg", dedent"""
+        --define:"feature.proj_a.testing"
+        -d:feature.proj_b.extra
+        --define:"not_a_feature"
+        """)
+
+        check parseNimCfgFeatures(CfgPath paths.getCurrentDir()).toHashSet ==
+          ["feature.proj_a.testing", "feature.proj_b.extra"].toHashSet
+
+  test "atlasRun install keeps features from nim.cfg with -k":
+      setAtlasVerbosity(Error)
+      withDir "tests/ws_features_global":
+        removeDir("deps")
+        removeDir("proj_feature_dep")
+
+        setContext(AtlasContext())
+        context().nameOverrides = Patterns()
+        context().urlOverrides = Patterns()
+        context().proxy = parseUri "http://localhost:4242"
+        context().flags = {DumbProxy}
+        context().depsDir = Path "deps"
+        context().defaultAlgo = SemVer
+        project(paths.getCurrentDir())
+
+        expectedVersionWithGitTags()
+        var nc = createNimbleContext()
+        nc.put("proj_a", toPkgUriRaw(parseUri "https://example.com/buildGraph/proj_a", true))
+        nc.put("proj_b", toPkgUriRaw(parseUri "https://example.com/buildGraph/proj_b", true))
+        nc.put("proj_c", toPkgUriRaw(parseUri "https://example.com/buildGraph/proj_c", true))
+        nc.put("proj_d", toPkgUriRaw(parseUri "https://example.com/buildGraph/proj_d", true))
+
+        let dir = paths.getCurrentDir().absolutePath
+        discard dir.loadWorkspace(nc, AllReleases, onClone=DoClone, doSolve=false)
+
+        let featureDepPath = (paths.getCurrentDir() / Path"proj_feature_dep").absolutePath
+        createDir($featureDepPath)
+        withDir $featureDepPath:
+          writeFile("proj_feature_dep.nimble", dedent"""
+          version "1.0.0"
+          """)
+          exec "git init"
+          exec "git add proj_feature_dep.nimble"
+          exec "git commit -m \"feat: add proj_feature_dep.nimble\""
+          exec "git tag v1.0.0"
+
+        withDir "deps" / "proj_a":
+          writeFile("proj_a.nimble", dedent"""
+          requires "proj_b >= 1.1.0"
+          feature "testing":
+            requires "$1 >= 1.0.0"
+          """ % [toWindowsFileUrl("file://" & $featureDepPath)])
+          exec "git add proj_a.nimble"
+          exec "git commit -m \"feat: add proj_a feature dep for keepFeatures test\""
+          exec "git tag v1.2.0"
+
+        writeFile("nim.cfg", dedent"""
+        --define:"feature.proj_a.testing"
+        """)
+
+        setContext(AtlasContext())
+        atlasRun(@[
+          "--deps=deps",
+          "--proxy=http://localhost:4242/",
+          "--dumbproxy",
+          "-k",
+          "install"
+        ])
+
+        check dirExists("deps" / "proj_feature_dep")
+        check "deps/proj_feature_dep" in readFile("nim.cfg")
 
   test "broken feature does not block other selected features":
       setAtlasVerbosity(Error)

--- a/tests/tinstall.nim
+++ b/tests/tinstall.nim
@@ -1,0 +1,38 @@
+import std/[os, paths, strutils, unittest]
+
+import basic/[context, reporters]
+import atlas
+
+template withDir(dir: Path; body: untyped) =
+  let old = os.getCurrentDir()
+  try:
+    os.setCurrentDir($dir)
+    body
+  finally:
+    os.setCurrentDir(old)
+
+suite "install":
+  test "runs when nimble file has no requirements":
+    let dir = getTempDir().Path / Path"atlas_install_no_requirements"
+    if dirExists($dir):
+      removeDir($dir)
+    createDir($dir)
+
+    try:
+      withDir dir:
+        writeFile("emptydeps.nimble", """
+version "0.1.0"
+""")
+
+        setAtlasVerbosity(Error)
+        setContext AtlasContext()
+        atlasRun(@["install"])
+
+        check atlasErrors() == 0
+        check fileExists("nim.cfg")
+        let cfg = readFile("nim.cfg")
+        check "--noNimblePath" in cfg
+        check "--path:" notin cfg
+    finally:
+      if dirExists($dir):
+        removeDir($dir)

--- a/tests/tlinks.nim
+++ b/tests/tlinks.nim
@@ -4,7 +4,7 @@ import std / [strutils, os, uri, jsonutils, json, tables, sequtils, unittest]
 import std/terminal
 
 import basic/[sattypes, context, reporters, pkgurls, compiledpatterns, versions]
-import basic/[deptypes, nimblecontext, deptypesjson]
+import basic/[deptypes, nimblecontext, deptypesjson, nimbleparser]
 import dependencies
 import depgraphs
 import integration_test_utils
@@ -149,6 +149,20 @@ suite "test link integration":
         check linkLines.len == 2
         check linkLines[0] == $linkedNimble
         check Path(linkLines[1]).absolutePath == project().absolutePath
+
+  test "link precheck detects existing dependency by URL":
+      withDir "tests/ws_link_integration":
+        let nimbleFile = Path"link_precheck.nimble"
+        writeFile($nimbleFile, dedent"""
+        requires "https://example.com/someuser/ws_link_semver"
+        """)
+        let linkedNimble = (paths.getCurrentDir() /
+          Path"../ws_link_semver/ws_link_semver.nimble").absolutePath
+        let linkUri = toPkgUriRaw(parseUri("link://" & $linkedNimble))
+
+        check hasNimbleRequirement(nimbleFile, linkUri)
+
+        removeFile($nimbleFile)
 
   test "expand using link files part 2":
       setAtlasVerbosity(Warning)

--- a/tests/tnimbleparser.nim
+++ b/tests/tnimbleparser.nim
@@ -55,6 +55,22 @@ suite "nimbleparser":
     check res.features["useOldAsyncTools"].len == 1
     check res.features["useOldAsyncTools"][0] == "asynctools >= 0.1.0"
 
+  test "patch nimble file skips existing dependency by URL project name":
+    let nimbleFile = Path("tests" / "test_data" / "use_duplicate.nimble")
+    writeFile($nimbleFile, dedent"""
+    requires "https://example.com/someuser/ws_link_semver"
+    """)
+    var nc = NimbleContext()
+    nc.put("ws_link_semver", toPkgUriRaw(parseUri "https://example.com/other/ws_link_semver"))
+
+    patchNimbleFile(nc, nimbleFile, "ws_link_semver")
+
+    let reqs = extractRequiresInfo(nimbleFile).requires
+    check reqs.len == 1
+    check reqs[0] == "https://example.com/someuser/ws_link_semver"
+
+    removeFile($nimbleFile)
+
   test "parse nimble file with when statements":
     let nimbleFile = Path("tests" / "test_data" / "jester_boolean.nimble")
     var res = extractRequiresInfo(nimbleFile)

--- a/tests/tsearch.nim
+++ b/tests/tsearch.nim
@@ -1,6 +1,7 @@
 import std/[os, paths, unittest]
-import basic/context
+import basic/[context, packageinfos]
 import atlas
+import pkgsearch
 
 template withDir(dir: string; body: untyped) =
   let old = os.getCurrentDir()
@@ -22,3 +23,14 @@ suite "search":
       check project() == Path("")
       check not fileExists("atlas.config")
       check not dirExists("deps")
+
+    test "skips aliases":
+      let pkgs = @[
+        PackageInfo(kind: pkAlias, name: "jwt", alias: "jwtpkg"),
+        PackageInfo(kind: pkPackage, name: "jwtpkg", url: "https://example.com/jwtpkg",
+          license: "", downloadMethod: "git", description: "jwt package",
+          tags: @["jwt"])
+      ]
+      let candidates = determineCandidates(pkgs, @["jwt"])
+      check candidates[0].len == 0
+      check candidates[1].len == 1

--- a/tests/ws_explicit_history_leak/ws_explicit_history_leak.nimble
+++ b/tests/ws_explicit_history_leak/ws_explicit_history_leak.nimble
@@ -1,1 +1,2 @@
-requires "jwt#b75638b3"
+version = "0.1.0"
+requires "https://example.invalid/elcritch/sarcophagus >= 0.6.3"


### PR DESCRIPTION
 
- Adds `--keepFeatures` / `-k` to preserve nim.cfg feature flags during install/update flows.
- duplicate dependency insertion for `atlas link` and `atlas use`
- atlas search jwt crashing on package aliases
- atlas install when a nimble file has no requires

Tests and docs were updated for the new behavior.

