### PR TITLE
fix: apply nimble.lock in replay/changed (deps mapping + cwd)

### DIFF
--- a/src/lockfiles.nim
+++ b/src/lockfiles.nim
@@ -172,18 +172,17 @@ proc convertNimbleLock*(nimble: Path): LockFile =
     error nimble, "invalid nimble lockfile"
     return
 
-  var nc = createNimbleContext()
-
   result = newLockFile()
   for (name, info) in jsonTree["packages"].pairs:
     if name == "nim":
       result.nimVersion = info["version"].getStr
     else:
-      # lookup package using url
       let pkgurl = info["url"].getStr
       info name, " imported "
-      let u = nc.createUrl(pkgurl)
-      let dir = depsDir(relative=true) / u.projectName.Path 
+      # the dependency directory is named after the nimble package name
+      # (the lockfile key), matching how atlas lays out deps/<name>; the
+      # url's repo name can differ
+      let dir = depsDir(relative=true) / name.Path
       result.items[name] = LockFileEntry(
         dir: dir.relativePath(project()),
         url: pkgurl,
@@ -204,20 +203,19 @@ proc listChanged*(lockFile: Path) =
     if not dirExists(dir):
       warn dir, "repo missing!"
       continue
-    withDir dir:
-      let url = getCanonicalUrl(dir)
-      if v.url != url:
-        warn v.dir, "remote URL has been changed;" &
-                       " found: " & url &
-                       " lockfile has: " & v.url
+    let url = getCanonicalUrl(dir)
+    if v.url != url:
+      warn v.dir, "remote URL has been changed;" &
+                     " found: " & url &
+                     " lockfile has: " & v.url
 
-      let commit = currentGitCommit(dir)
-      if commit.h != v.commit:
-        warn dir, "commit differs;" &
-                     " found: " & $commit &
-                     " lockfile has: " & v.commit
-      else:
-        notice "atlas:pin", "Repo:", $dir.relativePath(project()), "is up to date at:", commit.short()
+    let commit = currentGitCommit(dir)
+    if commit.h != v.commit:
+      warn dir, "commit differs;" &
+                   " found: " & $commit &
+                   " lockfile has: " & v.commit
+    else:
+      notice "atlas:pin", "Repo:", $dir.relativePath(project()), "is up to date at:", commit.short()
 
   if lf.hostOS == system.hostOS and lf.hostCPU == system.hostCPU:
     compareVersion "nim", lf.nimVersion, detectNimVersion()

--- a/tests/tlockfiles.nim
+++ b/tests/tlockfiles.nim
@@ -1,0 +1,122 @@
+## Unit tests for the lockfile machinery (`lockfiles.nim`).
+##
+## These exercise `listChanged` against real (local, offline) git repos so
+## that two regressions stay fixed:
+##   1. `convertNimbleLock` must map a nimble package to `deps/<package-name>`
+##      (the lockfile key), not `deps/<url-repo-name>`.
+##   2. `listChanged` must inspect each dep's git state via the dir path alone,
+##      without an extra `withDir` wrapper that double-applies the path and
+##      makes every repo read back as an empty url / "-" commit.
+
+import std/[os, osproc, paths, json]
+import unittest
+
+import basic/[reporters, context, lockfiletypes, gitops, versions]
+import lockfiles
+
+proc git(dir, args: string) =
+  let (outp, code) = execCmdEx("git -C " & quoteShell(dir) & " " & args)
+  doAssert code == 0, "git " & args & " failed in " & dir & ":\n" & outp
+
+proc freshDir(name: string): string =
+  result = os.getCurrentDir() / "tests" / name
+  if dirExists(result): removeDir(result)
+  createDir(result)
+
+proc setupDep(name, url: string): tuple[url, commit: string] =
+  ## Creates `deps/<name>` as a one-commit git repo with `origin` set to `url`.
+  ## Returns the canonical url and full commit hash as the lockfile-comparison
+  ## helpers see them (read from cwd, i.e. the project root).
+  let depDir = "deps" / name
+  createDir(depDir)
+  git(depDir, "init -q")
+  git(depDir, "config user.email test@example.com")
+  git(depDir, "config user.name test-user")
+  git(depDir, "remote add origin " & quoteShell(url))
+  writeFile(depDir / "f.txt", "hello")
+  git(depDir, "add .")
+  git(depDir, "commit -q -m initial")
+
+  let gotUrl = getCanonicalUrl(Path depDir)
+  let gotCommit = currentGitCommit(Path depDir)
+  doAssert gotCommit.isFull, "expected a full commit hash, got: " & $gotCommit
+  result = (gotUrl, gotCommit.h)
+
+template withCwd(dir: string; body: untyped) =
+  let saved = os.getCurrentDir()
+  setCurrentDir(dir)
+  try:
+    body
+  finally:
+    setCurrentDir(saved)
+
+suite "Lockfile listChanged":
+  setup:
+    # project()=="." while cwd is the fixture root, deps live under "deps".
+    setContext AtlasContext(projectDir: Path".", depsDir: Path"deps")
+
+  test "atlas.lock: matching deps produce no warnings":
+    let root = freshDir("ws_lockfiles_clean")
+    defer: removeDir(root)
+
+    withCwd root:
+      let exp = setupDep("foo", "https://example.com/foo")
+
+      var lf = LockFile(items: initOrderedTable[string, LockFileEntry]())
+      lf.items["foo"] = LockFileEntry(
+        dir: Path("deps" / "foo"), url: exp.url, commit: exp.commit)
+      # hostOS left empty so the nim/gcc/clang version comparison is skipped.
+      write(lf, "atlas.lock")
+
+      resetAtlasReporter()
+      listChanged(Path"atlas.lock")
+      check atlasReporter.warnings == 0
+
+  test "atlas.lock: a drifted commit is detected":
+    let root = freshDir("ws_lockfiles_drift")
+    defer: removeDir(root)
+
+    withCwd root:
+      let exp = setupDep("foo", "https://example.com/foo")
+
+      var lf = LockFile(items: initOrderedTable[string, LockFileEntry]())
+      lf.items["foo"] = LockFileEntry(
+        dir: Path("deps" / "foo"), url: exp.url, commit: exp.commit)
+      write(lf, "atlas.lock")
+
+      # move HEAD forward so the on-disk commit no longer matches the lock
+      git("deps" / "foo", "commit -q --allow-empty -m second")
+
+      resetAtlasReporter()
+      listChanged(Path"atlas.lock")
+      check atlasReporter.warnings >= 1
+
+  test "nimble.lock: conversion locates deps by package name":
+    let root = freshDir("ws_lockfiles_nimble")
+    defer: removeDir(root)
+
+    withCwd root:
+      # nimble package name "unittest2" but the repo is "nim-unittest2";
+      # the dep dir must be found as deps/unittest2 (the lockfile key).
+      let url = "https://github.com/status-im/nim-unittest2"
+      let exp = setupDep("unittest2", url)
+
+      let nl = %*{
+        "version": 2,
+        "packages": {
+          "unittest2": {
+            "version": "0.2.4",
+            "vcsRevision": exp.commit,
+            "url": exp.url,
+            "downloadMethod": "git",
+            "dependencies": [],
+            "checksums": {"sha1": "0000000000000000000000000000000000000000"}
+          }
+        },
+        "tasks": {}
+      }
+      writeFile("nimble.lock", pretty(nl))
+
+      resetAtlasReporter()
+      listChanged(NimbleLockFileName)
+      check atlasReporter.warnings == 0


### PR DESCRIPTION
atlas already knows how to consume a Nimble lockfile. atlas replay nimble.lock (and the dry-run atlas changed nimble.lock) route through convertNimbleLock to reproduce a pinned, offline source tree. In practice it didn't work: two bugs in src/lockfiles.nim made the converted lockfile point at the wrong directories and made the comparison read every repo as missing/empty. This was discovered when attempting to gather dependencies for the official langserver project.

Note: atlas install intentionally re-solves from the .nimble requires and does not read the lockfile. replay is the lockfile-applying path. This PR makes that path actually honor nimble.lock.

Bugs fixed

1. convertNimbleLock mapped deps to the URL repo name instead of the package name

It derived the dep directory from the remote's project name (u.projectName), so a package like unittest2 (repo status-im/nim-unittest2) was mapped to deps/nim-unittest2. Atlas lays deps out under `deps/<nimble-package-name>` (the lockfile key), so every package whose repo name differs from its nimble name resolved to a non-existent directory.

Fix: key the directory off the lockfile entry name. This also let us drop a now-dead createNimbleContext() / createUrl() call (the URL is stored verbatim from the lockfile).


2. listChanged double-applied the dep path

The inspection loop wrapped each repo in withDir dir: (chdir into the repo) and then also passed dir to `getCanonicalUrl(dir)` / `currentGitCommit(dir)`, pointing git at `<dir>/<dir>`. Result: every found repo reported an empty remote URL and a - commit ("commit differs").

Fix: drop the redundant withDir wrapper and call the helpers from the project root with the relative dir. the same way replay already does.

Before (atlas changed nimble.lock, all 20 deps present on disk):

```
[Warn] (nim-unittest2) repo missing!
[Warn] (nim-http-utils) repo missing!
... (and for the two that resolved) commit differs; found: -
```

After:

```
[Notice] (atlas:pin) Repo: deps/unittest2 is up to date at: <sha>
... (or a real "commit differs; found: <sha>" when the tree actually drifted)
```