### PR TITLE
Caching dep info and reusing git repo state

### DIFF
--- a/atlas.nimble
+++ b/atlas.nimble
@@ -1,5 +1,5 @@
 # Package
-version = "0.11.3"
+version = "0.12.0"
 author = "Araq"
 description = "Atlas is a simple package cloner tool. It manages an isolated project."
 license = "MIT"

--- a/doc/atlas.md
+++ b/doc/atlas.md
@@ -65,6 +65,12 @@ Atlas downloads `packages.json` into `deps/_packages` by default; pass
 If dependency URLs use `git://`, pass `--forceGitToHttps` to rewrite them to
 `https://` before cloning.
 
+Atlas caches parsed dependency release metadata in `deps/.cache`. Each cache
+file is scoped to one package URL and is reused only while the package's remote
+HEAD, local checked-out commit, and relevant release-collection flags still
+match. If those inputs change, Atlas reparses the package's Nimble files and
+rewrites the cache.
+
 In addition to full URLs and package names, Atlas supports a shorthand
 **forge alias** syntax of the form `<alias>:<user>/<repo>`. The supported
 aliases are:

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -547,7 +547,8 @@ proc atlasRun*(params: seq[string]) =
 
   of "search":
     var pkgs: seq[PackageInfo] = @[]
-    if dirExists(packagesDirectory()):
+    removeLegacyPackageCaches()
+    if fileExists(packageInfosFile()):
       pkgs = getPackageInfos()
     pkgsearch.search(pkgs, args)
 

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -341,6 +341,9 @@ proc update(filter: string) =
   ## update the dependencies
   ##
   ## this will check every git repository in `depsDir` and update it if needed
+  info "atlas:update", "updating packages database"
+  updatePackages()
+
   let depsRoot = depsDir()
   if depsRoot == Path"" or not dirExists(depsRoot):
     warn "atlas:update", "deps directory not found:", $depsRoot

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -198,7 +198,13 @@ proc afterGraphActions(g: DepGraph) =
   if atlasErrors() == 0:
     writeConfig()
 
-  writeDepGraph(g, debug = not g.root.active or KeepWorkspace in context().flags)
+  if DumpGraphs in context().flags:
+    writeDepGraph(g, debug = not g.root.active or KeepWorkspace in context().flags)
+  else:
+    removeDepGraphCache()
+
+  if atlasErrors() == 0:
+    writeActivationCache(g)
 
   if ShowGraph in context().flags:
     generateDepGraph g
@@ -251,11 +257,10 @@ proc linkPackage(linkDir, linkedNimble: Path) =
 
   # Load linked project's config to get its deps dir
   info "atlas:link", "linked project dir:", $linkDir
-  let lgraph = loadDepGraph(nc, linkedNimble)
+  let lcache = loadActivationCache(linkedNimble)
 
   # Create links for all nimble files and links in the linked project
-  for pkg in allNodes(lgraph):
-    let srcDir = if pkg.activeNimbleRelease().isNil: Path"" else: pkg.activeNimbleRelease().srcDir
+  for pkg in lcache.packages:
     let nimbleFiles = pkg.ondisk.findNimbleFile()
     if nimbleFiles.len() != 1:
       error $pkg.url.projectName, "error finding nimble file; got:", $nimbleFiles
@@ -266,7 +271,7 @@ proc linkPackage(linkDir, linkedNimble: Path) =
         linkUri
       else:
         pkg.url
-    createNimbleLink(linkPkgUrl, nimble, CfgPath(srcDir))
+    createNimbleLink(linkPkgUrl, nimble, CfgPath(pkg.srcDir))
 
   installDependencies(nc, nimbleFile)
 

--- a/src/basic/context.nim
+++ b/src/basic/context.nim
@@ -108,6 +108,12 @@ proc nimbleCachesDirectory*(): Path =
 proc depGraphCacheFile*(ctx: AtlasContext): Path =
   ctx.depsDir() / Path"atlas.cache.json"
 
+proc activationCacheFile*(ctx: AtlasContext): Path =
+  ctx.depsDir() / DefaultCachesSubDir / Path"atlas.active.json"
+
+proc activationCacheFile*(): Path =
+  activationCacheFile(context())
+
 proc relativeToWorkspace*(path: Path): string =
   result = "$project/" & $path.relativePath(project())
 

--- a/src/basic/context.nim
+++ b/src/basic/context.nim
@@ -18,7 +18,7 @@ const
 const
   AtlasProjectConfig = Path"atlas.config"
   DefaultPackagesSubDir* = Path"_packages"
-  DefaultCachesSubDir* = Path"_caches"
+  DefaultCachesSubDir* = Path".cache"
   DefaultNimbleCachesSubDir* = Path"_nimbles"
 
 

--- a/src/basic/dependencycache.nim
+++ b/src/basic/dependencycache.nim
@@ -1,0 +1,136 @@
+#
+#           Atlas Package Cloner
+#        (c) Copyright 2023 Andreas Rumpf
+#
+#    See the file "copying.txt", included in this
+#    distribution, for details about the copyright.
+#
+
+import std / [os, strutils, paths, dirs]
+import context, deptypes, versions, gitops, pkgurls, reporters, deptypesjson
+
+type
+  NimbleFileSource* = object
+    path*: Path
+    fromGit*: bool
+
+  PackageReleaseCacheEntry* = object
+    vtag*: VersionTag
+    release*: NimbleRelease
+
+  PackageReleaseCache = object
+    cacheVersion*: int
+    url*: PkgUrl
+    head*: CommitHash
+    current*: CommitHash
+    includeTagsAndNimbleCommits*: bool
+    nimbleCommitsMax*: bool
+    releases*: seq[PackageReleaseCacheEntry]
+
+const PackageReleaseCacheVersion = 1
+
+proc packageCacheStem*(url: PkgUrl): string =
+  result = url.fullName()
+  if result.len == 0:
+    result = url.projectName()
+  if result.len == 0:
+    result = $url
+
+  for c in mitems(result):
+    if c notin {'a'..'z', 'A'..'Z', '0'..'9', '.', '_', '-'}:
+      c = '_'
+
+proc packageReleaseCachePath*(pkg: Package): Path =
+  cachesDirectory() / Path(packageCacheStem(pkg.url) & ".json")
+
+proc includeTagsAndNimbleCommitsFlag*(): bool =
+  IncludeTagsAndNimbleCommits in context().flags
+
+proc nimbleCommitsMaxFlag*(): bool =
+  NimbleCommitsMax in context().flags
+
+proc canUsePackageReleaseCache*(
+    pkg: Package;
+    mode: TraversalMode;
+    explicitVersions: seq[VersionTag]
+): bool =
+  mode == AllReleases and
+    explicitVersions.len == 0 and
+    not pkg.isRoot and
+    not pkg.isAtlasProject and
+    not pkg.url.isNimbleLink() and
+    not pkg.isLocalOnly
+
+proc findGitNimbleFiles*(pkg: Package; commit: CommitHash): seq[NimbleFileSource] =
+  let files = listFiles(pkg.ondisk, commit)
+  for file in files:
+    if file.endsWith(".nimble"):
+      let source = NimbleFileSource(path: Path(file), fromGit: true)
+      if source.path.splitPath().tail == Path(pkg.url.shortName() & ".nimble"):
+        return @[source]
+      result.add source
+
+proc materializeNimbleFile*(pkg: Package; commit: CommitHash; source: NimbleFileSource): Path =
+  if not source.fromGit:
+    return source.path
+
+  let tmpDir = cachesDirectory() / Path"_tmp"
+  createDir(cachesDirectory())
+  createDir(tmpDir)
+  result = tmpDir / Path(packageCacheStem(pkg.url) & "-" & commit.short() & "-" & $source.path.splitPath().tail)
+  writeFile($result, showFile(pkg.ondisk, commit, $source.path))
+
+proc loadPackageReleaseCache*(
+    pkg: Package;
+    currentCommit: CommitHash;
+    entries: var seq[PackageReleaseCacheEntry]
+): bool =
+  if pkg.originHead.isEmpty():
+    return false
+
+  let cachePath = packageReleaseCachePath(pkg)
+  if not fileExists($cachePath):
+    return false
+
+  var cache: PackageReleaseCache
+  try:
+    cache.fromJson(parseFile($cachePath), Joptions(allowMissingKeys: true, allowExtraKeys: true))
+  except CatchableError as e:
+    warn pkg.url.projectName, "ignoring invalid dependency cache:", $cachePath, "error:", e.msg
+    return false
+
+  result =
+    cache.cacheVersion == PackageReleaseCacheVersion and
+    cache.url == pkg.url and
+    cache.head == pkg.originHead and
+    cache.current == currentCommit and
+    cache.includeTagsAndNimbleCommits == includeTagsAndNimbleCommitsFlag() and
+    cache.nimbleCommitsMax == nimbleCommitsMaxFlag()
+
+  if result:
+    entries = cache.releases
+    debug pkg.url.projectName, "loaded dependency cache:", $cachePath, "releases:", $entries.len
+
+proc savePackageReleaseCache*(
+    pkg: Package;
+    currentCommit: CommitHash;
+    versions: seq[(PackageVersion, NimbleRelease)]
+) =
+  if pkg.originHead.isEmpty():
+    return
+
+  var cache = PackageReleaseCache(
+    cacheVersion: PackageReleaseCacheVersion,
+    url: pkg.url,
+    head: pkg.originHead,
+    current: currentCommit,
+    includeTagsAndNimbleCommits: includeTagsAndNimbleCommitsFlag(),
+    nimbleCommitsMax: nimbleCommitsMaxFlag()
+  )
+  for (ver, release) in versions:
+    cache.releases.add PackageReleaseCacheEntry(vtag: ver.vtag, release: release)
+
+  createDir(cachesDirectory())
+  let cachePath = packageReleaseCachePath(pkg)
+  writeFile($cachePath, pretty(toJson(cache, ToJsonOptions(enumMode: joptEnumString))))
+  debug pkg.url.projectName, "wrote dependency cache:", $cachePath, "releases:", $cache.releases.len

--- a/src/basic/deptypesjson.nim
+++ b/src/basic/deptypesjson.nim
@@ -64,12 +64,15 @@ proc fromJsonHook*(a: var Table[PkgUrl, HashSet[string]]; b: JsonNode; opt = Jop
     flags.fromJson(toJson(v))
     a[url] = flags
 
+proc toJsonHook*(r: NimbleRelease, opt: ToJsonOptions): JsonNode
+proc fromJsonHook*(r: var NimbleRelease; b: JsonNode; opt = Joptions())
+
 proc toJsonHook*(t: OrderedTable[PackageVersion, NimbleRelease], opt: ToJsonOptions): JsonNode =
   result = newJArray()
   for k, v in t:
     var tpl = newJArray()
     tpl.add toJson(k, opt)
-    tpl.add toJson(v, opt)
+    tpl.add toJsonHook(v, opt)
     result.add tpl
     # result[repr(k.vtag)] = toJson(v, opt)
 
@@ -78,7 +81,7 @@ proc fromJsonHook*(t: var OrderedTable[PackageVersion, NimbleRelease]; b: JsonNo
     var pv: PackageVersion
     pv.fromJson(item[0])
     var release: NimbleRelease
-    release.fromJson(item[1])
+    fromJsonHook(release, item[1], opt)
     t[pv] = release
 
 proc toJsonHook*(t: OrderedTable[PkgUrl, Package], opt: ToJsonOptions): JsonNode =
@@ -94,8 +97,8 @@ proc fromJsonHook*(t: var OrderedTable[PkgUrl, Package]; b: JsonNode; opt = Jopt
     pkg.fromJson(v)
     t[url] = pkg
 
-proc toJsonHook*(r: NimbleRelease, opt: ToJsonOptions = ToJsonOptions()): JsonNode =
-  if r == nil:
+proc nimbleReleaseToJson(r: NimbleRelease, opt: ToJsonOptions): JsonNode =
+  if r.isNil:
     return newJNull()
   result = newJObject()
   result["requirements"] = toJson(r.requirements, opt)
@@ -115,6 +118,12 @@ proc toJsonHook*(r: NimbleRelease, opt: ToJsonOptions = ToJsonOptions()): JsonNo
     result["reqsByFeatures"] = toJson(r.reqsByFeatures, opt)
   if r.featureVars.len > 0:
     result["featureVars"] = toJson(r.featureVars, opt)
+
+proc toJsonHook*(r: NimbleRelease): JsonNode =
+  nimbleReleaseToJson(r, ToJsonOptions())
+
+proc toJsonHook*(r: NimbleRelease, opt: ToJsonOptions): JsonNode =
+  nimbleReleaseToJson(r, opt)
 
 proc fromJsonHook*(r: var NimbleRelease; b: JsonNode; opt = Joptions()) =
   if r.isNil:

--- a/src/basic/deptypesjson.nim
+++ b/src/basic/deptypesjson.nim
@@ -5,6 +5,7 @@ export json, jsonutils
 
 proc toJsonHook*(v: VersionInterval): JsonNode = toJson($(v))
 proc toJsonHook*(v: Version): JsonNode = toJson($v)
+proc toJsonHook*(v: CommitHash): JsonNode = toJson($v)
 proc toJsonHook*(v: VersionTag): JsonNode = toJson(repr(v))
 
 proc fromJsonHook*(a: var VersionInterval; b: JsonNode; opt = Joptions()) =
@@ -14,6 +15,9 @@ proc fromJsonHook*(a: var VersionInterval; b: JsonNode; opt = Joptions()) =
 
 proc fromJsonHook*(a: var Version; b: JsonNode; opt = Joptions()) =
   a = toVersion(b.getStr())
+
+proc fromJsonHook*(a: var CommitHash; b: JsonNode; opt = Joptions()) =
+  a = toCommitHash(b.getStr())
 
 proc fromJsonHook*(a: var VersionTag; b: JsonNode; opt = Joptions()) =
   var raw = b.getStr()
@@ -100,14 +104,24 @@ proc toJsonHook*(r: NimbleRelease, opt: ToJsonOptions = ToJsonOptions()): JsonNo
   if r.srcDir != Path "":
     result["srcDir"] = toJson(r.srcDir, opt)
   result["version"] = toJson(r.version, opt)
+  if r.nimVersion != Version"":
+    result["nimVersion"] = toJson(r.nimVersion, opt)
   result["status"] = toJson(r.status, opt)
   if r.err != "":
     result["err"] = toJson(r.err, opt)
+  if r.features.len > 0:
+    result["features"] = toJson(r.features, opt)
+  if r.reqsByFeatures.len > 0:
+    result["reqsByFeatures"] = toJson(r.reqsByFeatures, opt)
+  if r.featureVars.len > 0:
+    result["featureVars"] = toJson(r.featureVars, opt)
 
 proc fromJsonHook*(r: var NimbleRelease; b: JsonNode; opt = Joptions()) =
   if r.isNil:
     r = new(NimbleRelease)
   r.version.fromJson(b["version"])
+  if b.hasKey("nimVersion"):
+    r.nimVersion.fromJson(b["nimVersion"])
   r.requirements.fromJson(b["requirements"])
   r.status.fromJson(b["status"])
   if b.hasKey("hasInstallHooks"):
@@ -116,6 +130,12 @@ proc fromJsonHook*(r: var NimbleRelease; b: JsonNode; opt = Joptions()) =
     r.srcDir.fromJson(b["srcDir"])
   if b.hasKey("err"):
     r.err = b["err"].getStr()
+  if b.hasKey("features"):
+    r.features.fromJson(b["features"])
+  if b.hasKey("reqsByFeatures"):
+    r.reqsByFeatures.fromJson(b["reqsByFeatures"])
+  if b.hasKey("featureVars"):
+    r.featureVars.fromJson(b["featureVars"])
 
 proc toJsonGraph*(d: DepGraph): JsonNode =
   result = toJson(d, ToJsonOptions(enumMode: joptEnumString))

--- a/src/basic/gitops.nim
+++ b/src/basic/gitops.nim
@@ -41,11 +41,23 @@ type
     GitListFiles = "git -C $DIR ls-tree --name-only -r"
     GitForEachRef = "git -C $DIR for-each-ref"
 
+  RepoMetadata* = object
+    path*: Path
+    origin*: string
+    isLocalOnly*: bool
+    currentCommit*: CommitHash
+    canonicalUrl*: string
+    remoteName*: string
+    remoteRef*: string
+    originTip*: VersionTag
+
 proc fetchRemoteTags*(path: Path; origin = "origin"; errorReportLevel: MsgKind = Warning): bool
 proc fetchRemoteTagsByName(path: Path; remote: string; errorReportLevel: MsgKind = Warning): bool
 proc resolveRemoteName*(path: Path; origin = "origin"; errorReportLevel: MsgKind = Warning): string
 proc maybeUrlProxy*(url: Uri): Uri
 proc syncRemoteRefs(path: Path; srcRemote, dstRemote: string; errorReportLevel: MsgKind = Warning): bool
+proc readGitRef(path: Path; refName: string): string
+proc currentGitCommit*(path: Path, errorReportLevel: MsgKind = Info): CommitHash
 proc exec*(gitCmd: Command;
            path: Path;
            args: openArray[string],
@@ -65,6 +77,11 @@ proc execQuiet(gitCmd: Command;
 proc resolveRemoteTipRef*(path: Path; remote: string): string =
   ## Returns a local ref to the remote's tip without querying the network.
   if remote.len == 0: return ""
+  for branch in ["HEAD", "main", "master"]:
+    let refName = "refs/remotes/" & remote & "/" & branch
+    if readGitRef(path, refName).len > 0:
+      return remote & "/" & branch
+
   let base = "refs/remotes/" & remote & "/"
   let (outp, status) = execQuiet(GitShowRef, path, [])
   if status != RES_OK: return ""
@@ -132,6 +149,116 @@ proc exec*(gitCmd: Command;
   if result[1] != RES_OK:
     message errorReportLevel, "gitops", "Running Git failed:", $(int(result[1])), "command:", "`$1 $2`" % [cmd, join(args, " ")]
 
+proc gitMetadataDir(path: Path): Path =
+  let dotGit = path / Path".git"
+  if dirExists($dotGit):
+    return dotGit
+  if fileExists($dotGit):
+    for line in readFile($dotGit).splitLines():
+      let entry = line.strip()
+      if entry.startsWith("gitdir:"):
+        let gitDir = entry.substr("gitdir:".len).strip()
+        if gitDir.len == 0:
+          return Path""
+        return if isAbsolute(gitDir): Path(gitDir) else: path / Path(gitDir)
+  Path""
+
+proc commonGitDir(gitDir: Path): Path =
+  if gitDir.string == "":
+    return Path""
+  let commonDirFile = gitDir / Path"commondir"
+  if fileExists($commonDirFile):
+    let common = readFile($commonDirFile).strip()
+    if common.len > 0:
+      return if isAbsolute(common): Path(common) else: gitDir / Path(common)
+  gitDir
+
+proc parseRemoteSection(line: string): string =
+  let line = line.strip()
+  const prefix = "[remote \""
+  if line.startsWith(prefix) and line.endsWith("\"]"):
+    result = line[prefix.len ..< line.len - 2]
+
+proc configRemotes(path: Path): seq[string] =
+  let gitDir = gitMetadataDir(path)
+  if gitDir.string == "":
+    return
+  let configPath = commonGitDir(gitDir) / Path"config"
+  if not fileExists($configPath):
+    return
+  for line in readFile($configPath).splitLines():
+    let remote = parseRemoteSection(line)
+    if remote.len > 0:
+      result.add remote
+
+proc configRemoteUrl(path: Path; remote: string): string =
+  let gitDir = gitMetadataDir(path)
+  if gitDir.string == "":
+    return
+  let configPath = commonGitDir(gitDir) / Path"config"
+  if not fileExists($configPath):
+    return
+
+  var inRemoteSection = false
+  for rawLine in readFile($configPath).splitLines():
+    let line = rawLine.strip()
+    if line.startsWith("["):
+      inRemoteSection = parseRemoteSection(line) == remote
+    elif inRemoteSection and line.startsWith("url"):
+      let eq = line.find('=')
+      if eq >= 0:
+        return line[eq + 1 .. ^1].strip()
+
+proc readPackedRef(gitDir, commonDir: Path; refName: string): string =
+  for dir in [gitDir, commonDir]:
+    if dir.string == "":
+      continue
+    let packedRefs = dir / Path"packed-refs"
+    if not fileExists($packedRefs):
+      continue
+    for rawLine in readFile($packedRefs).splitLines():
+      let line = rawLine.strip()
+      if line.len == 0 or line[0] in {'#', '^'}:
+        continue
+      let parts = line.splitWhitespace()
+      if parts.len >= 2 and parts[1] == refName:
+        return parts[0]
+
+proc readGitRef(path: Path; refName: string): string =
+  let gitDir = gitMetadataDir(path)
+  if gitDir.string == "":
+    return
+  let commonDir = commonGitDir(gitDir)
+
+  for dir in [gitDir, commonDir]:
+    if dir.string == "":
+      continue
+    let refPath = dir / Path(refName)
+    if fileExists($refPath):
+      let refContent = readFile($refPath).strip()
+      if refContent.startsWith("ref:"):
+        return readGitRef(path, refContent.substr("ref:".len).strip())
+      return refContent
+
+  readPackedRef(gitDir, commonDir, refName)
+
+proc readGitHeadCommit(path: Path): string =
+  let gitDir = gitMetadataDir(path)
+  if gitDir.string == "":
+    return
+  let headPath = gitDir / Path"HEAD"
+  if not fileExists($headPath):
+    return
+  let head = readFile($headPath).strip()
+  if head.startsWith("ref:"):
+    readGitRef(path, head.substr("ref:".len).strip())
+  else:
+    head
+
+proc parseCommitRef(commit: string; origin = FromGitTag): VersionTag =
+  if commit.len > 0:
+    result = VersionTag(v: Version"", c: initCommitHash(commit.strip(), origin))
+
 proc checkGitDiffStatus*(path: Path): string =
   let (outp, status) = exec(GitDiff, path, [])
   if outp.len != 0:
@@ -142,11 +269,14 @@ proc checkGitDiffStatus*(path: Path): string =
     ""
 
 proc listRemotes(path: Path): seq[string] =
+  result = configRemotes(path)
+  if result.len > 0:
+    return
   let (outp, status) = exec(GitRemotesShow, path, [], Debug)
   if status == RES_OK:
-    outp.splitLines().mapIt(it.strip()).filterIt(it.len > 0)
+    result = outp.splitLines().mapIt(it.strip()).filterIt(it.len > 0)
   else:
-    @[]
+    result = @[]
 
 proc remoteNameFromGitUrl*(rawUrl: string): string =
   if rawUrl.len == 0:
@@ -180,6 +310,9 @@ proc remoteNameFromGitUrl*(rawUrl: string): string =
     repo & "." & user & "." & u.hostname
 
 proc getRemoteUrlFor(path: Path; remote: string): string =
+  result = configRemoteUrl(path, remote)
+  if result.len > 0:
+    return
   let (outp, status) = exec(
     GitRemoteUrl,
     path,
@@ -188,7 +321,7 @@ proc getRemoteUrlFor(path: Path; remote: string): string =
   )
   if status != RES_OK:
     return ""
-  outp.strip()
+  result = outp.strip()
 
 proc getCanonicalUrl*(path: Path; origin = "origin"): string =
   ## Returns the canonical URL stored in the `origin` remote.
@@ -197,6 +330,9 @@ proc getCanonicalUrl*(path: Path; origin = "origin"): string =
 proc ensureRemoteUrl(path: Path; remote, url: string; errorReportLevel: MsgKind = Warning): bool =
   if remote.len == 0 or url.len == 0 or not isGitDir(path):
     return false
+
+  if getRemoteUrlFor(path, remote) == url:
+    return true
 
   let remotes = listRemotes(path)
   if remote notin remotes:
@@ -365,17 +501,17 @@ proc gitDescribeRefTag*(path: Path, commit: string): string =
   let (lt, status) = exec(GitDescribe, path, ["--tags", commit])
   result = if status == RES_OK: strutils.strip(lt) else: ""
 
-proc findOriginTip*(path: Path; origin = "origin"; errorReportLevel: MsgKind = Warning, isLocalOnly = false): VersionTag =
-  let remoteName =
-    if isLocalOnly: ""
-    else: resolveRemoteName(path, origin, errorReportLevel)
-  var remoteRef =
-    if isLocalOnly: ""
-    else: resolveRemoteTipRef(path, remoteName)
-  if not isLocalOnly and remoteRef.len == 0:
-    # Ensure we have remote heads available for branch resolution.
-    if fetchRemoteHeads(path, origin, errorReportLevel):
-      remoteRef = resolveRemoteTipRef(path, remoteName)
+proc tipFromRef(path: Path; remoteName, remoteRef: string; errorReportLevel: MsgKind; isLocalOnly: bool): VersionTag =
+  let commit =
+    if isLocalOnly or remoteRef.len == 0:
+      readGitHeadCommit(path)
+    else:
+      readGitRef(path, "refs/remotes/" & remoteRef)
+  if commit.len > 0:
+    result = parseCommitRef(commit, FromHead)
+    result.isTip = true
+    return
+
   let cmd =
     if isLocalOnly or remoteRef.len == 0:
       GitLogLocal
@@ -394,47 +530,75 @@ proc findOriginTip*(path: Path; origin = "origin"; errorReportLevel: MsgKind = W
       result = allVersions[0]
       result.isTip = true
 
-proc collectTaggedVersions*(path: Path; origin = "origin"; errorReportLevel: MsgKind = Debug, isLocalOnly = false): seq[VersionTag] =
-  let remote =
-    if isLocalOnly: ""
-    else: resolveRemoteName(path, origin, errorReportLevel)
-  let tip = findOriginTip(path, origin, errorReportLevel, isLocalOnly)
+proc loadRepoMetadata*(
+    path: Path;
+    origin = "origin";
+    expectedCanonicalUrl = "";
+    errorReportLevel: MsgKind = Warning;
+    isLocalOnly = false
+): RepoMetadata =
+  result = RepoMetadata(path: path, origin: origin, isLocalOnly: isLocalOnly)
+  result.currentCommit = currentGitCommit(path, errorReportLevel)
+
+  if not isLocalOnly:
+    if expectedCanonicalUrl.len > 0:
+      discard ensureRemoteUrl(path, origin, expectedCanonicalUrl, errorReportLevel)
+    result.canonicalUrl = getCanonicalUrl(path, origin)
+    result.remoteName = resolveRemoteName(path, origin, errorReportLevel)
+    result.remoteRef = resolveRemoteTipRef(path, result.remoteName)
+    if result.remoteName.len > 0 and result.remoteRef.len == 0:
+      # Ensure we have remote heads available for branch resolution.
+      if fetchRemoteHeadsByName(path, result.remoteName, errorReportLevel):
+        result.remoteRef = resolveRemoteTipRef(path, result.remoteName)
+
+  result.originTip = tipFromRef(path, result.remoteName, result.remoteRef, errorReportLevel, isLocalOnly)
+
+proc findOriginTip*(repo: RepoMetadata; errorReportLevel: MsgKind = Warning): VersionTag =
+  if repo.originTip.commit.isEmpty():
+    tipFromRef(repo.path, repo.remoteName, repo.remoteRef, errorReportLevel, repo.isLocalOnly)
+  else:
+    repo.originTip
+
+proc findOriginTip*(path: Path; origin = "origin"; errorReportLevel: MsgKind = Warning, isLocalOnly = false): VersionTag =
+  let repo = loadRepoMetadata(path, origin, errorReportLevel = errorReportLevel, isLocalOnly = isLocalOnly)
+  findOriginTip(repo, errorReportLevel)
+
+proc collectTaggedVersions*(repo: RepoMetadata; errorReportLevel: MsgKind = Debug): seq[VersionTag] =
+  let tip = findOriginTip(repo, errorReportLevel)
 
   let localTags = "refs/tags"
   var refs: seq[string] = @["--format=%(objectname) %(refname)", localTags]
-  if remote.len > 0:
-    refs.add "refs/remotes/" & remote & "/tags"
-  let (outp, status) = exec(GitForEachRef, path, refs, errorReportLevel)
+  if repo.remoteName.len > 0:
+    refs.add "refs/remotes/" & repo.remoteName & "/tags"
+  let (outp, status) = exec(GitForEachRef, repo.path, refs, errorReportLevel)
   if status == RES_OK:
     result = parseTaggedVersions(outp)
     if result.len > 0 and tip.isTip:
       if result[0].c == tip.c:
         result[0].isTip = true
   else:
-    message(errorReportLevel, path, "could not collect tagged commits at:", $path)
+    message(errorReportLevel, repo.path, "could not collect tagged commits at:", $repo.path)
 
-proc collectFileCommits*(path, file: Path; origin = "origin"; errorReportLevel: MsgKind = Warning, isLocalOnly = false): seq[VersionTag] =
-  let remote =
-    if isLocalOnly: ""
-    else: resolveRemoteName(path, origin, errorReportLevel)
-  let tip = findOriginTip(path, origin, errorReportLevel, isLocalOnly)
+proc collectTaggedVersions*(path: Path; origin = "origin"; errorReportLevel: MsgKind = Debug, isLocalOnly = false): seq[VersionTag] =
+  let repo = loadRepoMetadata(path, origin, errorReportLevel = errorReportLevel, isLocalOnly = isLocalOnly)
+  collectTaggedVersions(repo, errorReportLevel)
 
-  if not isLocalOnly and remote.len == 0:
+proc collectFileCommits*(repo: RepoMetadata; file: Path; errorReportLevel: MsgKind = Warning): seq[VersionTag] =
+  let tip = findOriginTip(repo, errorReportLevel)
+
+  if not repo.isLocalOnly and repo.remoteName.len == 0:
     return @[]
-  let remoteRef =
-    if isLocalOnly: ""
-    else: resolveRemoteTipRef(path, remote)
   let cmd =
-    if isLocalOnly or remoteRef.len == 0:
+    if repo.isLocalOnly or repo.remoteRef.len == 0:
       GitLogLocal
     else:
       GitLog
   var args: seq[string] = @[]
   if cmd == GitLog:
-    args.add remoteRef
+    args.add repo.remoteRef
   args.add "--"
   args.add $file
-  let (outp, status) = exec(cmd, path, args, Warning)
+  let (outp, status) = exec(cmd, repo.path, args, Warning)
   if status == RES_OK:
     result = parseTaggedVersions(outp, requireVersions = false)
     if result.len > 0 and tip.isTip:
@@ -442,6 +606,10 @@ proc collectFileCommits*(path, file: Path; origin = "origin"; errorReportLevel: 
         result[0].isTip = true
   else:
     message(errorReportLevel, file, "could not collect file commits at:", $file)
+
+proc collectFileCommits*(path, file: Path; origin = "origin"; errorReportLevel: MsgKind = Warning, isLocalOnly = false): seq[VersionTag] =
+  let repo = loadRepoMetadata(path, origin, errorReportLevel = errorReportLevel, isLocalOnly = isLocalOnly)
+  collectFileCommits(repo, file, errorReportLevel)
 
 proc versionToCommit*(path: Path; origin = "origin"; algo: ResolutionAlgorithm; query: VersionInterval): CommitHash =
   let allVersions = collectTaggedVersions(path, origin)
@@ -462,12 +630,11 @@ proc shortToCommit*(path: Path, short: CommitHash): CommitHash =
     if vtags.len() == 1:
       result = vtags[0].c
 
-proc expandSpecial*(path: Path; origin = "origin"; vtag: VersionTag, errorReportLevel: MsgKind = Warning): VersionTag =
+proc expandSpecial*(repo: var RepoMetadata; vtag: VersionTag, errorReportLevel: MsgKind = Warning): VersionTag =
   if vtag.version.isHead():
-    return findOriginTip(path, origin, errorReportLevel, false)
+    return findOriginTip(repo, errorReportLevel)
 
-  let remote = resolveRemoteName(path, origin, errorReportLevel)
-  let (cc, status) = exec(GitRevParse, path, [vtag.version.string.substr(1)], errorReportLevel)
+  let query = vtag.version.string.substr(1)
 
   template processSpecial(cc: string) =
     let vtags = parseTaggedVersions(cc, requireVersions = false)
@@ -475,23 +642,38 @@ proc expandSpecial*(path: Path; origin = "origin"; vtag: VersionTag, errorReport
       result.c = vtags[0].c
       if vtag.version.string.substr(1) in result.c.h: # expand short commit hash to full hash
         result.v = Version("#" & $(result.c))
-    info path, "expandSpecial: ", $vtag, "result:", repr result
+    info repo.path, "expandSpecial: ", $vtag, "result:", repr result
 
   result = VersionTag(v: vtag.version, c: initCommitHash("", FromHead))
+  var cc = readGitRef(repo.path, "refs/heads/" & query)
+  if cc.len == 0 and repo.remoteName.len > 0:
+    cc = readGitRef(repo.path, "refs/remotes/" & repo.remoteName & "/" & query)
+  if cc.len > 0:
+    processSpecial(cc)
+    return
+
+  var (revParseOut, status) = exec(GitRevParse, repo.path, [query], errorReportLevel)
   if status == RES_OK:
+    cc = revParseOut
     processSpecial(cc)
   else:
-    if remote.len == 0:
-      message(errorReportLevel, path, "could not resolve remote from canonical '" & origin & "'")
+    if repo.remoteName.len == 0:
+      message(errorReportLevel, repo.path, "could not resolve remote from canonical '" & repo.origin & "'")
       return
-    let remoteRef = remote & "/" & vtag.version.string.substr(1)
-    var (ccRemote, statusRemote) = exec(GitRevParse, path, [remoteRef], errorReportLevel)
-    if statusRemote != RES_OK and fetchRemoteHeads(path, origin, errorReportLevel):
-      (ccRemote, statusRemote) = exec(GitRevParse, path, [remoteRef], errorReportLevel)
+    let remoteRef = repo.remoteName & "/" & query
+    var (ccRemote, statusRemote) = exec(GitRevParse, repo.path, [remoteRef], errorReportLevel)
+    if statusRemote != RES_OK and fetchRemoteHeadsByName(repo.path, repo.remoteName, errorReportLevel):
+      repo.remoteRef = resolveRemoteTipRef(repo.path, repo.remoteName)
+      repo.originTip = tipFromRef(repo.path, repo.remoteName, repo.remoteRef, errorReportLevel, repo.isLocalOnly)
+      (ccRemote, statusRemote) = exec(GitRevParse, repo.path, [remoteRef], errorReportLevel)
     if statusRemote == RES_OK:
       processSpecial(ccRemote)
     else:
-      message(errorReportLevel, path, "could not expand special version:", $vtag)
+      message(errorReportLevel, repo.path, "could not expand special version:", $vtag)
+
+proc expandSpecial*(path: Path; origin = "origin"; vtag: VersionTag, errorReportLevel: MsgKind = Warning): VersionTag =
+  var repo = loadRepoMetadata(path, origin, errorReportLevel = errorReportLevel)
+  expandSpecial(repo, vtag, errorReportLevel)
 
 proc listFiles*(path: Path): seq[string] =
   let (outp, status) = exec(GitLsFiles, path, [])
@@ -524,16 +706,23 @@ proc listRemoteTags*(path: Path, url: string, errorReportLevel: MsgKind = Debug)
     result = (@[], false)
 
 proc currentGitCommit*(path: Path, errorReportLevel: MsgKind = Info): CommitHash =
+  let headCommit = readGitHeadCommit(path)
+  if headCommit.len > 0:
+    return initCommitHash(headCommit, FromGitTag)
   let (currentCommit, status) = exec(GitCurrentCommit, path, [], errorReportLevel)
   if status == RES_OK:
     return initCommitHash(currentCommit.strip(), FromGitTag)
   else:
     return initCommitHash("", FromNone)
 
-proc checkoutGitCommit*(path: Path, commit: CommitHash, errorReportLevel: MsgKind = Warning): bool =
-  let currentCommit = currentGitCommit(path)
+proc checkoutGitCommitKnown(path: Path; commit, currentCommit: CommitHash; currentIsKnown: bool; errorReportLevel: MsgKind): bool =
   if currentCommit.isFull() and currentCommit == commit:
     return true
+
+  if not currentIsKnown:
+    let currentCommit = currentGitCommit(path)
+    if currentCommit.isFull() and currentCommit == commit:
+      return true
 
   let (_, statusB) = exec(GitCheckout, path, [commit.h], errorReportLevel)
   if statusB != RES_OK:
@@ -543,11 +732,20 @@ proc checkoutGitCommit*(path: Path, commit: CommitHash, errorReportLevel: MsgKin
     trace path, "updated package to ", $commit
     result = true
 
+proc checkoutGitCommit*(path: Path, commit: CommitHash, errorReportLevel: MsgKind = Warning): bool =
+  checkoutGitCommitKnown(path, commit, initCommitHash("", FromNone), false, errorReportLevel)
+
+proc checkoutGitCommit*(path: Path, commit, currentCommit: CommitHash, errorReportLevel: MsgKind = Warning): bool =
+  checkoutGitCommitKnown(path, commit, currentCommit, true, errorReportLevel)
+
 proc checkoutGitCommitFull*(path: Path; commit: CommitHash; origin = "origin";
                             errorReportLevel: MsgKind = Warning): bool =
   var smExtraArgs: seq[string] = @[]
   result = true
-  if ShallowClones in context().flags and commit.isFull():
+  let currentCommit = currentGitCommit(path)
+  let alreadyAtCommit = currentCommit.isFull() and currentCommit == commit
+
+  if ShallowClones in context().flags and commit.isFull() and not alreadyAtCommit:
     smExtraArgs.add "--depth=1"
 
     let remote = resolveRemoteName(path, origin, errorReportLevel)
@@ -564,7 +762,7 @@ proc checkoutGitCommitFull*(path: Path; commit: CommitHash; origin = "origin";
       result = false
     else:
       trace($path, "fetched package commit " & $commit)
-  elif commit.isShort():
+  elif commit.isShort() and not alreadyAtCommit:
     info($path, "found short commit id; doing full fetch to resolve " & $commit)
     let (outp, status) = exec(GitFetch, path, ["--unshallow", "--no-tags"])
     if status != RES_OK:
@@ -573,12 +771,13 @@ proc checkoutGitCommitFull*(path: Path; commit: CommitHash; origin = "origin";
     else:
       trace($path, "fetched package updates ")
 
-  let (_, status) = exec(GitCheckout, path, [commit.h], errorReportLevel)
-  if status != RES_OK:
-    message(errorReportLevel, $path, "could not checkout commit " & $commit)
-    result = false
-  else:
-    trace $path, "updated package to:", $commit
+  if not alreadyAtCommit:
+    let (_, status) = exec(GitCheckout, path, [commit.h], errorReportLevel)
+    if status != RES_OK:
+      message(errorReportLevel, $path, "could not checkout commit " & $commit)
+      result = false
+    else:
+      trace $path, "updated package to:", $commit
 
   if fileExists(path / Path".gitmodules"):
     notice relativeToWorkspace(path), "Found submodules; Updating..."
@@ -855,3 +1054,8 @@ proc fetchRemoteTags*(path: Path; origin = "origin"; errorReportLevel: MsgKind =
   if remote.len == 0:
     return false
   fetchRemoteTagsByName(path, remote, errorReportLevel)
+
+proc fetchRemoteTags*(repo: RepoMetadata; errorReportLevel: MsgKind = Warning): bool =
+  if repo.remoteName.len == 0:
+    return false
+  fetchRemoteTagsByName(repo.path, repo.remoteName, errorReportLevel)

--- a/src/basic/nimblecontext.nim
+++ b/src/basic/nimblecontext.nim
@@ -99,6 +99,15 @@ proc lookup*(nc: NimbleContext, name: string): PkgUrl =
   elif lname in nc.nameToUrl:
     result = nc.nameToUrl[lname]
 
+proc isForkUrl*(nc: NimbleContext; url: PkgUrl): bool =
+  let officialUrl = nc.lookup(url.shortName())
+  let isGitUrl = url.url.scheme notin ["file", "link", "atlas"]
+  result =
+    isGitUrl and
+    not officialUrl.isEmpty() and
+    officialUrl.url.scheme notin ["file", "link", "atlas"] and
+    officialUrl.url != url.url
+
 proc putImpl(nc: var NimbleContext, name: string, url: PkgUrl, isFromPath = false): bool =
   let name = unicode.toLower(name)
   if name in nc.nameToUrl:

--- a/src/basic/nimblecontext.nim
+++ b/src/basic/nimblecontext.nim
@@ -6,6 +6,7 @@ type
     packageToDependency*: OrderedTable[PkgUrl, Package]
     packageExtras*: OrderedTable[string, PkgUrl]
     nameToUrl: OrderedTable[string, PkgUrl]
+    urlToUrl: OrderedTable[string, PkgUrl]
     explicitVersions*: OrderedTable[PkgUrl, HashSet[VersionTag]]
     nameOverrides*: Patterns
     urlOverrides*: Patterns
@@ -152,6 +153,9 @@ proc createUrl*(nc: var NimbleContext, nameOrig: string): PkgUrl =
   if name.isUrl():
     result = createUrlSkipPatterns(name)
 
+    if $result.url in nc.urlToUrl:
+      result = nc.urlToUrl[$result.url]
+
     # Keep explicit URLs stable. Name overrides are for package-name lookups,
     # not for remapping already explicit URL requirements (especially file://).
     if not origWasUrl:
@@ -210,12 +214,12 @@ proc createUrlFromPath*(nc: var NimbleContext, orig: Path, isLinkPath = false): 
     discard nc.putFromPath(result.projectName, result)
 
 proc fillPackageLookupTable(c: var NimbleContext) =
-  let pkgsDir = packagesDirectory()
   if not c.hasPackageList:
     c.hasPackageList = true
-    if not fileExists(pkgsDir / Path"packages.json"):
-      updatePackages(pkgsDir)
-    let packages = getPackageInfos(pkgsDir)
+    removeLegacyPackageCaches()
+    if not fileExists(packageInfosFile()):
+      updatePackages()
+    let packages = getPackageInfos()
     var aliases: seq[PackageInfo] = @[]
 
     # add all packages to the lookup table
@@ -227,7 +231,7 @@ proc fillPackageLookupTable(c: var NimbleContext) =
         pkgUrl.hasShortName = true
         pkgUrl.qualifiedName.name = pkgInfo.name
         c.nameToUrl[unicode.toLower(pkgInfo.name)] = pkgUrl
-        # c.urlToNames[pkgUrl.url] = pkgInfo.name
+        c.urlToUrl[$pkgUrl.url] = pkgUrl
 
     # now we add aliases to the lookup table
     for pkgAlias in aliases:

--- a/src/basic/osutils.nim
+++ b/src/basic/osutils.nim
@@ -1,7 +1,7 @@
 ## OS utilities like 'withDir'.
 ## (c) 2021 Andreas Rumpf
 
-import std / [os, paths, strutils, osproc, uri]
+import std / [os, paths, strutils, osproc, uri, dirs]
 import reporters
 
 export paths
@@ -71,6 +71,13 @@ proc nimbleExec*(cmd: string; args: openArray[string]) =
     cmdLine.add ' '
     cmdLine.add quoteShell(args[i])
   discard os.execShellCmd(cmdLine)
+
+proc findProjects*(path: Path): seq[Path] =
+  ## Finds child directories that look like git-backed projects.
+  result = @[]
+  for k, f in walkDir(path):
+    if k == pcDir and dirExists(f / Path".git"):
+      result.add(f)
 
 template withDir*(dir: Path; body: untyped) =
   let oldDir = paths.getCurrentDir()

--- a/src/basic/packageinfos.nim
+++ b/src/basic/packageinfos.nim
@@ -91,41 +91,53 @@ proc toTags*(j: JsonNode): seq[string] =
     for elem in items j:
       result.add elem.getStr("")
 
-proc getPackageInfos*(pkgsDir = packagesDirectory()): seq[PackageInfo] =
+proc packageInfosFile*(cacheDir = cachesDirectory()): Path =
+  cacheDir / Path"packages.json"
+
+proc removeLegacyPackageCaches*(gitDir = packagesDirectory()) =
+  let oldNimbleCachesDir = depsDir() / Path"_nimble"
+  if dirExists(oldNimbleCachesDir):
+    removeDir($oldNimbleCachesDir)
+
+  if PackagesGit notin context().flags and dirExists(gitDir):
+    removeDir($gitDir)
+
+proc getPackageInfos*(cacheDir = cachesDirectory()): seq[PackageInfo] =
   result = @[]
   var uniqueNames = initHashSet[string]()
-  var jsonFiles = 0
-  for kind, path in walkDir(pkgsDir):
-    if kind == pcFile and path.string.endsWith(".json"):
-      inc jsonFiles
-      let packages = json.parseFile($path)
-      for p in packages:
-        let pkg = p.fromJson()
-        if pkg != nil and not uniqueNames.containsOrIncl(pkg.name):
-          result.add(pkg)
+  let pkgsFile = packageInfosFile(cacheDir)
+  if not fileExists($pkgsFile):
+    return
 
-proc updatePackages*(pkgsDir = packagesDirectory()) =
-  let pkgsPath = pkgsDir
-  let pkgsParent = pkgsPath.parentDir()
-  if pkgsParent.len > 0 and not dirExists(pkgsParent):
-    createDir(pkgsParent)
+  let packages = json.parseFile($pkgsFile)
+  for p in packages:
+    let pkg = p.fromJson()
+    if pkg != nil and not uniqueNames.containsOrIncl(pkg.name):
+      result.add(pkg)
+
+proc updatePackages*(cacheDir = cachesDirectory(); gitDir = packagesDirectory()) =
+  if $cacheDir == $cachesDirectory():
+    removeLegacyPackageCaches(gitDir)
+
+  if cacheDir.len > 0 and not dirExists(cacheDir):
+    createDir(cacheDir)
+
+  let pkgsFile = packageInfosFile(cacheDir)
   if PackagesGit in context().flags:
-    ## TODO: remove later?
-    if dirExists(pkgsPath):
-      gitPull(pkgsPath)
+    if dirExists(gitDir):
+      gitPull(gitDir)
     else:
       let pkgsUrl = parseUri "https://github.com/nim-lang/packages"
-      let res = clone(pkgsUrl, pkgsPath)
+      let res = clone(pkgsUrl, gitDir)
       if res[0] != Ok:
         error DefaultPackagesSubDir, "cannot clone packages repo: " & res[1]
+    copyFile($(gitDir / Path"packages.json"), $pkgsFile)
   else:
-    if not dirExists(pkgsPath):
-      createDir(pkgsPath)
     let client = newHttpClient()
     try:
       let contents = client.getContent(PackagesJsonUrl)
-      writeFile($(pkgsPath / Path"packages.json"), contents)
+      writeFile($pkgsFile, contents)
     except CatchableError as e:
-      error DefaultPackagesSubDir, "cannot download packages.json: " & e.msg
+      error DefaultCachesSubDir, "cannot download packages.json: " & e.msg
     finally:
       client.close()

--- a/src/basic/packageutils.nim
+++ b/src/basic/packageutils.nim
@@ -1,0 +1,21 @@
+#
+#           Atlas Package Cloner
+#        (c) Copyright 2023 Andreas Rumpf
+#
+#    See the file "copying.txt", included in this
+#    distribution, for details about the copyright.
+#
+
+import std/[paths, dirs]
+import context, deptypes, pkgurls, reporters
+
+proc copyFromDisk*(pkg: Package, dest: Path): (CloneStatus, string) =
+  let source = pkg.url.toOriginalPath()
+  info pkg, "copyFromDisk cloning:", $dest, "from:", $source
+  if dirExists(source) and not dirExists(dest):
+    trace pkg, "copyFromDisk cloning:", $dest, "from:", $source
+    copyDir(source, dest)
+    result = (Ok, "")
+  else:
+    error pkg, "copyFromDisk not found:", $source
+    result = (NotFound, $dest)

--- a/src/basic/packageutils.nim
+++ b/src/basic/packageutils.nim
@@ -6,7 +6,7 @@
 #    distribution, for details about the copyright.
 #
 
-import std/[paths, dirs]
+import std/[os, paths, dirs]
 import context, deptypes, pkgurls, reporters
 
 proc copyFromDisk*(pkg: Package, dest: Path): (CloneStatus, string) =
@@ -14,7 +14,7 @@ proc copyFromDisk*(pkg: Package, dest: Path): (CloneStatus, string) =
   info pkg, "copyFromDisk cloning:", $dest, "from:", $source
   if dirExists(source) and not dirExists(dest):
     trace pkg, "copyFromDisk cloning:", $dest, "from:", $source
-    copyDir(source, dest)
+    os.copyDir($source, $dest)
     result = (Ok, "")
   else:
     error pkg, "copyFromDisk not found:", $source

--- a/src/confighandler.nim
+++ b/src/confighandler.nim
@@ -8,8 +8,8 @@
 
 ## Configuration handling.
 
-import std / [strutils, os, streams, json, tables, jsonutils, uri, sequtils]
-import basic/[versions, nimblecontext, deptypesjson, context, reporters, compiledpatterns, parse_requires, deptypes]
+import std / [algorithm, strutils, os, streams, json, tables, jsonutils, uri, sequtils]
+import basic/[versions, nimblecontext, deptypesjson, context, reporters, compiledpatterns, parse_requires, deptypes, pkgurls]
 
 proc readPluginsDir(dir: Path) =
   for k, f in walkDir($(project() / dir)):
@@ -25,6 +25,18 @@ type
     plugins*: string
     resolver*: string
     graph*: JsonNode
+
+  ActivatedPackage* = object
+    url*: PkgUrl
+    version*: string
+    commit*: CommitHash
+    features*: seq[string]
+    ondisk*: Path
+    srcDir*: Path
+    isRoot*: bool
+
+  ActivationCache* = object
+    packages*: seq[ActivatedPackage]
 
 proc writeDefaultConfigFile*() =
   let config = JsonConfig(
@@ -115,6 +127,53 @@ proc writeDepGraph*(g: DepGraph, debug: bool = false) =
     configFile = configFile.changeFileExt("debug.json")
   debug "atlas", "writing dep graph to: ", $configFile
   dumpJson(g, $configFile, pretty = true)
+
+proc removeDepGraphCache*() =
+  for configFile in [
+    depGraphCacheFile(context()),
+    depGraphCacheFile(context()).changeFileExt("debug.json")
+  ]:
+    if fileExists($configFile):
+      removeFile($configFile)
+
+proc toActivationCache*(g: DepGraph): ActivationCache =
+  for pkg in values(g.pkgs):
+    if not pkg.active or pkg.activeVersion.isNil:
+      continue
+
+    let rel = pkg.activeNimbleRelease()
+    var features = pkg.activeFeatures
+    features.sort()
+
+    result.packages.add ActivatedPackage(
+      url: pkg.url,
+      version: repr(pkg.activeVersion.vtag),
+      commit: pkg.activeVersion.commit(),
+      features: features,
+      ondisk: pkg.ondisk,
+      srcDir: if rel.isNil: Path"" else: rel.srcDir,
+      isRoot: pkg.isRoot
+    )
+
+  result.packages.sort(proc (a, b: ActivatedPackage): int =
+    cmp($a.url, $b.url)
+  )
+
+proc writeActivationCache*(g: DepGraph) =
+  let configFile = activationCacheFile()
+  createDir($configFile.parentDir())
+  debug "atlas", "writing activation cache to: ", $configFile
+  let jn = toJson(toActivationCache(g), ToJsonOptions(enumMode: joptEnumString))
+  writeFile($configFile, pretty(jn))
+
+proc loadActivationCache*(nimbleFile: Path): ActivationCache =
+  doAssert nimbleFile.isAbsolute() and endsWith($nimbleFile, ".nimble") and fileExists($nimbleFile)
+  let projectDir = nimbleFile.parentDir()
+  var ctx = AtlasContext(projectDir: projectDir)
+  readAtlasContext(ctx, projectDir)
+  let configFile = activationCacheFile(ctx)
+  debug "atlas", "reading activation cache from: ", $configFile
+  result.fromJson(parseFile($configFile), Joptions(allowMissingKeys: true, allowExtraKeys: true))
 
 proc loadDepGraph*(nc: var NimbleContext, nimbleFile: Path): DepGraph =
   doAssert nimbleFile.isAbsolute() and endsWith($nimbleFile, ".nimble") and fileExists($nimbleFile)

--- a/src/dependencies.nim
+++ b/src/dependencies.nim
@@ -11,6 +11,175 @@ import basic/[context, deptypes, versions, osutils, nimbleparser, reporters, git
 
 export deptypes, versions, deptypesjson
 
+type
+  NimbleFileSource = object
+    path: Path
+    fromGit: bool
+
+  PackageReleaseCacheEntry = object
+    vtag*: VersionTag
+    release*: NimbleRelease
+
+  PackageReleaseCache = object
+    cacheVersion*: int
+    url*: PkgUrl
+    head*: CommitHash
+    current*: CommitHash
+    includeTagsAndNimbleCommits*: bool
+    nimbleCommitsMax*: bool
+    releases*: seq[PackageReleaseCacheEntry]
+
+const PackageReleaseCacheVersion = 1
+
+proc packageCacheStem(url: PkgUrl): string =
+  result = url.fullName()
+  if result.len == 0:
+    result = url.projectName()
+  if result.len == 0:
+    result = $url
+
+  for c in mitems(result):
+    if c notin {'a'..'z', 'A'..'Z', '0'..'9', '.', '_', '-'}:
+      c = '_'
+
+proc packageReleaseCachePath(pkg: Package): Path =
+  cachesDirectory() / Path(packageCacheStem(pkg.url) & ".json")
+
+proc includeTagsAndNimbleCommitsFlag(): bool =
+  IncludeTagsAndNimbleCommits in context().flags
+
+proc nimbleCommitsMaxFlag(): bool =
+  NimbleCommitsMax in context().flags
+
+proc canUsePackageReleaseCache(pkg: Package; mode: TraversalMode; explicitVersions: seq[VersionTag]): bool =
+  mode == AllReleases and
+    explicitVersions.len == 0 and
+    not pkg.isRoot and
+    not pkg.isAtlasProject and
+    not pkg.url.isNimbleLink() and
+    not pkg.isLocalOnly
+
+proc findGitNimbleFiles(pkg: Package; commit: CommitHash): seq[NimbleFileSource] =
+  let files = listFiles(pkg.ondisk, commit)
+  for file in files:
+    if file.endsWith(".nimble"):
+      let source = NimbleFileSource(path: Path(file), fromGit: true)
+      if source.path.splitPath().tail == Path(pkg.url.shortName() & ".nimble"):
+        return @[source]
+      result.add source
+
+proc materializeNimbleFile(pkg: Package; commit: CommitHash; source: NimbleFileSource): Path =
+  if not source.fromGit:
+    return source.path
+
+  let tmpDir = cachesDirectory() / Path"_tmp"
+  createDir(cachesDirectory())
+  createDir(tmpDir)
+  result = tmpDir / Path(packageCacheStem(pkg.url) & "-" & commit.short() & "-" & $source.path.splitPath().tail)
+  writeFile($result, showFile(pkg.ondisk, commit, $source.path))
+
+proc isForkUrl(nc: NimbleContext; url: PkgUrl): bool
+proc childDependencyState(pkg: Package; deferChildDeps: bool): PackageState
+
+proc registerReleaseDependencies(
+    nc: var NimbleContext;
+    pkg: Package;
+    release: NimbleRelease;
+    deferChildDeps: bool
+) =
+  if release.status != Normal:
+    return
+
+  for pkgUrl, interval in items(release.requirements):
+    # debug pkg.url.projectName, "INTERVAL: ", $interval, "isSpecial:", $interval.isSpecial, "explicit:", $interval.extractSpecificCommit()
+    if interval.isSpecial:
+      let commit = interval.extractSpecificCommit()
+      nc.explicitVersions.mgetOrPut(pkgUrl, initHashSet[VersionTag]()).incl(VersionTag(v: Version($(interval)), c: commit))
+
+    let state = childDependencyState(pkg, deferChildDeps)
+    if pkgUrl notin nc.packageToDependency:
+      debug pkg.url.projectName, "Found new pkg:", pkgUrl.projectName, "url:", $pkgUrl.url, "projectName:", $pkgUrl.projectName, "state:", $state
+      # debug pkg.url.projectName, "Found new pkg:", pkgUrl.projectName, "repr:", $pkgUrl.repr
+      let pkgDep = Package(url: pkgUrl, state: state, isFork: isForkUrl(nc, pkgUrl))
+      nc.packageToDependency[pkgUrl] = pkgDep
+    else:
+      if nc.packageToDependency[pkgUrl].state == LazyDeferred and state != LazyDeferred:
+        warn pkg.url.projectName, "Changing LazyDeferred pkg to DoLoad:", $pkgUrl.url
+        nc.packageToDependency[pkgUrl].state = DoLoad
+
+  for feature, rq in release.features:
+    for pkgUrl, interval in items(rq):
+      if interval.isSpecial:
+        let commit = interval.extractSpecificCommit()
+        nc.explicitVersions.mgetOrPut(pkgUrl, initHashSet[VersionTag]()).incl(VersionTag(v: Version($(interval)), c: commit))
+      if pkgUrl notin nc.packageToDependency:
+        let state =
+          if feature notin context().features: LazyDeferred
+          else: childDependencyState(pkg, deferChildDeps)
+        debug pkg.url.projectName, "Found new feature pkg:", pkgUrl.projectName, "url:", $pkgUrl.url, "projectName:", $pkgUrl.projectName, "state:", $state
+        let pkgDep = Package(url: pkgUrl, state: state, isFork: isForkUrl(nc, pkgUrl))
+        nc.packageToDependency[pkgUrl] = pkgDep
+      elif feature in context().features and nc.packageToDependency[pkgUrl].state == LazyDeferred and childDependencyState(pkg, deferChildDeps) != LazyDeferred:
+        warn pkg.url.projectName, "Changing LazyDeferred feature pkg to DoLoad:", $pkgUrl.url
+        nc.packageToDependency[pkgUrl].state = DoLoad
+
+proc enrichPackageDependencies(
+    nc: var NimbleContext;
+    pkg: Package;
+    deferChildDeps: bool
+) =
+  ## Enrich the traversal context from already-loaded package release info.
+  ## This is intentionally separate from release parsing/cache loading.
+  for _, release in pkg.versions:
+    nc.registerReleaseDependencies(pkg, release, deferChildDeps)
+
+proc loadPackageReleaseCache(pkg: Package; currentCommit: CommitHash; entries: var seq[PackageReleaseCacheEntry]): bool =
+  if pkg.originHead.isEmpty():
+    return false
+
+  let cachePath = packageReleaseCachePath(pkg)
+  if not fileExists($cachePath):
+    return false
+
+  var cache: PackageReleaseCache
+  try:
+    cache.fromJson(parseFile($cachePath), Joptions(allowMissingKeys: true, allowExtraKeys: true))
+  except CatchableError as e:
+    warn pkg.url.projectName, "ignoring invalid dependency cache:", $cachePath, "error:", e.msg
+    return false
+
+  result =
+    cache.cacheVersion == PackageReleaseCacheVersion and
+    cache.url == pkg.url and
+    cache.head == pkg.originHead and
+    cache.current == currentCommit and
+    cache.includeTagsAndNimbleCommits == includeTagsAndNimbleCommitsFlag() and
+    cache.nimbleCommitsMax == nimbleCommitsMaxFlag()
+
+  if result:
+    entries = cache.releases
+    debug pkg.url.projectName, "loaded dependency cache:", $cachePath, "releases:", $entries.len
+
+proc savePackageReleaseCache(pkg: Package; currentCommit: CommitHash; versions: seq[(PackageVersion, NimbleRelease)]) =
+  if pkg.originHead.isEmpty():
+    return
+
+  var cache = PackageReleaseCache(
+    cacheVersion: PackageReleaseCacheVersion,
+    url: pkg.url,
+    head: pkg.originHead,
+    current: currentCommit,
+    includeTagsAndNimbleCommits: includeTagsAndNimbleCommitsFlag(),
+    nimbleCommitsMax: nimbleCommitsMaxFlag()
+  )
+  for (ver, release) in versions:
+    cache.releases.add PackageReleaseCacheEntry(vtag: ver.vtag, release: release)
+
+  createDir(cachesDirectory())
+  let cachePath = packageReleaseCachePath(pkg)
+  writeFile($cachePath, pretty(toJson(cache, ToJsonOptions(enumMode: joptEnumString))))
+  debug pkg.url.projectName, "wrote dependency cache:", $cachePath, "releases:", $cache.releases.len
+
 proc collectNimbleVersions*(nc: NimbleContext; pkg: Package): seq[VersionTag] =
   let nimbleFiles = findNimbleFile(pkg)
   let dir = pkg.ondisk
@@ -59,16 +228,16 @@ proc processNimbleRelease(
 ): NimbleRelease =
   trace pkg.url.projectName, "Processing release:", $release
 
-  var nimbleFiles: seq[Path]
+  var nimbleFiles: seq[NimbleFileSource]
   if release.version == Version"#head":
     trace pkg.url.projectName, "processRelease using current commit"
-    nimbleFiles = findNimbleFile(pkg)
+    nimbleFiles = findNimbleFile(pkg).mapIt(NimbleFileSource(path: it, fromGit: false))
   elif release.commit.isEmpty():
     warn pkg.url.projectName, "processRelease missing commit ", $release, "at:", $pkg.ondisk
     result = NimbleRelease(status: HasBrokenRelease, err: "no commit")
     return
   else:
-    nimbleFiles = cacheNimbleFilesFromGit(pkg, release.commit)
+    nimbleFiles = findGitNimbleFiles(pkg, release.commit)
 
     # warn pkg.url.projectName, "processRelease unable to checkout commit ", $release, "at:", $pkg.ondisk
     # result = NimbleRelease(status: HasBrokenRelease, err: "error checking out release")
@@ -77,45 +246,16 @@ proc processNimbleRelease(
     info "processRelease", "skipping release: missing nimble file:", $release
     result = NimbleRelease(status: HasUnknownNimbleFile, err: "missing nimble file")
   elif nimbleFiles.len() > 1:
-    info "processRelease", "skipping release: ambiguous nimble file:", $release, "files:", $(nimbleFiles.mapIt(it.splitPath().tail).join(", "))
+    info "processRelease", "skipping release: ambiguous nimble file:", $release, "files:", $(nimbleFiles.mapIt($it.path.splitPath().tail).join(", "))
     result = NimbleRelease(status: HasUnknownNimbleFile, err: "ambiguous nimble file")
   else:
-    let nimbleFile = nimbleFiles[0]
-    result = nc.parseNimbleFile(nimbleFile)
-
-    if result.status == Normal:
-      for pkgUrl, interval in items(result.requirements):
-        # debug pkg.url.projectName, "INTERVAL: ", $interval, "isSpecial:", $interval.isSpecial, "explicit:", $interval.extractSpecificCommit()
-        if interval.isSpecial:
-          let commit = interval.extractSpecificCommit()
-          nc.explicitVersions.mgetOrPut(pkgUrl, initHashSet[VersionTag]()).incl(VersionTag(v: Version($(interval)), c: commit))
-
-        let state = childDependencyState(pkg, deferChildDeps)
-        if pkgUrl notin nc.packageToDependency:
-          debug pkg.url.projectName, "Found new pkg:", pkgUrl.projectName, "url:", $pkgUrl.url, "projectName:", $pkgUrl.projectName, "state:", $state
-          # debug pkg.url.projectName, "Found new pkg:", pkgUrl.projectName, "repr:", $pkgUrl.repr
-          let pkgDep = Package(url: pkgUrl, state: state, isFork: isForkUrl(nc, pkgUrl))
-          nc.packageToDependency[pkgUrl] = pkgDep
-        else:
-          if nc.packageToDependency[pkgUrl].state == LazyDeferred and state != LazyDeferred:
-            warn pkg.url.projectName, "Changing LazyDeferred pkg to DoLoad:", $pkgUrl.url
-            nc.packageToDependency[pkgUrl].state = DoLoad
-
-      for feature, rq in result.features:
-        for pkgUrl, interval in items(rq):
-          if interval.isSpecial:
-            let commit = interval.extractSpecificCommit()
-            nc.explicitVersions.mgetOrPut(pkgUrl, initHashSet[VersionTag]()).incl(VersionTag(v: Version($(interval)), c: commit))
-          if pkgUrl notin nc.packageToDependency:
-            let state =
-              if feature notin context().features: LazyDeferred
-              else: childDependencyState(pkg, deferChildDeps)
-            debug pkg.url.projectName, "Found new feature pkg:", pkgUrl.projectName, "url:", $pkgUrl.url, "projectName:", $pkgUrl.projectName, "state:", $state
-            let pkgDep = Package(url: pkgUrl, state: state, isFork: isForkUrl(nc, pkgUrl))
-            nc.packageToDependency[pkgUrl] = pkgDep
-          elif feature in context().features and nc.packageToDependency[pkgUrl].state == LazyDeferred and childDependencyState(pkg, deferChildDeps) != LazyDeferred:
-            warn pkg.url.projectName, "Changing LazyDeferred feature pkg to DoLoad:", $pkgUrl.url
-            nc.packageToDependency[pkgUrl].state = DoLoad
+    let source = nimbleFiles[0]
+    let nimbleFile = materializeNimbleFile(pkg, release.commit, source)
+    try:
+      result = nc.parseNimbleFile(nimbleFile)
+    finally:
+      if source.fromGit and fileExists($nimbleFile):
+        removeFile($nimbleFile)
 
 proc addFeatureDependencies(pkg: Package) =
 
@@ -187,6 +327,16 @@ proc traverseDependency*(
   if not pkg.isLocalOnly:
     discard gitops.ensureCanonicalOrigin(pkg.ondisk, pkg.url.toUri)
   pkg.originHead = gitops.findOriginTip(pkg.ondisk, errorReportLevel = Warning, isLocalOnly = pkg.isLocalOnly).commit()
+
+  if canUsePackageReleaseCache(pkg, mode, expandedExplicitVersions):
+    var cachedReleases: seq[PackageReleaseCacheEntry]
+    if loadPackageReleaseCache(pkg, currentCommit, cachedReleases):
+      pkg.versions.clear()
+      for entry in cachedReleases:
+        pkg.versions[entry.vtag.toPkgVer()] = entry.release
+      pkg.state = Processed
+      nc.enrichPackageDependencies(pkg, deferChildDeps)
+      return
 
   if mode == CurrentCommit and currentCommit.isEmpty():
     discard
@@ -306,8 +456,13 @@ proc traverseDependency*(
   # TODO: filter by unique versions first?
   pkg.state = Processed
 
+  nc.enrichPackageDependencies(pkg, deferChildDeps)
+
   if pkg.isRoot and context().features.len > 0:
     addFeatureDependencies(pkg)
+
+  if canUsePackageReleaseCache(pkg, mode, expandedExplicitVersions):
+    savePackageReleaseCache(pkg, currentCommit, pkg.versions.pairs().toSeq())
 
 
 proc loadDependency*(

--- a/src/dependencies.nim
+++ b/src/dependencies.nim
@@ -229,11 +229,10 @@ proc loadDependency*(
           gitops.clone(pkg.url.toUri, pkg.ondisk)
       if status == Ok:
         if not pkg.isLocalOnly:
-          discard gitops.ensureCanonicalOrigin(pkg.ondisk, pkg.url.toUri)
-          discard gitops.resolveRemoteName(pkg.ondisk)
+          var repo = gitops.loadRepoMetadata(pkg.ondisk, expectedCanonicalUrl = $pkg.url.toUri)
           if isFork:
             discard gitops.ensureRemoteForUrl(pkg.ondisk, officialUrl.toUri)
-          discard gitops.fetchRemoteTags(pkg.ondisk)
+          discard gitops.fetchRemoteTags(repo)
         pkg.state = Found
       else:
         pkg.state = Error
@@ -242,14 +241,14 @@ proc loadDependency*(
     if pkg.ondisk.dirExists():
       pkg.state = Found
       if not pkg.isLocalOnly:
-        discard gitops.ensureCanonicalOrigin(pkg.ondisk, pkg.url.toUri)
-        discard gitops.resolveRemoteName(pkg.ondisk)
+        discard gitops.loadRepoMetadata(pkg.ondisk, expectedCanonicalUrl = $pkg.url.toUri)
         if isFork:
           discard gitops.ensureRemoteForUrl(pkg.ondisk, officialUrl.toUri)
       if UpdateRepos in context().flags:
         gitops.updateRepo(pkg.ondisk)
         if not pkg.isLocalOnly:
-          discard gitops.fetchRemoteTags(pkg.ondisk)
+          var repo = gitops.loadRepoMetadata(pkg.ondisk, expectedCanonicalUrl = $pkg.url.toUri)
+          discard gitops.fetchRemoteTags(repo)
         
     else:
       pkg.state = Error

--- a/src/dependencies.nim
+++ b/src/dependencies.nim
@@ -11,8 +11,11 @@ import basic/[context, deptypes, versions, osutils, nimbleparser, reporters, git
 
 export deptypes, versions, deptypesjson
 
-## Returns the initial package state to use for dependencies discovered from a release.
-proc childDependencyState(pkg: Package; deferChildDeps: bool): PackageState
+proc childDependencyState(pkg: Package; deferChildDeps: bool): PackageState =
+  ## Returns the initial state for newly discovered child dependencies.
+  ## Non-root children are marked lazy when `deferChildDeps` is enabled.
+  if deferChildDeps and not pkg.isRoot: LazyDeferred
+  else: NotInitialized
 
 proc registerReleaseDependencies(
     nc: var NimbleContext;
@@ -81,12 +84,6 @@ proc collectNimbleVersions*(nc: NimbleContext; pkg: Package): seq[VersionTag] =
 type
   PackageAction* = enum
     DoNothing, DoClone
-
-proc childDependencyState(pkg: Package; deferChildDeps: bool): PackageState =
-  ## Returns the initial state for newly discovered child dependencies.
-  ## Non-root children are marked lazy when `deferChildDeps` is enabled.
-  if deferChildDeps and not pkg.isRoot: LazyDeferred
-  else: NotInitialized
 
 proc processNimbleRelease(
     nc: var NimbleContext;

--- a/src/dependencies.nim
+++ b/src/dependencies.nim
@@ -6,10 +6,19 @@
 #    distribution, for details about the copyright.
 #
 
-import std / [os, strutils, uri, tables, sequtils, sets, hashes, algorithm, paths, dirs]
-import basic/[context, deptypes, versions, osutils, nimbleparser, reporters, gitops, pkgurls, nimblecontext, deptypesjson, dependencycache, packageutils]
+## Dependency graph expansion and package loading.
+##
+## This module turns a workspace root into a dependency graph by locating or
+## cloning packages, loading their release metadata through `releaseinfo`, and
+## registering requirements discovered in Nimble files. It also handles lazy
+## dependency deferral, explicit commit requirements, and root feature
+## dependencies during traversal.
 
-export deptypes, versions, deptypesjson
+import std / [os, strutils, uri, tables, sequtils, sets, hashes, paths, dirs]
+import basic/[context, deptypes, versions, osutils, reporters, gitops, pkgurls, nimblecontext, deptypesjson, packageutils]
+import releaseinfo
+
+export deptypes, versions, deptypesjson, releaseinfo
 
 proc childDependencyState(pkg: Package; deferChildDeps: bool): PackageState =
   ## Returns the initial state for newly discovered child dependencies.
@@ -69,57 +78,9 @@ proc enrichPackageDependencies(
   for _, release in pkg.versions:
     nc.registerReleaseDependencies(pkg, release, deferChildDeps)
 
-proc collectNimbleVersions*(nc: NimbleContext; pkg: Package): seq[VersionTag] =
-  ## Collects commits that modified the package's Nimble file.
-  ## These commits are used as fallback release candidates when tags are absent.
-  let nimbleFiles = findNimbleFile(pkg)
-  let dir = pkg.ondisk
-  doAssert(pkg.ondisk.string != "", "Package ondisk must be set before collectNimbleVersions can be called! Package: " & $(pkg))
-  result = @[]
-  if nimbleFiles.len() == 1:
-    result = collectFileCommits(dir, nimbleFiles[0], isLocalOnly = pkg.isLocalOnly)
-    result.reverse()
-    trace pkg, "collectNimbleVersions commits:", mapIt(result, it.c.short()).join(", "), "nimble:", $nimbleFiles[0]
-
 type
   PackageAction* = enum
     DoNothing, DoClone
-
-proc processNimbleRelease(
-    nc: var NimbleContext;
-    pkg: Package,
-    release: VersionTag;
-    deferChildDeps: bool
-): NimbleRelease =
-  ## Loads and parses the Nimble file for a specific package release candidate.
-  ## Historical releases are read from git contents and materialized only temporarily.
-  trace pkg.url.projectName, "Processing release:", $release
-
-  var nimbleFiles: seq[NimbleFileSource]
-  if release.version == Version"#head":
-    trace pkg.url.projectName, "processRelease using current commit"
-    nimbleFiles = findNimbleFile(pkg).mapIt(NimbleFileSource(path: it, fromGit: false))
-  elif release.commit.isEmpty():
-    warn pkg.url.projectName, "processRelease missing commit ", $release, "at:", $pkg.ondisk
-    result = NimbleRelease(status: HasBrokenRelease, err: "no commit")
-    return
-  else:
-    nimbleFiles = findGitNimbleFiles(pkg, release.commit)
-
-  if nimbleFiles.len() == 0:
-    info "processRelease", "skipping release: missing nimble file:", $release
-    result = NimbleRelease(status: HasUnknownNimbleFile, err: "missing nimble file")
-  elif nimbleFiles.len() > 1:
-    info "processRelease", "skipping release: ambiguous nimble file:", $release, "files:", $(nimbleFiles.mapIt($it.path.splitPath().tail).join(", "))
-    result = NimbleRelease(status: HasUnknownNimbleFile, err: "ambiguous nimble file")
-  else:
-    let source = nimbleFiles[0]
-    let nimbleFile = materializeNimbleFile(pkg, release.commit, source)
-    try:
-      result = nc.parseNimbleFile(nimbleFile)
-    finally:
-      if source.fromGit and fileExists($nimbleFile):
-        removeFile($nimbleFile)
 
 proc addFeatureDependencies(pkg: Package) =
   ## Marks root package feature requirements as active when requested by context flags.
@@ -148,36 +109,6 @@ proc addFeatureDependencies(pkg: Package) =
     warn pkg.url.projectName, "feature dependencies added"
     pkg.state = Found
 
-proc addRelease(
-    versions: var seq[(PackageVersion, NimbleRelease)],
-    nc: var NimbleContext;
-    pkg: Package,
-    vtag: VersionTag;
-    deferChildDeps: bool
-): bool =
-  ## Parses one release candidate and appends it to the pending version list.
-  ## The returned release version is normalized against tag or Nimble-file metadata.
-  var pkgver = vtag.toPkgVer()
-  trace pkg.url.projectName, "Adding Nimble version:", $vtag
-  try:
-    let release = nc.processNimbleRelease(pkg, vtag, deferChildDeps)
-
-    if vtag.v.string == "":
-      pkgver.vtag.v = release.version
-      trace pkg.url.projectName, "updating release tag information:", $pkgver.vtag
-    elif release.version.string == "":
-      warn pkg.url.projectName, "nimble file missing version information:", $pkgver.vtag
-      release.version = vtag.version
-    elif vtag.v != release.version and not pkg.isRoot:
-      info pkg.url.projectName, "version mismatch between version tag:", $vtag.v, "and nimble version:", $release.version
-    
-    versions.add((pkgver, release))
-
-    result = true
-  except CatchableError as e:
-    info pkg.url.projectName, "error processing nimble release:", $vtag, "error:", $e.msg
-    return false
-
 proc traverseDependency*(
     nc: var NimbleContext;
     pkg: var Package,
@@ -186,136 +117,24 @@ proc traverseDependency*(
     deferChildDeps = false;
 ) =
   ## Resolves the set of package releases for a found dependency.
-  ## Results are enriched into traversal state and may be loaded from or saved to cache.
+  ## Release metadata is loaded separately, then enriched into traversal state.
   doAssert pkg.ondisk.dirExists() and pkg.state != NotInitialized, "Package should've been found or cloned at this point. Package: " & $pkg.url & " on disk: " & $pkg.ondisk
 
-  var versions: seq[(PackageVersion, NimbleRelease)]
-  var expandedExplicitVersions = explicitVersions
-
-  let currentCommit = currentGitCommit(pkg.ondisk, Warning)
-  if not pkg.isLocalOnly:
-    discard gitops.ensureCanonicalOrigin(pkg.ondisk, pkg.url.toUri)
-  pkg.originHead = gitops.findOriginTip(pkg.ondisk, errorReportLevel = Warning, isLocalOnly = pkg.isLocalOnly).commit()
-
-  if canUsePackageReleaseCache(pkg, mode, expandedExplicitVersions):
-    var cachedReleases: seq[PackageReleaseCacheEntry]
-    if loadPackageReleaseCache(pkg, currentCommit, cachedReleases):
-      pkg.versions.clear()
-      for entry in cachedReleases:
-        pkg.versions[entry.vtag.toPkgVer()] = entry.release
-      pkg.state = Processed
-      nc.enrichPackageDependencies(pkg, deferChildDeps)
-      return
-
-  if mode == CurrentCommit and currentCommit.isEmpty():
-    discard
-  elif currentCommit.isEmpty():
-    warn pkg.url.projectName, "traversing dependency unable to find git current version at ", $pkg.ondisk
-    let vtag = VersionTag(v: Version"#head", c: initCommitHash("", FromHead))
-    versions.add((vtag.toPkgVer, NimbleRelease(version: vtag.version, status: HasBrokenRepo)))
+  let releaseInfo = nc.loadPackageReleaseInfo(pkg, mode, explicitVersions)
+  if releaseInfo.repoError:
     pkg.state = Error
     return
-  else:
-    trace pkg.url.projectName, "traversing dependency current commit:", $currentCommit
 
-  case mode
-  of CurrentCommit:
-    trace pkg.url.projectName, "traversing dependency for only current commit"
-    let vtag = VersionTag(v: Version"#head", c: initCommitHash(currentCommit, FromHead))
-    discard versions.addRelease(nc, pkg, vtag, deferChildDeps)
+  if releaseInfo.loadedFromCache:
+    pkg.versions.clear()
 
-  of ExplicitVersions:
-    debug pkg.url.projectName, "traversing dependency found explicit versions:", $expandedExplicitVersions
-
-    var uniqueCommits: HashSet[CommitHash]
-    for ver in pkg.versions.keys():
-      uniqueCommits.incl(ver.vtag.c)
-
-    # Expand short hashes, branches, and #head before loading explicit releases.
-    for version in mitems(expandedExplicitVersions):
-      let vtag = gitops.expandSpecial(pkg.ondisk, vtag = version)
-      version = vtag
-      debug pkg.url.projectName, "explicit version:", $version, "vtag:", repr vtag
-
-    for version in expandedExplicitVersions:
-      debug pkg.url.projectName, "check explicit version:", repr version
-      if version.commit.isEmpty():
-        warn pkg.url.projectName, "explicit version has empty commit:", $version
-      elif not uniqueCommits.containsOrIncl(version.commit):
-        debug pkg.url.projectName, "add explicit version:", $version
-        discard versions.addRelease(nc, pkg, version, deferChildDeps)
-
-  of AllReleases:
-    try:
-      var uniqueCommits: HashSet[CommitHash]
-      var nimbleVersions: HashSet[Version]
-      var nimbleCommits = nc.collectNimbleVersions(pkg)
-
-      debug pkg.url.projectName, "nimble explicit versions:", $explicitVersions
-      for version in explicitVersions:
-        var vtag = gitops.expandSpecial(pkg.ondisk, vtag = version)
-        if not vtag.commit.isEmpty() and not uniqueCommits.containsOrIncl(vtag.commit):
-          discard versions.addRelease(nc, pkg, vtag, deferChildDeps)
-
-      # Prefer tagged versions over versions inferred from Nimble-file history.
-      let tags = collectTaggedVersions(pkg.ondisk, isLocalOnly = pkg.isLocalOnly)
-      debug pkg.url.projectName, "nimble tags:", $tags
-      for tag in tags:
-        if not uniqueCommits.containsOrIncl(tag.c):
-          discard versions.addRelease(nc, pkg, tag, deferChildDeps)
-          assert tag.commit.orig == FromGitTag, "maybe this needs to be overriden like before: " & $tag.commit.orig
-
-      if tags.len() == 0 or IncludeTagsAndNimbleCommits in context().flags:
-        # Use Nimble-file commit versions only when tags are absent or explicitly requested.
-        # Otherwise deleted tags could be reintroduced as inferred releases.
-        if NimbleCommitsMax in context().flags:
-          # Reverse the order so the newest commit is preferred for each version.
-          nimbleCommits.reverse()
-
-        debug pkg.url.projectName, "nimble commits:", $nimbleCommits
-        for tag in nimbleCommits:
-          if not uniqueCommits.containsOrIncl(tag.c):
-            var vers: seq[(PackageVersion, NimbleRelease)]
-            let added = vers.addRelease(nc, pkg, tag, deferChildDeps)
-            if added and not nimbleVersions.containsOrIncl(vers[0][0].vtag.v):
-              versions.add(vers)
-          else:
-            error pkg.url.projectName, "traverseDependency skipping nimble commit:", $tag, "uniqueCommits:", $(tag.c in uniqueCommits), "nimbleVersions:", $(tag.v in nimbleVersions)
-
-        if not currentCommit.isEmpty() and not uniqueCommits.containsOrIncl(currentCommit):
-          # Existing checkouts can be detached or on a non-default branch.
-          # Include their current nimble version when remote-tip traversal misses it.
-          var vers: seq[(PackageVersion, NimbleRelease)]
-          let currentTag = VersionTag(v: Version"", c: currentCommit)
-          let added = vers.addRelease(nc, pkg, currentTag, deferChildDeps)
-          if added and not nimbleVersions.containsOrIncl(vers[0][0].vtag.v):
-            versions.add(vers)
-
-      if versions.len() == 0:
-        let vtag = VersionTag(v: Version"#head", c: initCommitHash(currentCommit, FromHead))
-        debug pkg.url.projectName, "traverseDependency no versions found, using default #head", "at", $pkg.ondisk
-        discard versions.addRelease(nc, pkg, vtag, deferChildDeps)
-
-    finally:
-      if not checkoutGitCommit(pkg.ondisk, currentCommit, Warning):
-        info pkg.url.projectName, "traverseDependency error loading versions reverting to ", $currentCommit
-
-  # Make identical NimbleReleases share the same ref object.
-  var uniqueReleases: Table[NimbleRelease, NimbleRelease]
-  for (ver, rel) in versions:
-    if rel notin uniqueReleases:
-      uniqueReleases[rel] = rel
-    else:
-      trace pkg.url.projectName, "found duplicate release requirements at:", $ver.vtag
-
-  info pkg.url.projectName, "unique versions found:", uniqueReleases.values().toSeq().mapIt($it.version).join(", ")
-  for (ver, rel) in versions:
+  for (ver, rel) in releaseInfo.releases:
     if mode != ExplicitVersions and ver in pkg.versions:
       error pkg.url.projectName, "duplicate release found:", $ver.vtag, "new:", repr(rel)
       error pkg.url.projectName, "... existing: ", repr(pkg.versions[ver])
       error pkg.url.projectName, "duplicate release found:", $ver.vtag, "new:", repr(rel), " existing: ", repr(pkg.versions[ver])
       error pkg.url.projectName, "versions table:", $pkg.versions.keys().toSeq()
-    pkg.versions[ver] = uniqueReleases[rel]
+    pkg.versions[ver] = rel
 
   # Release entries are now loaded; enrichment below registers their dependencies.
   pkg.state = Processed
@@ -324,10 +143,6 @@ proc traverseDependency*(
 
   if pkg.isRoot and context().features.len > 0:
     addFeatureDependencies(pkg)
-
-  if canUsePackageReleaseCache(pkg, mode, expandedExplicitVersions):
-    savePackageReleaseCache(pkg, currentCommit, pkg.versions.pairs().toSeq())
-
 
 proc loadDependency*(
     nc: NimbleContext,

--- a/src/dependencies.nim
+++ b/src/dependencies.nim
@@ -11,6 +11,7 @@ import basic/[context, deptypes, versions, osutils, nimbleparser, reporters, git
 
 export deptypes, versions, deptypesjson
 
+## Returns the initial package state to use for dependencies discovered from a release.
 proc childDependencyState(pkg: Package; deferChildDeps: bool): PackageState
 
 proc registerReleaseDependencies(
@@ -19,6 +20,8 @@ proc registerReleaseDependencies(
     release: NimbleRelease;
     deferChildDeps: bool
 ) =
+  ## Registers dependency edges discovered in a loaded Nimble release.
+  ## This also records explicit commit requirements for later traversal.
   if release.status != Normal:
     return
 
@@ -58,12 +61,14 @@ proc enrichPackageDependencies(
     pkg: Package;
     deferChildDeps: bool
 ) =
-  ## Enrich the traversal context from already-loaded package release info.
+  ## Enriches the traversal context from already-loaded package release info.
   ## This is intentionally separate from release parsing/cache loading.
   for _, release in pkg.versions:
     nc.registerReleaseDependencies(pkg, release, deferChildDeps)
 
 proc collectNimbleVersions*(nc: NimbleContext; pkg: Package): seq[VersionTag] =
+  ## Collects commits that modified the package's Nimble file.
+  ## These commits are used as fallback release candidates when tags are absent.
   let nimbleFiles = findNimbleFile(pkg)
   let dir = pkg.ondisk
   doAssert(pkg.ondisk.string != "", "Package ondisk must be set before collectNimbleVersions can be called! Package: " & $(pkg))
@@ -89,6 +94,8 @@ proc processNimbleRelease(
     release: VersionTag;
     deferChildDeps: bool
 ): NimbleRelease =
+  ## Loads and parses the Nimble file for a specific package release candidate.
+  ## Historical releases are read from git contents and materialized only temporarily.
   trace pkg.url.projectName, "Processing release:", $release
 
   var nimbleFiles: seq[NimbleFileSource]
@@ -118,6 +125,8 @@ proc processNimbleRelease(
         removeFile($nimbleFile)
 
 proc addFeatureDependencies(pkg: Package) =
+  ## Marks root package feature requirements as active when requested by context flags.
+  ## This can reopen root processing so newly enabled feature dependencies are traversed.
 
   var featuresAdded = false
   warn pkg.url.projectName, "adding feature dependencies for root package; features:", $(context().features.toSeq().join(", ")), "versions:", $(pkg.versions.keys().toSeq().mapIt($it).join(", "))
@@ -144,12 +153,13 @@ proc addFeatureDependencies(pkg: Package) =
 
 proc addRelease(
     versions: var seq[(PackageVersion, NimbleRelease)],
-    # pkg: var Package,
     nc: var NimbleContext;
     pkg: Package,
     vtag: VersionTag;
     deferChildDeps: bool
 ): bool =
+  ## Parses one release candidate and appends it to the pending version list.
+  ## The returned release version is normalized against tag or Nimble-file metadata.
   var pkgver = vtag.toPkgVer()
   trace pkg.url.projectName, "Adding Nimble version:", $vtag
   try:
@@ -178,6 +188,8 @@ proc traverseDependency*(
     explicitVersions: seq[VersionTag];
     deferChildDeps = false;
 ) =
+  ## Resolves the set of package releases for a found dependency.
+  ## Results are enriched into traversal state and may be loaded from or saved to cache.
   doAssert pkg.ondisk.dirExists() and pkg.state != NotInitialized, "Package should've been found or cloned at this point. Package: " & $pkg.url & " on disk: " & $pkg.ondisk
 
   var versions: seq[(PackageVersion, NimbleRelease)]
@@ -222,7 +234,7 @@ proc traverseDependency*(
     for ver in pkg.versions.keys():
       uniqueCommits.incl(ver.vtag.c)
 
-    # get full hash from short hashes
+    # Expand short hashes, branches, and #head before loading explicit releases.
     for version in mitems(expandedExplicitVersions):
       let vtag = gitops.expandSpecial(pkg.ondisk, vtag = version)
       version = vtag
@@ -248,7 +260,7 @@ proc traverseDependency*(
         if not vtag.commit.isEmpty() and not uniqueCommits.containsOrIncl(vtag.commit):
           discard versions.addRelease(nc, pkg, vtag, deferChildDeps)
 
-      ## Note: always prefer tagged versions
+      # Prefer tagged versions over versions inferred from Nimble-file history.
       let tags = collectTaggedVersions(pkg.ondisk, isLocalOnly = pkg.isLocalOnly)
       debug pkg.url.projectName, "nimble tags:", $tags
       for tag in tags:
@@ -257,16 +269,15 @@ proc traverseDependency*(
           assert tag.commit.orig == FromGitTag, "maybe this needs to be overriden like before: " & $tag.commit.orig
 
       if tags.len() == 0 or IncludeTagsAndNimbleCommits in context().flags:
-        ## Note: skip nimble commit versions unless explicitly enabled
-        ## package maintainers may delete a tag to skip a versions, which we'd override here
+        # Use Nimble-file commit versions only when tags are absent or explicitly requested.
+        # Otherwise deleted tags could be reintroduced as inferred releases.
         if NimbleCommitsMax in context().flags:
-          # reverse the order so the newest commit is preferred for new versions
+          # Reverse the order so the newest commit is preferred for each version.
           nimbleCommits.reverse()
 
         debug pkg.url.projectName, "nimble commits:", $nimbleCommits
         for tag in nimbleCommits:
           if not uniqueCommits.containsOrIncl(tag.c):
-            # trace pkg.url.projectName, "traverseDependency adding nimble commit:", $tag
             var vers: seq[(PackageVersion, NimbleRelease)]
             let added = vers.addRelease(nc, pkg, tag, deferChildDeps)
             if added and not nimbleVersions.containsOrIncl(vers[0][0].vtag.v):
@@ -292,11 +303,10 @@ proc traverseDependency*(
       if not checkoutGitCommit(pkg.ondisk, currentCommit, Warning):
         info pkg.url.projectName, "traverseDependency error loading versions reverting to ", $currentCommit
 
-  # make sure identicle NimbleReleases refer to the same ref
+  # Make identical NimbleReleases share the same ref object.
   var uniqueReleases: Table[NimbleRelease, NimbleRelease]
   for (ver, rel) in versions:
     if rel notin uniqueReleases:
-      # trace pkg.url.projectName, "found unique release requirements at:", $ver.vtag
       uniqueReleases[rel] = rel
     else:
       trace pkg.url.projectName, "found duplicate release requirements at:", $ver.vtag
@@ -310,7 +320,7 @@ proc traverseDependency*(
       error pkg.url.projectName, "versions table:", $pkg.versions.keys().toSeq()
     pkg.versions[ver] = uniqueReleases[rel]
 
-  # TODO: filter by unique versions first?
+  # Release entries are now loaded; enrichment below registers their dependencies.
   pkg.state = Processed
 
   nc.enrichPackageDependencies(pkg, deferChildDeps)
@@ -327,6 +337,8 @@ proc loadDependency*(
     pkg: var Package,
     onClone: PackageAction = DoClone,
 ) = 
+  ## Ensures a package has an on-disk location and marks it ready for traversal.
+  ## Depending on URL and policy this may clone, copy, reuse, update, or defer the package.
   if pkg.isRoot:
     pkg.ondisk = project()
     pkg.isAtlasProject = true
@@ -411,12 +423,14 @@ proc processPendingPackages(
     onClone: PackageAction;
     deferChildDeps: bool
 ) =
+  ## Processes all packages currently known to the context until no immediate work remains.
+  ## Lazy packages are represented in the graph without loading their full release history.
   var processing = true
   while processing:
     processing = false
     let pkgUrls = nc.packageToDependency.keys().toSeq()
 
-    # just for more concise logging
+    # Build concise package lists for progress logging.
     var initializingPkgs: seq[string]
     var processingPkgs: seq[string]
     for pkgUrl in pkgUrls:
@@ -433,7 +447,7 @@ proc processPendingPackages(
     if processingPkgs.len() > 0:
       notice root.projectName, "Processing packages:", processingPkgs.join(", ")
 
-    # process packages
+    # Process a stable snapshot so newly discovered packages are handled on the next loop.
     debug "atlas:expandGraph", "Processing package count: ", $pkgUrls.len()
     for pkgUrl in pkgUrls:
       var pkg = nc.packageToDependency[pkgUrl]
@@ -484,13 +498,13 @@ proc expandGraph*(
     isLinkPath = false,
     deferChildDeps = false
 ): DepGraph =
-  ## Expand the graph by adding all dependencies.
+  ## Expands a workspace root into a dependency graph.
+  ## Explicit commit requirements can add new work, so processing repeats to a fixed point.
   
   doAssert path.string != "."
   let url = nc.createUrlFromPath(path, isLinkPath)
   notice url.projectName, "expanding root package at:", $path, "url:", $url
   var root = Package(url: url, isRoot: true, isFork: isForkUrl(nc, url))
-  # nc.loadDependency(pkg)
 
   result = DepGraph(root: root, mode: mode)
   nc.packageToDependency[root.url] = root
@@ -519,9 +533,3 @@ proc expandGraph*(
       nc.explicitVersions.len != explicitCountBeforeExplicit
 
   info "atlas:expand", "Finished expanding packages for:", $root.projectName
-
-proc findProjects*(path: Path): seq[Path] =
-  result = @[]
-  for k, f in walkDir(path):
-    if k == pcDir and dirExists(f / Path".git"):
-      result.add(f)

--- a/src/dependencies.nim
+++ b/src/dependencies.nim
@@ -7,76 +7,9 @@
 #
 
 import std / [os, strutils, uri, tables, sequtils, sets, hashes, algorithm, paths, dirs]
-import basic/[context, deptypes, versions, osutils, nimbleparser, reporters, gitops, pkgurls, nimblecontext, deptypesjson]
+import basic/[context, deptypes, versions, osutils, nimbleparser, reporters, gitops, pkgurls, nimblecontext, deptypesjson, dependencycache]
 
 export deptypes, versions, deptypesjson
-
-type
-  NimbleFileSource = object
-    path: Path
-    fromGit: bool
-
-  PackageReleaseCacheEntry = object
-    vtag*: VersionTag
-    release*: NimbleRelease
-
-  PackageReleaseCache = object
-    cacheVersion*: int
-    url*: PkgUrl
-    head*: CommitHash
-    current*: CommitHash
-    includeTagsAndNimbleCommits*: bool
-    nimbleCommitsMax*: bool
-    releases*: seq[PackageReleaseCacheEntry]
-
-const PackageReleaseCacheVersion = 1
-
-proc packageCacheStem(url: PkgUrl): string =
-  result = url.fullName()
-  if result.len == 0:
-    result = url.projectName()
-  if result.len == 0:
-    result = $url
-
-  for c in mitems(result):
-    if c notin {'a'..'z', 'A'..'Z', '0'..'9', '.', '_', '-'}:
-      c = '_'
-
-proc packageReleaseCachePath(pkg: Package): Path =
-  cachesDirectory() / Path(packageCacheStem(pkg.url) & ".json")
-
-proc includeTagsAndNimbleCommitsFlag(): bool =
-  IncludeTagsAndNimbleCommits in context().flags
-
-proc nimbleCommitsMaxFlag(): bool =
-  NimbleCommitsMax in context().flags
-
-proc canUsePackageReleaseCache(pkg: Package; mode: TraversalMode; explicitVersions: seq[VersionTag]): bool =
-  mode == AllReleases and
-    explicitVersions.len == 0 and
-    not pkg.isRoot and
-    not pkg.isAtlasProject and
-    not pkg.url.isNimbleLink() and
-    not pkg.isLocalOnly
-
-proc findGitNimbleFiles(pkg: Package; commit: CommitHash): seq[NimbleFileSource] =
-  let files = listFiles(pkg.ondisk, commit)
-  for file in files:
-    if file.endsWith(".nimble"):
-      let source = NimbleFileSource(path: Path(file), fromGit: true)
-      if source.path.splitPath().tail == Path(pkg.url.shortName() & ".nimble"):
-        return @[source]
-      result.add source
-
-proc materializeNimbleFile(pkg: Package; commit: CommitHash; source: NimbleFileSource): Path =
-  if not source.fromGit:
-    return source.path
-
-  let tmpDir = cachesDirectory() / Path"_tmp"
-  createDir(cachesDirectory())
-  createDir(tmpDir)
-  result = tmpDir / Path(packageCacheStem(pkg.url) & "-" & commit.short() & "-" & $source.path.splitPath().tail)
-  writeFile($result, showFile(pkg.ondisk, commit, $source.path))
 
 proc isForkUrl(nc: NimbleContext; url: PkgUrl): bool
 proc childDependencyState(pkg: Package; deferChildDeps: bool): PackageState
@@ -132,53 +65,6 @@ proc enrichPackageDependencies(
   ## This is intentionally separate from release parsing/cache loading.
   for _, release in pkg.versions:
     nc.registerReleaseDependencies(pkg, release, deferChildDeps)
-
-proc loadPackageReleaseCache(pkg: Package; currentCommit: CommitHash; entries: var seq[PackageReleaseCacheEntry]): bool =
-  if pkg.originHead.isEmpty():
-    return false
-
-  let cachePath = packageReleaseCachePath(pkg)
-  if not fileExists($cachePath):
-    return false
-
-  var cache: PackageReleaseCache
-  try:
-    cache.fromJson(parseFile($cachePath), Joptions(allowMissingKeys: true, allowExtraKeys: true))
-  except CatchableError as e:
-    warn pkg.url.projectName, "ignoring invalid dependency cache:", $cachePath, "error:", e.msg
-    return false
-
-  result =
-    cache.cacheVersion == PackageReleaseCacheVersion and
-    cache.url == pkg.url and
-    cache.head == pkg.originHead and
-    cache.current == currentCommit and
-    cache.includeTagsAndNimbleCommits == includeTagsAndNimbleCommitsFlag() and
-    cache.nimbleCommitsMax == nimbleCommitsMaxFlag()
-
-  if result:
-    entries = cache.releases
-    debug pkg.url.projectName, "loaded dependency cache:", $cachePath, "releases:", $entries.len
-
-proc savePackageReleaseCache(pkg: Package; currentCommit: CommitHash; versions: seq[(PackageVersion, NimbleRelease)]) =
-  if pkg.originHead.isEmpty():
-    return
-
-  var cache = PackageReleaseCache(
-    cacheVersion: PackageReleaseCacheVersion,
-    url: pkg.url,
-    head: pkg.originHead,
-    current: currentCommit,
-    includeTagsAndNimbleCommits: includeTagsAndNimbleCommitsFlag(),
-    nimbleCommitsMax: nimbleCommitsMaxFlag()
-  )
-  for (ver, release) in versions:
-    cache.releases.add PackageReleaseCacheEntry(vtag: ver.vtag, release: release)
-
-  createDir(cachesDirectory())
-  let cachePath = packageReleaseCachePath(pkg)
-  writeFile($cachePath, pretty(toJson(cache, ToJsonOptions(enumMode: joptEnumString))))
-  debug pkg.url.projectName, "wrote dependency cache:", $cachePath, "releases:", $cache.releases.len
 
 proc collectNimbleVersions*(nc: NimbleContext; pkg: Package): seq[VersionTag] =
   let nimbleFiles = findNimbleFile(pkg)

--- a/src/dependencies.nim
+++ b/src/dependencies.nim
@@ -109,6 +109,33 @@ proc addFeatureDependencies(pkg: Package) =
     warn pkg.url.projectName, "feature dependencies added"
     pkg.state = Found
 
+proc canonicalizeUrl(nc: var NimbleContext; url: PkgUrl): PkgUrl =
+  if url.url.scheme == "error":
+    return url
+  try:
+    result = nc.createUrl($url)
+  except CatchableError:
+    result = url
+
+proc canonicalizeReleaseUrls(nc: var NimbleContext; rel: NimbleRelease) =
+  for req in mitems(rel.requirements):
+    req[0] = canonicalizeUrl(nc, req[0])
+
+  if rel.reqsByFeatures.len > 0:
+    var reqsByFeatures = initTable[PkgUrl, HashSet[string]]()
+    for url, flags in rel.reqsByFeatures:
+      reqsByFeatures[canonicalizeUrl(nc, url)] = flags
+    rel.reqsByFeatures = reqsByFeatures
+
+  if rel.features.len > 0:
+    var features = initTable[string, seq[(PkgUrl, VersionInterval)]]()
+    for feature, reqs in rel.features:
+      var fixedReqs: seq[(PkgUrl, VersionInterval)]
+      for req in reqs:
+        fixedReqs.add (canonicalizeUrl(nc, req[0]), req[1])
+      features[feature] = fixedReqs
+    rel.features = features
+
 proc traverseDependency*(
     nc: var NimbleContext;
     pkg: var Package,
@@ -134,6 +161,7 @@ proc traverseDependency*(
       error pkg.url.projectName, "... existing: ", repr(pkg.versions[ver])
       error pkg.url.projectName, "duplicate release found:", $ver.vtag, "new:", repr(rel), " existing: ", repr(pkg.versions[ver])
       error pkg.url.projectName, "versions table:", $pkg.versions.keys().toSeq()
+    canonicalizeReleaseUrls(nc, rel)
     pkg.versions[ver] = rel
 
   # Release entries are now loaded; enrichment below registers their dependencies.

--- a/src/dependencies.nim
+++ b/src/dependencies.nim
@@ -7,11 +7,10 @@
 #
 
 import std / [os, strutils, uri, tables, sequtils, sets, hashes, algorithm, paths, dirs]
-import basic/[context, deptypes, versions, osutils, nimbleparser, reporters, gitops, pkgurls, nimblecontext, deptypesjson, dependencycache]
+import basic/[context, deptypes, versions, osutils, nimbleparser, reporters, gitops, pkgurls, nimblecontext, deptypesjson, dependencycache, packageutils]
 
 export deptypes, versions, deptypesjson
 
-proc isForkUrl(nc: NimbleContext; url: PkgUrl): bool
 proc childDependencyState(pkg: Package; deferChildDeps: bool): PackageState
 
 proc registerReleaseDependencies(
@@ -79,26 +78,6 @@ proc collectNimbleVersions*(nc: NimbleContext; pkg: Package): seq[VersionTag] =
 type
   PackageAction* = enum
     DoNothing, DoClone
-
-proc copyFromDisk*(pkg: Package, dest: Path): (CloneStatus, string) =
-  let source = pkg.url.toOriginalPath()
-  info pkg, "copyFromDisk cloning:", $dest, "from:", $source
-  if dirExists(source) and not dirExists(dest):
-    trace pkg, "copyFromDisk cloning:", $dest, "from:", $source
-    copyDir(source.string, dest.string)
-    result = (Ok, "")
-  else:
-    error pkg, "copyFromDisk not found:", $source
-    result = (NotFound, $dest)
-
-proc isForkUrl(nc: NimbleContext; url: PkgUrl): bool =
-  let officialUrl = nc.lookup(url.shortName())
-  let isGitUrl = url.url.scheme notin ["file", "link", "atlas"]
-  result =
-    isGitUrl and
-    not officialUrl.isEmpty() and
-    officialUrl.url.scheme notin ["file", "link", "atlas"] and
-    officialUrl.url != url.url
 
 proc childDependencyState(pkg: Package; deferChildDeps: bool): PackageState =
   ## Returns the initial state for newly discovered child dependencies.

--- a/src/dependencies.nim
+++ b/src/dependencies.nim
@@ -23,7 +23,6 @@ proc registerReleaseDependencies(
     return
 
   for pkgUrl, interval in items(release.requirements):
-    # debug pkg.url.projectName, "INTERVAL: ", $interval, "isSpecial:", $interval.isSpecial, "explicit:", $interval.extractSpecificCommit()
     if interval.isSpecial:
       let commit = interval.extractSpecificCommit()
       nc.explicitVersions.mgetOrPut(pkgUrl, initHashSet[VersionTag]()).incl(VersionTag(v: Version($(interval)), c: commit))
@@ -31,7 +30,6 @@ proc registerReleaseDependencies(
     let state = childDependencyState(pkg, deferChildDeps)
     if pkgUrl notin nc.packageToDependency:
       debug pkg.url.projectName, "Found new pkg:", pkgUrl.projectName, "url:", $pkgUrl.url, "projectName:", $pkgUrl.projectName, "state:", $state
-      # debug pkg.url.projectName, "Found new pkg:", pkgUrl.projectName, "repr:", $pkgUrl.repr
       let pkgDep = Package(url: pkgUrl, state: state, isFork: isForkUrl(nc, pkgUrl))
       nc.packageToDependency[pkgUrl] = pkgDep
     else:
@@ -103,9 +101,6 @@ proc processNimbleRelease(
     return
   else:
     nimbleFiles = findGitNimbleFiles(pkg, release.commit)
-
-    # warn pkg.url.projectName, "processRelease unable to checkout commit ", $release, "at:", $pkg.ondisk
-    # result = NimbleRelease(status: HasBrokenRelease, err: "error checking out release")
 
   if nimbleFiles.len() == 0:
     info "processRelease", "skipping release: missing nimble file:", $release
@@ -222,15 +217,12 @@ proc traverseDependency*(
 
   of ExplicitVersions:
     debug pkg.url.projectName, "traversing dependency found explicit versions:", $expandedExplicitVersions
-    # for ver, rel in pkg.versions:
-    #   versions.add((ver, rel))
 
     var uniqueCommits: HashSet[CommitHash]
     for ver in pkg.versions.keys():
       uniqueCommits.incl(ver.vtag.c)
 
     # get full hash from short hashes
-    # TODO: handle shallow clones here?
     for version in mitems(expandedExplicitVersions):
       let vtag = gitops.expandSpecial(pkg.ondisk, vtag = version)
       version = vtag

--- a/src/releaseinfo.nim
+++ b/src/releaseinfo.nim
@@ -159,10 +159,6 @@ proc loadPackageReleaseInfo*(
   of ExplicitVersions:
     debug pkg.url.projectName, "traversing dependency found explicit versions:", $result.expandedExplicitVersions
 
-    var uniqueCommits: HashSet[CommitHash]
-    for ver in pkg.versions.keys():
-      uniqueCommits.incl(ver.vtag.c)
-
     # Expand short hashes, branches, and #head before loading explicit releases.
     for version in mitems(result.expandedExplicitVersions):
       let vtag = gitops.expandSpecial(pkg.ondisk, vtag = version)
@@ -173,7 +169,7 @@ proc loadPackageReleaseInfo*(
       debug pkg.url.projectName, "check explicit version:", repr version
       if version.commit.isEmpty():
         warn pkg.url.projectName, "explicit version has empty commit:", $version
-      elif not uniqueCommits.containsOrIncl(version.commit):
+      elif version.toPkgVer() notin pkg.versions:
         debug pkg.url.projectName, "add explicit version:", $version
         discard result.releases.addRelease(nc, pkg, version)
 

--- a/src/releaseinfo.nim
+++ b/src/releaseinfo.nim
@@ -1,0 +1,238 @@
+#
+#           Atlas Package Cloner
+#        (c) Copyright 2023 Andreas Rumpf
+#
+#    See the file "copying.txt", included in this
+#    distribution, for details about the copyright.
+#
+
+## Release metadata loading for Atlas packages.
+##
+## This module discovers the Nimble releases available for a package from git
+## tags, Nimble-file history, explicit commit requirements, or the release
+## cache. It only loads and normalizes release information; dependency graph
+## enrichment is handled by `dependencies`.
+
+import std / [os, strutils, tables, sequtils, sets, algorithm, paths]
+import basic/[context, deptypes, versions, nimbleparser, reporters, gitops, pkgurls, nimblecontext, dependencycache]
+
+type
+  PackageReleaseInfo* = object
+    currentCommit*: CommitHash
+    expandedExplicitVersions*: seq[VersionTag]
+    releases*: seq[(PackageVersion, NimbleRelease)]
+    loadedFromCache*: bool
+    repoError*: bool
+
+proc collectNimbleVersions*(nc: NimbleContext; pkg: Package): seq[VersionTag] =
+  ## Collects commits that modified the package's Nimble file.
+  ## These commits are used as fallback release candidates when tags are absent.
+  let nimbleFiles = findNimbleFile(pkg)
+  let dir = pkg.ondisk
+  doAssert(pkg.ondisk.string != "", "Package ondisk must be set before collectNimbleVersions can be called! Package: " & $(pkg))
+  result = @[]
+  if nimbleFiles.len() == 1:
+    result = collectFileCommits(dir, nimbleFiles[0], isLocalOnly = pkg.isLocalOnly)
+    result.reverse()
+    trace pkg, "collectNimbleVersions commits:", mapIt(result, it.c.short()).join(", "), "nimble:", $nimbleFiles[0]
+
+proc processNimbleRelease*(
+    nc: var NimbleContext;
+    pkg: Package,
+    release: VersionTag;
+): NimbleRelease =
+  ## Loads and parses the Nimble file for a specific package release candidate.
+  ## Historical releases are read from git contents and materialized only temporarily.
+  trace pkg.url.projectName, "Processing release:", $release
+
+  var nimbleFiles: seq[NimbleFileSource]
+  if release.version == Version"#head":
+    trace pkg.url.projectName, "processRelease using current commit"
+    nimbleFiles = findNimbleFile(pkg).mapIt(NimbleFileSource(path: it, fromGit: false))
+  elif release.commit.isEmpty():
+    warn pkg.url.projectName, "processRelease missing commit ", $release, "at:", $pkg.ondisk
+    result = NimbleRelease(status: HasBrokenRelease, err: "no commit")
+    return
+  else:
+    nimbleFiles = findGitNimbleFiles(pkg, release.commit)
+
+  if nimbleFiles.len() == 0:
+    info "processRelease", "skipping release: missing nimble file:", $release
+    result = NimbleRelease(status: HasUnknownNimbleFile, err: "missing nimble file")
+  elif nimbleFiles.len() > 1:
+    info "processRelease", "skipping release: ambiguous nimble file:", $release, "files:", $(nimbleFiles.mapIt($it.path.splitPath().tail).join(", "))
+    result = NimbleRelease(status: HasUnknownNimbleFile, err: "ambiguous nimble file")
+  else:
+    let source = nimbleFiles[0]
+    let nimbleFile = materializeNimbleFile(pkg, release.commit, source)
+    try:
+      result = nc.parseNimbleFile(nimbleFile)
+    finally:
+      if source.fromGit and fileExists($nimbleFile):
+        removeFile($nimbleFile)
+
+proc addRelease(
+    versions: var seq[(PackageVersion, NimbleRelease)],
+    nc: var NimbleContext;
+    pkg: Package,
+    vtag: VersionTag;
+): bool =
+  ## Parses one release candidate and appends it to the pending version list.
+  ## The returned release version is normalized against tag or Nimble-file metadata.
+  var pkgver = vtag.toPkgVer()
+  trace pkg.url.projectName, "Adding Nimble version:", $vtag
+  try:
+    let release = nc.processNimbleRelease(pkg, vtag)
+
+    if vtag.v.string == "":
+      pkgver.vtag.v = release.version
+      trace pkg.url.projectName, "updating release tag information:", $pkgver.vtag
+    elif release.version.string == "":
+      warn pkg.url.projectName, "nimble file missing version information:", $pkgver.vtag
+      release.version = vtag.version
+    elif vtag.v != release.version and not pkg.isRoot:
+      info pkg.url.projectName, "version mismatch between version tag:", $vtag.v, "and nimble version:", $release.version
+
+    versions.add((pkgver, release))
+
+    result = true
+  except CatchableError as e:
+    info pkg.url.projectName, "error processing nimble release:", $vtag, "error:", $e.msg
+    return false
+
+proc deduplicateReleases(
+    pkg: Package;
+    versions: seq[(PackageVersion, NimbleRelease)]
+): seq[(PackageVersion, NimbleRelease)] =
+  ## Makes identical NimbleReleases share the same ref object.
+  var uniqueReleases: Table[NimbleRelease, NimbleRelease]
+  for (ver, rel) in versions:
+    if rel notin uniqueReleases:
+      uniqueReleases[rel] = rel
+    else:
+      trace pkg.url.projectName, "found duplicate release requirements at:", $ver.vtag
+
+  info pkg.url.projectName, "unique versions found:", uniqueReleases.values().toSeq().mapIt($it.version).join(", ")
+  for (ver, rel) in versions:
+    result.add((ver, uniqueReleases[rel]))
+
+proc loadPackageReleaseInfo*(
+    nc: var NimbleContext;
+    pkg: var Package,
+    mode: TraversalMode;
+    explicitVersions: seq[VersionTag]
+): PackageReleaseInfo =
+  ## Loads release metadata for a package without enriching dependency graph state.
+  ## Results may come from cache, git tags, Nimble-file history, or explicit commits.
+  result.expandedExplicitVersions = explicitVersions
+
+  result.currentCommit = currentGitCommit(pkg.ondisk, Warning)
+  if not pkg.isLocalOnly:
+    discard gitops.ensureCanonicalOrigin(pkg.ondisk, pkg.url.toUri)
+  pkg.originHead = gitops.findOriginTip(pkg.ondisk, errorReportLevel = Warning, isLocalOnly = pkg.isLocalOnly).commit()
+
+  if canUsePackageReleaseCache(pkg, mode, result.expandedExplicitVersions):
+    var cachedReleases: seq[PackageReleaseCacheEntry]
+    if loadPackageReleaseCache(pkg, result.currentCommit, cachedReleases):
+      for entry in cachedReleases:
+        result.releases.add((entry.vtag.toPkgVer(), entry.release))
+      result.loadedFromCache = true
+      return
+
+  if mode == CurrentCommit and result.currentCommit.isEmpty():
+    discard
+  elif result.currentCommit.isEmpty():
+    warn pkg.url.projectName, "traversing dependency unable to find git current version at ", $pkg.ondisk
+    let vtag = VersionTag(v: Version"#head", c: initCommitHash("", FromHead))
+    result.releases.add((vtag.toPkgVer, NimbleRelease(version: vtag.version, status: HasBrokenRepo)))
+    result.repoError = true
+    return
+  else:
+    trace pkg.url.projectName, "traversing dependency current commit:", $result.currentCommit
+
+  case mode
+  of CurrentCommit:
+    trace pkg.url.projectName, "traversing dependency for only current commit"
+    let vtag = VersionTag(v: Version"#head", c: initCommitHash(result.currentCommit, FromHead))
+    discard result.releases.addRelease(nc, pkg, vtag)
+
+  of ExplicitVersions:
+    debug pkg.url.projectName, "traversing dependency found explicit versions:", $result.expandedExplicitVersions
+
+    var uniqueCommits: HashSet[CommitHash]
+    for ver in pkg.versions.keys():
+      uniqueCommits.incl(ver.vtag.c)
+
+    # Expand short hashes, branches, and #head before loading explicit releases.
+    for version in mitems(result.expandedExplicitVersions):
+      let vtag = gitops.expandSpecial(pkg.ondisk, vtag = version)
+      version = vtag
+      debug pkg.url.projectName, "explicit version:", $version, "vtag:", repr vtag
+
+    for version in result.expandedExplicitVersions:
+      debug pkg.url.projectName, "check explicit version:", repr version
+      if version.commit.isEmpty():
+        warn pkg.url.projectName, "explicit version has empty commit:", $version
+      elif not uniqueCommits.containsOrIncl(version.commit):
+        debug pkg.url.projectName, "add explicit version:", $version
+        discard result.releases.addRelease(nc, pkg, version)
+
+  of AllReleases:
+    try:
+      var uniqueCommits: HashSet[CommitHash]
+      var nimbleVersions: HashSet[Version]
+      var nimbleCommits = nc.collectNimbleVersions(pkg)
+
+      debug pkg.url.projectName, "nimble explicit versions:", $explicitVersions
+      for version in explicitVersions:
+        var vtag = gitops.expandSpecial(pkg.ondisk, vtag = version)
+        if not vtag.commit.isEmpty() and not uniqueCommits.containsOrIncl(vtag.commit):
+          discard result.releases.addRelease(nc, pkg, vtag)
+
+      # Prefer tagged versions over versions inferred from Nimble-file history.
+      let tags = collectTaggedVersions(pkg.ondisk, isLocalOnly = pkg.isLocalOnly)
+      debug pkg.url.projectName, "nimble tags:", $tags
+      for tag in tags:
+        if not uniqueCommits.containsOrIncl(tag.c):
+          discard result.releases.addRelease(nc, pkg, tag)
+          assert tag.commit.orig == FromGitTag, "maybe this needs to be overriden like before: " & $tag.commit.orig
+
+      if tags.len() == 0 or IncludeTagsAndNimbleCommits in context().flags:
+        # Use Nimble-file commit versions only when tags are absent or explicitly requested.
+        # Otherwise deleted tags could be reintroduced as inferred releases.
+        if NimbleCommitsMax in context().flags:
+          # Reverse the order so the newest commit is preferred for each version.
+          nimbleCommits.reverse()
+
+        debug pkg.url.projectName, "nimble commits:", $nimbleCommits
+        for tag in nimbleCommits:
+          if not uniqueCommits.containsOrIncl(tag.c):
+            var vers: seq[(PackageVersion, NimbleRelease)]
+            let added = vers.addRelease(nc, pkg, tag)
+            if added and not nimbleVersions.containsOrIncl(vers[0][0].vtag.v):
+              result.releases.add(vers)
+          else:
+            error pkg.url.projectName, "traverseDependency skipping nimble commit:", $tag, "uniqueCommits:", $(tag.c in uniqueCommits), "nimbleVersions:", $(tag.v in nimbleVersions)
+
+        if not result.currentCommit.isEmpty() and not uniqueCommits.containsOrIncl(result.currentCommit):
+          # Existing checkouts can be detached or on a non-default branch.
+          # Include their current nimble version when remote-tip traversal misses it.
+          var vers: seq[(PackageVersion, NimbleRelease)]
+          let currentTag = VersionTag(v: Version"", c: result.currentCommit)
+          let added = vers.addRelease(nc, pkg, currentTag)
+          if added and not nimbleVersions.containsOrIncl(vers[0][0].vtag.v):
+            result.releases.add(vers)
+
+      if result.releases.len() == 0:
+        let vtag = VersionTag(v: Version"#head", c: initCommitHash(result.currentCommit, FromHead))
+        debug pkg.url.projectName, "traverseDependency no versions found, using default #head", "at", $pkg.ondisk
+        discard result.releases.addRelease(nc, pkg, vtag)
+
+    finally:
+      if not checkoutGitCommit(pkg.ondisk, result.currentCommit, Warning):
+        info pkg.url.projectName, "traverseDependency error loading versions reverting to ", $result.currentCommit
+
+  result.releases = deduplicateReleases(pkg, result.releases)
+
+  if canUsePackageReleaseCache(pkg, mode, result.expandedExplicitVersions):
+    savePackageReleaseCache(pkg, result.currentCommit, result.releases)

--- a/src/releaseinfo.nim
+++ b/src/releaseinfo.nim
@@ -24,17 +24,20 @@ type
     loadedFromCache*: bool
     repoError*: bool
 
-proc collectNimbleVersions*(nc: NimbleContext; pkg: Package): seq[VersionTag] =
+proc collectNimbleVersions*(nc: NimbleContext; pkg: Package; repo: RepoMetadata): seq[VersionTag] =
   ## Collects commits that modified the package's Nimble file.
   ## These commits are used as fallback release candidates when tags are absent.
   let nimbleFiles = findNimbleFile(pkg)
-  let dir = pkg.ondisk
   doAssert(pkg.ondisk.string != "", "Package ondisk must be set before collectNimbleVersions can be called! Package: " & $(pkg))
   result = @[]
   if nimbleFiles.len() == 1:
-    result = collectFileCommits(dir, nimbleFiles[0], isLocalOnly = pkg.isLocalOnly)
+    result = collectFileCommits(repo, nimbleFiles[0])
     result.reverse()
     trace pkg, "collectNimbleVersions commits:", mapIt(result, it.c.short()).join(", "), "nimble:", $nimbleFiles[0]
+
+proc collectNimbleVersions*(nc: NimbleContext; pkg: Package): seq[VersionTag] =
+  let repo = loadRepoMetadata(pkg.ondisk, isLocalOnly = pkg.isLocalOnly)
+  nc.collectNimbleVersions(pkg, repo)
 
 proc processNimbleRelease*(
     nc: var NimbleContext;
@@ -126,10 +129,14 @@ proc loadPackageReleaseInfo*(
   ## Results may come from cache, git tags, Nimble-file history, or explicit commits.
   result.expandedExplicitVersions = explicitVersions
 
-  result.currentCommit = currentGitCommit(pkg.ondisk, Warning)
-  if not pkg.isLocalOnly:
-    discard gitops.ensureCanonicalOrigin(pkg.ondisk, pkg.url.toUri)
-  pkg.originHead = gitops.findOriginTip(pkg.ondisk, errorReportLevel = Warning, isLocalOnly = pkg.isLocalOnly).commit()
+  var repo = loadRepoMetadata(
+    pkg.ondisk,
+    expectedCanonicalUrl = if pkg.isLocalOnly: "" else: $pkg.url.toUri,
+    errorReportLevel = Warning,
+    isLocalOnly = pkg.isLocalOnly
+  )
+  result.currentCommit = repo.currentCommit
+  pkg.originHead = repo.originTip.commit()
 
   if canUsePackageReleaseCache(pkg, mode, result.expandedExplicitVersions):
     var cachedReleases: seq[PackageReleaseCacheEntry]
@@ -161,7 +168,7 @@ proc loadPackageReleaseInfo*(
 
     # Expand short hashes, branches, and #head before loading explicit releases.
     for version in mitems(result.expandedExplicitVersions):
-      let vtag = gitops.expandSpecial(pkg.ondisk, vtag = version)
+      let vtag = gitops.expandSpecial(repo, vtag = version)
       version = vtag
       debug pkg.url.projectName, "explicit version:", $version, "vtag:", repr vtag
 
@@ -177,16 +184,16 @@ proc loadPackageReleaseInfo*(
     try:
       var uniqueCommits: HashSet[CommitHash]
       var nimbleVersions: HashSet[Version]
-      var nimbleCommits = nc.collectNimbleVersions(pkg)
+      var nimbleCommits = nc.collectNimbleVersions(pkg, repo)
 
       debug pkg.url.projectName, "nimble explicit versions:", $explicitVersions
       for version in explicitVersions:
-        var vtag = gitops.expandSpecial(pkg.ondisk, vtag = version)
+        var vtag = gitops.expandSpecial(repo, vtag = version)
         if not vtag.commit.isEmpty() and not uniqueCommits.containsOrIncl(vtag.commit):
           discard result.releases.addRelease(nc, pkg, vtag)
 
       # Prefer tagged versions over versions inferred from Nimble-file history.
-      let tags = collectTaggedVersions(pkg.ondisk, isLocalOnly = pkg.isLocalOnly)
+      let tags = collectTaggedVersions(repo)
       debug pkg.url.projectName, "nimble tags:", $tags
       for tag in tags:
         if not uniqueCommits.containsOrIncl(tag.c):
@@ -225,7 +232,7 @@ proc loadPackageReleaseInfo*(
         discard result.releases.addRelease(nc, pkg, vtag)
 
     finally:
-      if not checkoutGitCommit(pkg.ondisk, result.currentCommit, Warning):
+      if not checkoutGitCommit(pkg.ondisk, result.currentCommit, result.currentCommit, Warning):
         info pkg.url.projectName, "traverseDependency error loading versions reverting to ", $result.currentCommit
 
   result.releases = deduplicateReleases(pkg, result.releases)

--- a/tests/tfeatures.nim
+++ b/tests/tfeatures.nim
@@ -295,15 +295,18 @@ suite "test global features":
 
         check dirExists("deps" / "proj_feature_dep")
         check "deps/proj_feature_dep" in readFile("nim.cfg")
+        check fileExists("deps" / ".cache" / "atlas.active.json")
+        check not fileExists("deps" / "atlas.cache.json")
 
-        var nc2 = createNimbleContext()
-        let graph = loadDepGraph(nc2, (paths.getCurrentDir() / Path"ws_features_global.nimble").absolutePath)
-        let featurePkgs = graph.pkgs.values().toSeq().filterIt(it.isProjFeatureDep())
+        let cache = loadActivationCache((paths.getCurrentDir() / Path"ws_features_global.nimble").absolutePath)
+        let featurePkgs = cache.packages.filterIt(
+          it.url.projectName == "proj_feature_dep" or
+          it.url.shortName == "proj_feature_dep" or
+          ($it.ondisk).splitPath().tail == "proj_feature_dep"
+        )
         check featurePkgs.len == 1
         if featurePkgs.len == 1:
-          check featurePkgs[0].active
-          check not featurePkgs[0].activeVersion.isNil
-          check $featurePkgs[0].activeVersion.vtag.version == "1.0.0"
+          check featurePkgs[0].version.startsWith("1.0.0@")
 
   test "parse features from nim.cfg":
       withDir "tests/ws_features_global":

--- a/tests/tlinks.nim
+++ b/tests/tlinks.nim
@@ -71,6 +71,7 @@ suite "test link integration":
         context().flags.incl DumpGraphs
         var sol: Solution
         solve(graph, form)
+        writeActivationCache(graph)
 
         check graph.root.active
         check graph.pkgs[nc.createUrl("proj_a")].active

--- a/tests/tpackageinfos.nim
+++ b/tests/tpackageinfos.nim
@@ -1,10 +1,11 @@
-import std/[unittest, os, times, files, paths]
+import std/[unittest, os, times, paths]
+import basic/context
 import basic/packageinfos
 
 suite "packages list":
   test "updatePackages downloads packages.json":
     let pkgsDir = Path(getTempDir()) / Path("atlas_pkgs_" & $int(epochTime()))
-    let pkgsFile = pkgsDir / Path"packages.json"
+    let pkgsFile = packageInfosFile(pkgsDir)
     defer:
       if fileExists($pkgsFile):
         removeFile($pkgsFile)
@@ -13,3 +14,39 @@ suite "packages list":
     updatePackages(pkgsDir)
     check fileExists($pkgsFile)
     check getFileSize($pkgsFile) > 0
+
+  test "legacy package caches are removed by default":
+    let oldCtx = context()
+    let ws = Path(getTempDir()) / Path("atlas_cleanup_" & $int(epochTime()))
+    defer:
+      setContext(oldCtx)
+      if dirExists($ws):
+        removeDir($ws)
+
+    setContext(AtlasContext(projectDir: ws, depsDir: Path"deps"))
+    createDir($depsDir())
+    createDir($(depsDir() / Path"_nimble"))
+    createDir($packagesDirectory())
+
+    removeLegacyPackageCaches()
+
+    check not dirExists($(depsDir() / Path"_nimble"))
+    check not dirExists($packagesDirectory())
+
+  test "packages git cache is kept for packages repo mode":
+    let oldCtx = context()
+    let ws = Path(getTempDir()) / Path("atlas_cleanup_git_" & $int(epochTime()))
+    defer:
+      setContext(oldCtx)
+      if dirExists($ws):
+        removeDir($ws)
+
+    setContext(AtlasContext(projectDir: ws, depsDir: Path"deps", flags: {PackagesGit}))
+    createDir($depsDir())
+    createDir($(depsDir() / Path"_nimble"))
+    createDir($packagesDirectory())
+
+    removeLegacyPackageCaches()
+
+    check not dirExists($(depsDir() / Path"_nimble"))
+    check dirExists($packagesDirectory())

--- a/tests/tserde.nim
+++ b/tests/tserde.nim
@@ -1,4 +1,4 @@
-import std/[unittest, json, jsonutils]
+import std/[unittest, json, jsonutils, sets, tables]
 import basic/[context, sattypes, pkgurls, deptypes, nimblecontext, depgraphtypes]
 import basic/[deptypesjson, versions]
 
@@ -73,6 +73,30 @@ suite "json serde":
     var release2: NimbleRelease
     release2.fromJson(jnRelease)
     check release == release2
+
+  test "json serde nimble release with features":
+    let featureUrl = nc.createUrl("proj_a")
+    var reqsByFeatures: Table[PkgUrl, HashSet[string]]
+    reqsByFeatures[featureUrl] = ["testing"].toHashSet
+    let release = NimbleRelease(
+      version: Version"1.0.0",
+      nimVersion: Version"2.0.0",
+      status: Normal,
+      requirements: @[(nc.createUrl("foobar"), p"1.0.0")],
+      features: {"testing": @[(featureUrl, p">= 1.0.0")]}.toTable,
+      reqsByFeatures: reqsByFeatures,
+      featureVars: {"testing": VarId(3)}.toTable
+    )
+    let jnRelease = toJson(release)
+    var release2: NimbleRelease
+    release2.fromJson(jnRelease)
+
+    check release2.version == release.version
+    check release2.nimVersion == release.nimVersion
+    check release2.requirements == release.requirements
+    check release2.features == release.features
+    check release2.reqsByFeatures == release.reqsByFeatures
+    check release2.featureVars == release.featureVars
 
   test "json serde version interval":
 

--- a/tests/tserde.nim
+++ b/tests/tserde.nim
@@ -68,10 +68,23 @@ suite "json serde":
 
   test "json serde nimble release":
     let release = NimbleRelease(version: Version"1.0.0", requirements: @[(nc.createUrl("foobar"), p"1.0.0")])
-    let jnRelease = toJson(release)
+    let jnRelease = toJsonHook(release)
     echo "jnRelease: ", pretty(jnRelease)
+    check "srcDir" notin jnRelease
+    check "err" notin jnRelease
+    check "features" notin jnRelease
+    check "featureVars" notin jnRelease
+    check "reqsByFeatures" notin jnRelease
+    var versions: OrderedTable[PackageVersion, NimbleRelease]
+    versions[VersionTag(v: Version"1.0.0").toPkgVer] = release
+    let jnVersions = toJsonHook(versions, ToJsonOptions(enumMode: joptEnumString))
+    check "srcDir" notin jnVersions[0][1]
+    check "err" notin jnVersions[0][1]
+    check "features" notin jnVersions[0][1]
+    check "featureVars" notin jnVersions[0][1]
+    check "reqsByFeatures" notin jnVersions[0][1]
     var release2: NimbleRelease
-    release2.fromJson(jnRelease)
+    fromJsonHook(release2, jnRelease)
     check release == release2
 
   test "json serde nimble release with features":
@@ -83,17 +96,26 @@ suite "json serde":
       nimVersion: Version"2.0.0",
       status: Normal,
       requirements: @[(nc.createUrl("foobar"), p"1.0.0")],
+      srcDir: Path"src",
+      err: "broken",
       features: {"testing": @[(featureUrl, p">= 1.0.0")]}.toTable,
       reqsByFeatures: reqsByFeatures,
       featureVars: {"testing": VarId(3)}.toTable
     )
-    let jnRelease = toJson(release)
+    let jnRelease = toJsonHook(release)
+    check jnRelease["srcDir"].getStr() == "src"
+    check jnRelease["err"].getStr() == "broken"
+    check jnRelease.hasKey("features")
+    check jnRelease.hasKey("featureVars")
+    check jnRelease.hasKey("reqsByFeatures")
     var release2: NimbleRelease
-    release2.fromJson(jnRelease)
+    fromJsonHook(release2, jnRelease)
 
     check release2.version == release.version
     check release2.nimVersion == release.nimVersion
     check release2.requirements == release.requirements
+    check release2.srcDir == release.srcDir
+    check release2.err == release.err
     check release2.features == release.features
     check release2.reqsByFeatures == release.reqsByFeatures
     check release2.featureVars == release.featureVars


### PR DESCRIPTION
This PR does some cleanup and adds caching for basic package info and reuses git repo metadata usage. This improves performance a lot:

- Reinstalling a project (Sargophagus) using `atlas -k install` improved from ~8.76s to ~1.63s
- Sys time dropped from ~1.34s to ~0.07s

A big speedup comes from loading git metadata once during dep traversal instead of repeatedly resolving the same remote/config/ref state through git subprocesses. Though the project info caching also speeds up things a lot.

## Project Info Caching

This separates out the "loading project info and versions" from the more specific "enriched" data that includes explicit hashes based on traversed project requirements. 

I think that makes it a bit easier to understand. It also makes Atlas usable as a library for parsing package info and versions.

First each package is processed for historical versions from Nimble file history and git tags. This info is now written as `deps/.cache/repo.user.gitforge.json`. Invalidation of the cache is handled by the Git Head (e.g. if the tip has new refs it'll be re-processed).


## Changes

- Removes `deps/_nimbles/` and `deps/_packages/` in favor of `deps/.cache/`
- Adds project info caching in `deps/.cache/repo.user.gitforge.json`
- Adds transient `RepoMetadata` for reuse during release-info traversal
- Reads local git config, HEAD, refs, and packed refs directly where practical
- Reuses repo metadata across tag, Nimble-history, explicit-version, and origin-tip lookups
- Skips no-op remote URL updates and checkout work when already current

