### PR TITLE
Fix feature matching and CLI dependency workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,8 @@ jobs:
       - name: Install SAT
         run: |
           git clone https://github.com/nim-lang/sat.git
+          cd atlas
+          nimble -y develop --add:../sat
 
       - name: Run tests
         run: |
@@ -136,7 +138,7 @@ jobs:
       - name: Test install with Nimble
         run: |
           cd atlas
-          nimble install -y
+          nimble install -n --offline
 
       - name: Test install.sh
         if: runner.os == 'Linux' || runner.os == 'macOS'

--- a/atlas.nimble
+++ b/atlas.nimble
@@ -1,5 +1,5 @@
 # Package
-version = "0.14.7"
+version = "0.14.8"
 author = "Araq"
 description = "Atlas is a simple package cloner tool. It manages an isolated project."
 license = "MIT"

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -74,7 +74,7 @@ Options:
   --dumpgraphs          dump dependency graphs for debugging
   --showGraph           show the dependency graph
   --tree                show `atlas deps` output as a dependency tree
-  --update              for `install`, update dependency repos before solving
+  --update, -u          for `install`, update dependency repos before solving
   --noexec              do not perform any action that may run arbitrary code
   --autoenv             detect the minimal Nim $version and setup a
                         corresponding Nim virtual environment
@@ -267,8 +267,9 @@ proc activeDirectDependencies(cache: ActivationCache; pkg: ActivatedPackage): se
     if idx >= 0 and not cache.packages[idx].isRoot and not seen.containsOrIncl(idx):
       result.add(cache.packages[idx])
   for feature in pkg.features:
-    if feature in rel.features:
-      for (depUrl, _) in rel.features[feature]:
+    let declaredFeature = rel.features.findFeature(feature)
+    if declaredFeature.len > 0:
+      for (depUrl, _) in rel.features[declaredFeature]:
         let idx = cache.findActivatedPackage(depUrl)
         if idx >= 0 and not cache.packages[idx].isRoot and not seen.containsOrIncl(idx):
           result.add(cache.packages[idx])
@@ -591,7 +592,7 @@ proc parseAtlasOptions(params: seq[string], action: var string, args: var seq[st
       of "dumpformular": context().flags.incl DumpFormular
       of "showgraph": context().flags.incl ShowGraph
       of "tree": context().flags.incl TreeView
-      of "update": context().flags.incl UpdateBeforeInstall
+      of "update", "u": context().flags.incl UpdateBeforeInstall
       of "ignoreurls": context().flags.incl IgnoreGitRemoteUrls
       of "keepworkspace": context().flags.incl KeepWorkspace
       of "autoenv": context().flags.incl AutoEnv

--- a/src/basic/context.nim
+++ b/src/basic/context.nim
@@ -6,7 +6,7 @@
 #    distribution, for details about the copyright.
 #
 
-import std / [os, uri, paths, files, tables, sets]
+import std / [os, uri, paths, files, tables, sets, strutils]
 import versions, parse_requires, compiledpatterns, reporters
 
 export reporters
@@ -118,17 +118,40 @@ proc allFeaturesRequested*(): bool =
   initAtlasContext()
   AllFeatures in atlasContext.flags
 
+func sameFeature*(a, b: string): bool {.inline.} =
+  ## Feature names follow Nim's style-insensitive conditional-symbol semantics.
+  cmpIgnoreStyle(a, b) == 0
+
+proc findFeature*[T](features: Table[string, T]; name: string): string =
+  ## Returns the declared spelling of `name`, or an empty string when missing.
+  for declaredName in features.keys():
+    if sameFeature(declaredName, name):
+      return declaredName
+
+proc containsFeature*(features: HashSet[string]; name: string): bool =
+  for feature in features:
+    if sameFeature(feature, name):
+      return true
+
+proc containsFeature*(features: openArray[string]; name: string): bool =
+  for feature in features:
+    if sameFeature(feature, name):
+      return true
+
+proc addUniqueFeature*(features: var seq[string]; feature: string) =
+  if not features.containsFeature(feature):
+    features.add feature
+
 proc hasRequestedFeature*(pkgShortName, pkgProjectName, feature: string): bool =
   initAtlasContext()
   if AllFeatures in atlasContext.flags:
     return true
-  if feature in atlasContext.features:
-    return true
   let scopedByShortName = "feature." & pkgShortName & "." & feature
   let scopedByProjectName = "feature." & pkgProjectName & "." & feature
   result =
-    scopedByShortName in atlasContext.features or
-    scopedByProjectName in atlasContext.features
+    atlasContext.features.containsFeature(feature) or
+    atlasContext.features.containsFeature(scopedByShortName) or
+    atlasContext.features.containsFeature(scopedByProjectName)
 
 proc packagesDirectory*(): Path =
   depsDir() / DefaultPackagesSubDir

--- a/src/basic/nimbleparser.nim
+++ b/src/basic/nimbleparser.nim
@@ -99,7 +99,7 @@ proc hasNimbleRequirement*(nimbleFile: Path; url: PkgUrl): bool =
     url.requiresName().toLowerAscii()
   ]
 
-  for req in extractRequiresInfo(nimbleFile).requires:
+  proc matchesRequirement(req: string): bool =
     let (name, _, _) = extractRequirementName(req)
     if name.toLowerAscii() in names:
       return true
@@ -107,6 +107,15 @@ proc hasNimbleRequirement*(nimbleFile: Path; url: PkgUrl): bool =
       let reqUrl = createUrlSkipPatterns(name)
       if reqUrl.shortName().toLowerAscii() == url.shortName().toLowerAscii() or
           reqUrl.projectName().toLowerAscii() == url.projectName().toLowerAscii():
+        return true
+
+  let nimbleInfo = extractRequiresInfo(nimbleFile)
+  for req in nimbleInfo.requires:
+    if matchesRequirement(req):
+      return true
+  for _, reqs in nimbleInfo.features:
+    for req in reqs:
+      if matchesRequirement(req):
         return true
 
 proc patchNimbleFile*(nc: var NimbleContext;

--- a/src/depgraphs.nim
+++ b/src/depgraphs.nim
@@ -94,10 +94,11 @@ proc requirementMatches*(query: VersionInterval; depVer: PackageVersion; depRel:
     result = query.matches(depRel.version)
 
 proc hasSatisfiedFeatureDeps(graph: DepGraph; rel: NimbleRelease; featName: string): bool =
-  if featName notin rel.features:
+  let declaredFeature = rel.features.findFeature(featName)
+  if declaredFeature.len == 0:
     return false
 
-  let reqs = rel.features[featName]
+  let reqs = rel.features[declaredFeature]
   if reqs.len == 0:
     return true
 
@@ -156,9 +157,11 @@ proc collectUnsatisfiedContextFeatures(graph: DepGraph): seq[string] =
         let rel = pkg.activeNimbleRelease()
         if rel.isNil:
           continue
-        if featName in rel.features:
+        let declaredFeature = rel.features.findFeature(featName)
+        if declaredFeature.len > 0:
           declaredInNimble = true
-          if featName in pkg.activeFeatures or hasSatisfiedFeatureDeps(graph, rel, featName):
+          if pkg.activeFeatures.containsFeature(declaredFeature) or
+              hasSatisfiedFeatureDeps(graph, rel, declaredFeature):
             featureSatisfied = true
             break
 
@@ -241,8 +244,9 @@ proc addVersionConstraints(b: var Builder; graph: var DepGraph, pkg: Package) =
         if depMatches:
           compatibleVersions.add(depVer.vid)
         for feature in flags:
-          if feature in nimbleRelease.features:
-            let featureVarId = nimbleRelease.featureVars[feature]
+          let declaredFeature = nimbleRelease.features.findFeature(feature)
+          if declaredFeature.len > 0:
+            let featureVarId = nimbleRelease.featureVars[declaredFeature]
             featureVersions.mgetOrPut(depVer.vid, @[]).add(featureVarId)
 
       # Add implication: if this version is selected, one of its compatible deps must be selected
@@ -290,8 +294,9 @@ proc addVersionConstraints(b: var Builder; graph: var DepGraph, pkg: Package) =
           var featureVersions: Table[VarId, seq[VarId]]
           for depVer, nimbleRelease in depNode.validVersions():
             trace pkg.url.projectName, "checking global feature dependency:", depNode.url.projectName, "version:", $depVer
-            if feature in nimbleRelease.features:
-              let featureVarId = nimbleRelease.featureVars[feature]
+            let declaredFeature = nimbleRelease.features.findFeature(feature)
+            if declaredFeature.len > 0:
+              let featureVarId = nimbleRelease.featureVars[declaredFeature]
               featureVersions.mgetOrPut(depVer.vid, @[]).add(featureVarId)
 
           # Add implication: if this version is selected, one of its compatible deps must be selected
@@ -491,8 +496,9 @@ proc chooseDuplicatePackage(graph: DepGraph; name: string; dupePkgs: seq[Package
         return true
 
     for feature in graph.root.activeFeatures:
-      if feature in rel.features:
-        for (depUrl, _) in rel.features[feature]:
+      let declaredFeature = rel.features.findFeature(feature)
+      if declaredFeature.len > 0:
+        for (depUrl, _) in rel.features[declaredFeature]:
           if depUrl == url:
             return true
 
@@ -657,7 +663,7 @@ proc solve*(graph: var DepGraph; form: Form, rerun: var bool) =
         assert not mapInfo.release.isNil, "too bad: " & $pkg.url
         pkg.activeVersion = mapInfo.version
         if mapInfo.feature.len > 0:
-          pkg.activeFeatures.add(mapInfo.feature)
+          pkg.activeFeatures.addUniqueFeature(mapInfo.feature)
           debug pkg.url.projectName, "package satisfiable", "feature: ", mapInfo.feature
         else:
           debug pkg.url.projectName, "package satisfiable"
@@ -815,10 +821,10 @@ proc activateGraph*(graph: DepGraph): tuple[paths: seq[CfgPath], features: seq[s
   for feature in context().features:
     if feature.startsWith("feature."):
       # Already in full format: feature.$PKG.$FEATURE
-      result.features.addUnique feature
+      result.features.addUniqueFeature feature
     else:
       # Short format: FOO -> feature.$ROOT.FOO
-      result.features.addUnique "feature." & graph.root.url.projectName & "." & feature
+      result.features.addUniqueFeature "feature." & graph.root.url.projectName & "." & feature
 
   # Apply global feature flags to activeFeatures for introspection/tests.
   for pkg in graph.pkgs.values():
@@ -829,18 +835,18 @@ proc activateGraph*(graph: DepGraph): tuple[paths: seq[CfgPath], features: seq[s
       continue
     for featName in rel.features.keys():
       if hasContextFeature(pkg, featName) and hasSatisfiedFeatureDeps(graph, rel, featName):
-        pkg.activeFeatures.addUnique(featName)
+        pkg.activeFeatures.addUniqueFeature(featName)
 
   if not graph.root.isNil and graph.root.active:
     for feature in graph.root.activeFeatures:
-      result.features.addUnique "feature." & graph.root.url.projectName & "." & feature
+      result.features.addUniqueFeature "feature." & graph.root.url.projectName & "." & feature
 
   for pkg in allActiveNodes(graph):
     if pkg.isRoot: continue
     trace pkg.url.projectName, "adding CfgPath:", $relativeToWorkspace(toDestDir(graph, pkg) / getCfgPath(graph, pkg).Path)
     result.paths.add CfgPath(toDestDir(graph, pkg) / getCfgPath(graph, pkg).Path)
     for feature in pkg.activeFeatures:
-      result.features.addUnique "feature." & pkg.url.shortName & "." & feature
+      result.features.addUniqueFeature "feature." & pkg.url.shortName & "." & feature
 
   result.paths.sort(proc (a, b: CfgPath): int =
     cmp(a.string, b.string)

--- a/tests/tfeatures.nim
+++ b/tests/tfeatures.nim
@@ -284,7 +284,7 @@ suite "test global features":
         withDir "deps" / "proj_a":
           writeFile("proj_a.nimble", dedent"""
           requires "proj_b >= 1.1.0"
-          feature "testing":
+          feature "Test_Ing":
             requires "$1 >= 1.0.0"
           """ % [toWindowsFileUrl("file://" & $featureDepPath)])
           exec "git add proj_a.nimble"
@@ -301,7 +301,9 @@ suite "test global features":
         ])
 
         check dirExists("deps" / "proj_feature_dep")
-        check "deps/proj_feature_dep" in readFile("nim.cfg")
+        let nimCfg = readFile("nim.cfg")
+        check "deps/proj_feature_dep" in nimCfg
+        check "feature.proj_a.testing" in nimCfg
         check fileExists("deps" / ".cache" / "atlas.active.json")
         check not fileExists("deps" / "atlas.cache.json")
 

--- a/tests/tinstall.nim
+++ b/tests/tinstall.nim
@@ -61,6 +61,30 @@ version "0.1.0"
       if dirExists($dir):
         removeDir($dir)
 
+  test "install accepts -u when nimble file has no requirements":
+    let dir = getTempDir().Path / Path"atlas_install_short_update_no_requirements"
+    if dirExists($dir):
+      removeDir($dir)
+    createDir($dir)
+
+    try:
+      withDir dir:
+        writeFile("emptydeps.nimble", """
+version "0.1.0"
+""")
+
+        setAtlasVerbosity(Error)
+        setContext AtlasContext()
+        atlasRun(@["-u", "install"])
+
+        check atlasErrors() == 0
+        check fileExists("nim.cfg")
+        let cfg = readFile("nim.cfg")
+        check "--noNimblePath" in cfg
+    finally:
+      if dirExists($dir):
+        removeDir($dir)
+
   test "removes stale nimble.paths when writing nim.cfg":
     let oldCtx = context()
     let dir = getTempDir().Path / Path"atlas_install_stale_nimble_paths"

--- a/tests/tlinks.nim
+++ b/tests/tlinks.nim
@@ -4,7 +4,7 @@ import std / [strutils, os, uri, jsonutils, json, tables, sequtils, unittest]
 import std/terminal
 
 import basic/[sattypes, context, reporters, pkgurls, compiledpatterns, versions]
-import basic/[deptypes, nimblecontext, deptypesjson, nimbleparser]
+import basic/[deptypes, nimblecontext, deptypesjson, nimbleparser, parse_requires]
 import dependencies
 import depgraphs
 import integration_test_utils
@@ -163,6 +163,32 @@ suite "test link integration":
         check hasNimbleRequirement(nimbleFile, linkUri)
 
         removeFile($nimbleFile)
+
+  test "link precheck detects forge alias dependency in feature block":
+      withDir "tests/ws_link_integration":
+        let nimbleFile = Path"link_feature_precheck.nimble"
+        defer:
+          removeFile($nimbleFile)
+        writeFile($nimbleFile, dedent"""
+        feature "SiWin":
+          requires "gh:elcritch/siwin"
+        """)
+
+        let linkedNimble =
+          (paths.getCurrentDir() / Path"siwin.nimble").absolutePath
+        let linkUri = toPkgUriRaw(parseUri("link://" & $linkedNimble))
+        let forgeUri = createUrlSkipPatterns("gh:elcritch/siwin")
+
+        check $forgeUri == "https://github.com/elcritch/siwin"
+        check hasNimbleRequirement(nimbleFile, linkUri)
+
+        var nc = createNimbleContext()
+        nc.put("siwin", linkUri)
+        patchNimbleFile(nc, nimbleFile, "siwin")
+
+        let info = extractRequiresInfo(nimbleFile)
+        check info.requires.len == 0
+        check info.features["SiWin"] == @["gh:elcritch/siwin"]
 
   test "expand using link files part 2":
       setAtlasVerbosity(Warning)

--- a/tests/tlockfiles.nim
+++ b/tests/tlockfiles.nim
@@ -1,0 +1,113 @@
+import std/[os, paths, strutils, tables, unittest]
+
+import atlas
+import basic/[context, gitops, lockfiletypes, pkgurls, reporters]
+import integration_test_utils
+
+type
+  LockFixture = object
+    baseDir: Path
+    projectDir: Path
+    dependencyDir: Path
+    dependencyUrl: string
+    dependencyCommit: string
+    nimbleContent: string
+
+proc createLockFixture(name: string): LockFixture =
+  result.baseDir = getTempDir().Path / Path("atlas_lockfiles_" & name)
+  result.projectDir = result.baseDir / Path"workspace"
+  result.dependencyDir = result.baseDir / Path"source" / Path"lockeddep"
+
+  if dirExists($result.baseDir):
+    removeDir($result.baseDir)
+  createDir($result.projectDir)
+  createDir($result.dependencyDir)
+
+  withDir $result.dependencyDir:
+    writeFile("lockeddep.nimble", "version \"1.0.0\"\n")
+    writeFile("marker.txt", "locked revision\n")
+    exec "git init"
+    exec "git config user.email atlas-tests@example.com"
+    exec "git config user.name Atlas Tests"
+    exec "git add lockeddep.nimble marker.txt"
+    exec "git commit -m \"Add locked dependency\""
+    exec "git tag v1.0.0"
+
+  result.dependencyCommit = currentGitCommit(result.dependencyDir).h
+  result.dependencyUrl = toWindowsFileUrl(
+    "file://" & $result.dependencyDir.absolutePath)
+  result.nimbleContent =
+    "version \"0.1.0\"\n" &
+    "requires \"" & result.dependencyUrl & " >= 1.0.0\"\n"
+  writeFile($(result.projectDir / Path"lockfixture.nimble"), result.nimbleContent)
+
+proc removeLockFixture(fixture: LockFixture) =
+  if dirExists($fixture.baseDir):
+    removeDir($fixture.baseDir)
+
+proc installFixture(fixture: LockFixture) =
+  setContext AtlasContext()
+  setAtlasVerbosity(Error)
+  withDir $fixture.projectDir:
+    atlasRun(@["--deps=deps", "--project=.", "--noexec", "install"])
+
+suite "lock file integration":
+  test "pin creates an Atlas lock file from installed dependencies":
+    let oldContext = context()
+    let fixture = createLockFixture("pin")
+    defer:
+      setContext(oldContext)
+      removeLockFixture(fixture)
+
+    fixture.installFixture()
+    withDir $fixture.projectDir:
+      let nimCfg = readFile("nim.cfg")
+      atlasRun(@["pin"])
+
+      check atlasErrors() == 0
+      check fileExists("atlas.lock")
+
+      let lock = readLockFile(Path"atlas.lock")
+      check lock.items.len == 1
+      check lock.items.hasKey("lockeddep")
+      if lock.items.hasKey("lockeddep"):
+        let entry = lock.items["lockeddep"]
+        check entry.dir == Path"$deps" / Path"lockeddep"
+        check entry.url == fixture.dependencyUrl
+        check entry.commit == fixture.dependencyCommit
+      check lock.nimcfg.join("\n") == nimCfg
+      check lock.nimbleFile.filename == Path"lockfixture.nimble"
+      check lock.nimbleFile.content.join("\n") == fixture.nimbleContent
+
+  test "replay restores the locked revision and project files":
+    let oldContext = context()
+    let fixture = createLockFixture("replay")
+    defer:
+      setContext(oldContext)
+      removeLockFixture(fixture)
+
+    fixture.installFixture()
+    withDir $fixture.projectDir:
+      let nimCfg = readFile("nim.cfg")
+      atlasRun(@["pin", "saved.lock"])
+
+      withDir $fixture.dependencyDir:
+        writeFile("marker.txt", "new revision\n")
+        exec "git add marker.txt"
+        exec "git commit -m \"Advance dependency\""
+      check currentGitCommit(fixture.dependencyDir).h != fixture.dependencyCommit
+
+      removeDir("deps")
+      writeFile("nim.cfg", "corrupted config\n")
+      writeFile("lockfixture.nimble", "version \"9.9.9\"\n")
+
+      atlasRun(@["replay", "saved.lock"])
+
+      let installedDependency = Path"deps" / Path"lockeddep"
+      check atlasErrors() == 0
+      check dirExists($installedDependency)
+      check currentGitCommit(installedDependency).h == fixture.dependencyCommit
+      check readFile($(installedDependency / Path"marker.txt")) ==
+        "locked revision\n"
+      check readFile("nim.cfg") == nimCfg
+      check readFile("lockfixture.nimble") == fixture.nimbleContent


### PR DESCRIPTION
## Summary

- match feature names with Nim style-insensitive semantics across solving, activation, dependency lookup, and emitted defines
- detect link dependencies declared inside feature blocks, including forge aliases such as `gh:...`
- add lock-file pin/replay integration coverage
- add `-u` as the short alias for `--update`
- bump the package version to 0.14.8

## Root cause

Feature lookups used exact table and sequence membership even though Nim conditional symbols ignore case and underscores. Link prechecks only inspected top-level requirements, so feature-scoped and forge-aliased dependencies were missed.

## Validation

- `nim c -r tests/tlinks.nim`
- `nim c -r tests/tfeatures.nim`
- `nim c -r tests/tinstall.nim`
- `nim c -r tests/tlockfiles.nim`
- `nim c -d:release -r tests/tlockfiles.nim`
- `nim c -d:danger -r tests/tlockfiles.nim`
- `nim build`
- `git diff --check`