### PR TITLE
fix tags caching issue and add unlink command

### DIFF
--- a/atlas.nimble
+++ b/atlas.nimble
@@ -1,5 +1,5 @@
 # Package
-version = "0.14.8"
+version = "0.14.9"
 author = "Araq"
 description = "Atlas is a simple package cloner tool. It manages an isolated project."
 license = "MIT"

--- a/doc/atlas.md
+++ b/doc/atlas.md
@@ -155,7 +155,7 @@ For example:
   atlas link ../other-project
 ```
 
-This will link the other project and make its dependencies available to your current project. The other project must be another Atlas project and have a Nimble file.
+This will link the other project and make its dependencies available to your current project. The other project must be another Atlas project and have a Nimble file. Run `atlas install` in the linked project first so Atlas can create its current dependency activation cache. This is required when linking projects last installed by an older Atlas version.
 
 The linked project will be added to this project's Nimble file if it's not already present.
 

--- a/doc/atlas.md
+++ b/doc/atlas.md
@@ -161,6 +161,25 @@ The linked project will be added to this project's Nimble file if it's not alrea
 
 Note, that the other project's `nameOverrides` and `urlOverrides` *aren't* imported. You may need to import the name-overrides to properly use the deps. This is due to the triplet-naming above.
 
+### Unlink <package>
+
+Remove a linked package from the current project, including its `nimble-link`
+files, activation-cache entries, and generated `nim.cfg` paths. By default,
+Atlas also removes the linked package's cached child dependencies:
+
+```
+  atlas unlink other-project
+```
+
+Children still needed by another active dependency are kept linked.
+
+Use `--only` to remove just the named package while keeping its child
+dependencies linked:
+
+```
+  atlas unlink --only other-project
+```
+
 ### Use / Update <url>/<package name>
 
 `atlas use <url|pkgname>` clones a package and its dependencies (recursively) into the project.

--- a/doc/atlas.md
+++ b/doc/atlas.md
@@ -67,9 +67,10 @@ If dependency URLs use `git://`, pass `--forceGitToHttps` to rewrite them to
 
 Atlas caches parsed dependency release metadata in `deps/.cache`. Each cache
 file is scoped to one package URL and is reused only while the package's remote
-HEAD, local checked-out commit, and relevant release-collection flags still
-match. If those inputs change, Atlas reparses the package's Nimble files and
-rewrites the cache.
+HEAD, local checked-out commit, fetched tag refs, and relevant
+release-collection flags still match. If those inputs change, Atlas reparses
+the package's Nimble files and rewrites the cache. This includes a new tag
+published at an existing commit after `atlas install --update` fetches it.
 
 In addition to full URLs and package names, Atlas supports a shorthand
 **forge alias** syntax of the form `<alias>:<user>/<repo>`. The supported

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -390,6 +390,11 @@ proc linkPackage(linkDir, linkedNimble: Path) =
   ## nimble file and create links to the dependent nimble files in the current
   ## project's deps directory
 
+  # Do this before altering the current project's Nimble file. Older Atlas
+  # versions did not create this cache, so explain how to upgrade the linked
+  # project instead of failing while trying to parse a missing file.
+  let lcache = loadActivationCache(linkedNimble)
+
   let linkUri = toPkgUriRaw(parseUri("link://" & $linkedNimble))
   discard context().nameOverrides.addPattern(linkUri.projectName, $linkUri.url)
   info "atlas:link", "link uri:", $linkUri
@@ -408,7 +413,6 @@ proc linkPackage(linkDir, linkedNimble: Path) =
 
   # Load linked project's config to get its deps dir
   info "atlas:link", "linked project dir:", $linkDir
-  let lcache = loadActivationCache(linkedNimble)
 
   # Create links for all nimble files and links in the linked project
   for pkg in lcache.packages:

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -38,6 +38,7 @@ Commands:
                         search for package that contains the given keywords
   link <path>           link an existing project into the current project
                         to share its dependencies
+  unlink <package>      remove a linked package and its linked dependencies
   tag [major|minor|patch|<semver>|a..z]
                         add and push a new tag, input must be one of:
                         ['major'|'minor'|'patch'] or a SemVer tag like ['1.0.3']
@@ -75,6 +76,7 @@ Options:
   --showGraph           show the dependency graph
   --tree                show `atlas deps` output as a dependency tree
   --update, -u          for `install`, update dependency repos before solving
+  --only                for `unlink`, leave child dependencies linked
   --noexec              do not perform any action that may run arbitrary code
   --autoenv             detect the minimal Nim $version and setup a
                         corresponding Nim virtual environment
@@ -393,6 +395,11 @@ proc linkPackage(linkDir, linkedNimble: Path) =
   # Do this before altering the current project's Nimble file. Older Atlas
   # versions did not create this cache, so explain how to upgrade the linked
   # project instead of failing while trying to parse a missing file.
+  let linkedActivationCache = activationCacheFileFor(linkedNimble)
+  if not fileExists($linkedActivationCache):
+    fatal "The linked project has no current activation cache at " &
+      $linkedActivationCache & ". Run `atlas install` in " & $linkDir &
+      " with this version of Atlas, then retry `atlas link`."
   let lcache = loadActivationCache(linkedNimble)
 
   let linkUri = toPkgUriRaw(parseUri("link://" & $linkedNimble))
@@ -429,6 +436,102 @@ proc linkPackage(linkDir, linkedNimble: Path) =
     createNimbleLink(linkPkgUrl, nimble, CfgPath(pkg.srcDir))
 
   installDependencies(nc, nimbleFile)
+
+proc activatedPackageMatches(pkg: ActivatedPackage; name: string): bool =
+  let needle = name.toLowerAscii()
+  result = needle == ($pkg.url).toLowerAscii() or
+    needle == pkg.url.shortName().toLowerAscii() or
+    needle == pkg.url.projectName().toLowerAscii() or
+    needle == pkg.url.fullName().toLowerAscii()
+
+proc findActivatedPackage(cache: ActivationCache; name: string): int =
+  for i, pkg in cache.packages:
+    if not pkg.isRoot and pkg.activatedPackageMatches(name):
+      return i
+  return -1
+
+proc linkedPackageClosure(cache: ActivationCache; packageIndex: int;
+                          only: bool): HashSet[int] =
+  var closure: HashSet[int]
+
+  proc collect(pkg: ActivatedPackage) =
+    let idx = cache.findActivatedPackage($pkg.url)
+    if idx < 0 or closure.containsOrIncl(idx):
+      return
+    if not only:
+      for child in cache.activeDirectDependencies(cache.packages[idx]):
+        collect(child)
+
+  collect(cache.packages[packageIndex])
+  if not only:
+    var retained: HashSet[int]
+
+    proc retain(pkg: ActivatedPackage) =
+      let idx = cache.findActivatedPackage($pkg.url)
+      if idx < 0 or idx == packageIndex or retained.containsOrIncl(idx):
+        return
+      for child in cache.activeDirectDependencies(cache.packages[idx]):
+        retain(child)
+
+    for pkg in cache.packages:
+      if pkg.isRoot:
+        for child in cache.activeDirectDependencies(pkg):
+          retain(child)
+        break
+    for idx in retained:
+      closure.excl(idx)
+  result = closure
+
+proc activationCachePaths(cache: ActivationCache): tuple[
+    paths: seq[CfgPath], features: seq[string]] =
+  for pkg in cache.packages:
+    if pkg.isRoot:
+      for feature in pkg.features:
+        result.features.addUniqueFeature "feature." & pkg.url.projectName & "." & feature
+    else:
+      result.paths.add CfgPath(pkg.ondisk / pkg.srcDir)
+      for feature in pkg.features:
+        result.features.addUniqueFeature "feature." & pkg.url.shortName & "." & feature
+  result.paths.sort(proc (a, b: CfgPath): int = cmp(a.string, b.string))
+
+proc linkFileFor(pkg: ActivatedPackage): Path =
+  result = pkg.url.toLinkPath()
+  if result.len == 0:
+    result = depsDir() / Path(pkg.url.projectName() & ".nimble-link")
+
+proc unlinkPackage(name: string; only: bool = false) =
+  ## Removes a linked package and optionally its cached child dependencies.
+  let nimbleFile = findProjectNimbleFile().absolutePath
+  let cache = loadActivationCache(nimbleFile)
+  let packageIndex = cache.findActivatedPackage(name)
+  if packageIndex < 0:
+    fatal "No active linked package named: " & name
+
+  let removal = cache.linkedPackageClosure(packageIndex, only)
+  let target = cache.packages[packageIndex]
+  if not target.url.isNimbleLink():
+    fatal "Package is not linked: " & name
+  if removeNimbleRequirement(nimbleFile, target.url):
+    info "atlas:unlink", "removed dependency from:", $nimbleFile
+  else:
+    warn "atlas:unlink", "no top-level requirement found for:", target.url.projectName
+
+  var updated: ActivationCache
+  for i, pkg in cache.packages:
+    if i in removal:
+      let linkFile = pkg.linkFileFor()
+      if fileExists($linkFile):
+        removeFile($linkFile)
+      info "atlas:unlink", "unlinked:", pkg.url.projectName
+    else:
+      updated.packages.add(pkg)
+
+  discard context().nameOverrides.removePattern(target.url.projectName)
+  writeConfig()
+  removeDepGraphCache()
+  writeActivationCache(updated)
+  let (paths, features) = updated.activationCachePaths()
+  patchNimCfg(paths, CfgPath project(), features)
 
 proc detectProject(): bool =
   ## find project by checking `currentDir` and its parents.
@@ -597,6 +700,7 @@ proc parseAtlasOptions(params: seq[string], action: var string, args: var seq[st
       of "showgraph": context().flags.incl ShowGraph
       of "tree": context().flags.incl TreeView
       of "update", "u": context().flags.incl UpdateBeforeInstall
+      of "only": context().flags.incl UnlinkOnly
       of "ignoreurls": context().flags.incl IgnoreGitRemoteUrls
       of "keepworkspace": context().flags.incl KeepWorkspace
       of "autoenv": context().flags.incl AutoEnv
@@ -690,6 +794,8 @@ proc atlasRun*(params: seq[string]) =
 
   if UpdateBeforeInstall in context().flags and action != "install":
     fatal "--update option is only valid with `install`"
+  if UnlinkOnly in context().flags and action != "unlink":
+    fatal "--only option is only valid with `unlink`"
 
   if action notin ["init", "tag", "search", "list"]:
     doAssert project().string != "" and project().dirExists(), "project was not set"
@@ -764,6 +870,10 @@ proc atlasRun*(params: seq[string]) =
       quit(2)
 
     linkPackage(linkDir, linkedNimbles[0])
+
+  of "unlink":
+    singleArg()
+    unlinkPackage(args[0], UnlinkOnly in context().flags)
 
   of "pin":
     optSingleArg($LockFileName)

--- a/src/basic/compiledpatterns.nim
+++ b/src/basic/compiledpatterns.nim
@@ -220,6 +220,20 @@ proc addPattern*(p: var Patterns; inputPattern, outputPattern: string): string =
       p.patterns.add((inputPattern, outputPattern))
       result = ""
 
+proc removePattern*(p: var Patterns; inputPattern: string): bool =
+  ## Removes all rewrite rules with `inputPattern`.
+  var kept: seq[(string, string)]
+  for (input, output) in p.patterns:
+    if input == inputPattern:
+      result = true
+    else:
+      kept.add((input, output))
+
+  if result:
+    p = initPatterns()
+    for (input, output) in kept:
+      discard p.addPattern(input, output)
+
 proc substitute*(p: Patterns; input: string; didReplace: var bool): string =
   if input in p.t:
     didReplace = true

--- a/src/basic/context.nim
+++ b/src/basic/context.nim
@@ -59,6 +59,7 @@ type
     KeepFeatures
     AllFeatures
     TreeView
+    UnlinkOnly
     IncludeTagsAndNimbleCommits # include nimble commits and tags in the solver
     NimbleCommitsMax # takes the newest commit for each version
 

--- a/src/basic/dependencycache.nim
+++ b/src/basic/dependencycache.nim
@@ -26,6 +26,7 @@ type
     fullName*: string
     head*: CommitHash
     current*: CommitHash
+    tagRefs*: string
     author*: string
     description*: string
     license*: string
@@ -46,7 +47,7 @@ type
     releases*: seq[PackageReleaseCacheEntry]
 
 const
-  PackageReleaseCacheVersion = 4
+  PackageReleaseCacheVersion = 5
 
 proc sanitizeCacheStem(stem: var string) =
   for c in mitems(stem):
@@ -181,6 +182,7 @@ proc toPackageReleaseCacheJson(cache: PackageReleaseCache; opt: ToJsonOptions): 
     result["fullName"] = toJson(cache.fullName, opt)
   result["head"] = toJson(cache.head, opt)
   result["current"] = toJson(cache.current, opt)
+  result["tagRefs"] = toJson(cache.tagRefs, opt)
   if cache.author.len > 0:
     result["author"] = toJson(cache.author, opt)
   if cache.description.len > 0:
@@ -316,7 +318,8 @@ proc loadPackageReleaseCacheJson(cache: var PackageReleaseCache; jn: JsonNode) =
 proc loadPackageReleaseCache*(
     pkg: Package;
     currentCommit: CommitHash;
-    entries: var seq[PackageReleaseCacheEntry]
+    entries: var seq[PackageReleaseCacheEntry];
+    tagRefs = ""
 ): bool =
   if pkg.originHead.isEmpty():
     return false
@@ -342,6 +345,7 @@ proc loadPackageReleaseCache*(
     cache.subdir == (if pkg.subdir.len > 0: pkg.subdir else: pkg.url.subdir()) and
     cache.head == pkg.originHead and
     cache.current == currentCommit and
+    cache.tagRefs == tagRefs and
     cache.includeTagsAndNimbleCommits == includeTagsAndNimbleCommitsFlag() and
     cache.nimbleCommitsMax == nimbleCommitsMaxFlag()
 
@@ -352,7 +356,8 @@ proc loadPackageReleaseCache*(
 proc savePackageReleaseCache*(
     pkg: Package;
     currentCommit: CommitHash;
-    versions: seq[(PackageVersion, NimbleRelease)]
+    versions: seq[(PackageVersion, NimbleRelease)];
+    tagRefs = ""
 ) =
   if pkg.originHead.isEmpty():
     return
@@ -365,6 +370,7 @@ proc savePackageReleaseCache*(
     fullName: pkg.url.fullName(),
     head: pkg.originHead,
     current: currentCommit,
+    tagRefs: tagRefs,
     author: firstNonEmptyMetadata(versions, proc (release: NimbleRelease): string = release.author),
     description: firstNonEmptyMetadata(versions, proc (release: NimbleRelease): string = release.description),
     license: firstNonEmptyMetadata(versions, proc (release: NimbleRelease): string = release.license),

--- a/src/basic/gitops.nim
+++ b/src/basic/gitops.nim
@@ -563,6 +563,21 @@ proc findOriginTip*(path: Path; origin = "origin"; errorReportLevel: MsgKind = W
   let repo = loadRepoMetadata(path, origin, errorReportLevel = errorReportLevel, isLocalOnly = isLocalOnly)
   findOriginTip(repo, errorReportLevel)
 
+proc tagRefsSnapshot*(repo: RepoMetadata; errorReportLevel: MsgKind = Debug): string =
+  ## Returns the tag refs used for release discovery, including their targets.
+  ##
+  ## Unlike the branch tip, this changes when a tag is added to an existing
+  ## commit, so release caches can use it to detect newly published versions.
+  if not isGitDir(repo.path):
+    return
+
+  var refs = @["--format=%(refname) %(objectname)", "refs/tags"]
+  if repo.remoteName.len > 0:
+    refs.add "refs/remotes/" & repo.remoteName & "/tags"
+  let (outp, status) = exec(GitForEachRef, repo.path, refs, errorReportLevel)
+  if status == RES_OK:
+    result = outp.strip()
+
 proc collectTaggedVersions*(repo: RepoMetadata; errorReportLevel: MsgKind = Debug): seq[VersionTag] =
   let tip = findOriginTip(repo, errorReportLevel)
 

--- a/src/basic/nimbleparser.nim
+++ b/src/basic/nimbleparser.nim
@@ -118,6 +118,48 @@ proc hasNimbleRequirement*(nimbleFile: Path; url: PkgUrl): bool =
       if matchesRequirement(req):
         return true
 
+proc removeNimbleRequirement*(nimbleFile: Path; url: PkgUrl): bool =
+  ## Removes a top-level, single-requirement line previously added by Atlas.
+  ## Feature requirements and grouped requirements are left untouched.
+  doAssert nimbleFile.string.fileExists()
+
+  let names = [
+    url.shortName().toLowerAscii(),
+    url.projectName().toLowerAscii(),
+    url.fullName().toLowerAscii(),
+    url.requiresName().toLowerAscii()
+  ]
+
+  proc matchesRequirement(req: string): bool =
+    let (name, _, _) = extractRequirementName(req)
+    if name.toLowerAscii() in names:
+      return true
+    if name.isUrl():
+      let reqUrl = createUrlSkipPatterns(name)
+      return reqUrl.shortName().toLowerAscii() == url.shortName().toLowerAscii() or
+        reqUrl.projectName().toLowerAscii() == url.projectName().toLowerAscii()
+
+  let content = readFile($nimbleFile)
+  var lines: seq[string]
+  for line in content.splitLines():
+    let stripped = line.strip()
+    var remove = false
+    if line == stripped and stripped.startsWith("requires "):
+      let req = stripped["requires ".len .. ^1].strip()
+      if req.len >= 2 and req[0] == '"' and req[^1] == '"':
+        remove = matchesRequirement(req[1 .. ^2])
+    if remove:
+      result = true
+    else:
+      lines.add(line)
+
+  if result:
+    var updated = lines.join("\n")
+    if content.len > 0 and content[^1] == '\n' and
+        (updated.len == 0 or updated[^1] != '\n'):
+      updated.add "\n"
+    writeFile($nimbleFile, updated)
+
 proc patchNimbleFile*(nc: var NimbleContext;
                       nimbleFile: Path, name: string) =
   var url = nc.createUrl(name)  # This will handle both name and URL overrides internally

--- a/src/confighandler.nim
+++ b/src/confighandler.nim
@@ -212,12 +212,23 @@ proc writeActivationCache*(g: DepGraph) =
   let jn = toJson(toActivationCache(g), ToJsonOptions(enumMode: joptEnumString))
   writeFile($configFile, pretty(jn))
 
-proc loadActivationCache*(nimbleFile: Path): ActivationCache =
-  doAssert nimbleFile.isAbsolute() and endsWith($nimbleFile, ".nimble") and fileExists($nimbleFile)
+proc activationCacheFileFor*(nimbleFile: Path): Path =
+  ## Returns the activation-cache path configured for a project Nimble file.
+  doAssert nimbleFile.isAbsolute() and endsWith($nimbleFile, ".nimble") and
+    fileExists($nimbleFile)
   let projectDir = nimbleFile.parentDir()
   var ctx = AtlasContext(projectDir: projectDir)
   readAtlasContext(ctx, projectDir)
-  let configFile = activationCacheFile(ctx)
+  result = activationCacheFile(ctx)
+
+proc loadActivationCache*(nimbleFile: Path): ActivationCache =
+  ## Loads the dependency activation cache created by `atlas install`.
+  let projectDir = nimbleFile.parentDir()
+  let configFile = activationCacheFileFor(nimbleFile)
+  if not fileExists($configFile):
+    fatal "The linked project has no current activation cache at " & $configFile &
+      ". Run `atlas install` in " & $projectDir &
+      " with this version of Atlas, then retry `atlas link`."
   debug "atlas", "reading activation cache from: ", $configFile
   result.fromJson(parseFile($configFile), Joptions(allowMissingKeys: true, allowExtraKeys: true))
 

--- a/src/confighandler.nim
+++ b/src/confighandler.nim
@@ -205,12 +205,15 @@ proc toActivationCache*(g: DepGraph): ActivationCache =
     cmp($a.url, $b.url)
   )
 
-proc writeActivationCache*(g: DepGraph) =
+proc writeActivationCache*(cache: ActivationCache) =
   let configFile = activationCacheFile()
   createDir($configFile.parentDir())
   debug "atlas", "writing activation cache to: ", $configFile
-  let jn = toJson(toActivationCache(g), ToJsonOptions(enumMode: joptEnumString))
+  let jn = toJson(cache, ToJsonOptions(enumMode: joptEnumString))
   writeFile($configFile, pretty(jn))
+
+proc writeActivationCache*(g: DepGraph) =
+  writeActivationCache(toActivationCache(g))
 
 proc activationCacheFileFor*(nimbleFile: Path): Path =
   ## Returns the activation-cache path configured for a project Nimble file.
@@ -226,9 +229,8 @@ proc loadActivationCache*(nimbleFile: Path): ActivationCache =
   let projectDir = nimbleFile.parentDir()
   let configFile = activationCacheFileFor(nimbleFile)
   if not fileExists($configFile):
-    fatal "The linked project has no current activation cache at " & $configFile &
-      ". Run `atlas install` in " & $projectDir &
-      " with this version of Atlas, then retry `atlas link`."
+    fatal "No current activation cache at " & $configFile & ". Run `atlas install` in " &
+      $projectDir & " with this version of Atlas, then retry."
   debug "atlas", "reading activation cache from: ", $configFile
   result.fromJson(parseFile($configFile), Joptions(allowMissingKeys: true, allowExtraKeys: true))
 

--- a/src/releaseinfo.nim
+++ b/src/releaseinfo.nim
@@ -137,10 +137,11 @@ proc loadPackageReleaseInfo*(
   )
   result.currentCommit = repo.currentCommit
   pkg.originHead = repo.originTip.commit()
+  let tagRefs = tagRefsSnapshot(repo)
 
   if canUsePackageReleaseCache(pkg, mode, result.expandedExplicitVersions):
     var cachedReleases: seq[PackageReleaseCacheEntry]
-    if loadPackageReleaseCache(pkg, result.currentCommit, cachedReleases):
+    if loadPackageReleaseCache(pkg, result.currentCommit, cachedReleases, tagRefs):
       for entry in cachedReleases:
         result.releases.add((entry.vtag.toPkgVer(), entry.release))
       result.loadedFromCache = true
@@ -238,4 +239,4 @@ proc loadPackageReleaseInfo*(
   result.releases = deduplicateReleases(pkg, result.releases)
 
   if canUsePackageReleaseCache(pkg, mode, result.expandedExplicitVersions):
-    savePackageReleaseCache(pkg, result.currentCommit, result.releases)
+    savePackageReleaseCache(pkg, result.currentCommit, result.releases, tagRefsSnapshot(repo))

--- a/tests/tlinks.nim
+++ b/tests/tlinks.nim
@@ -190,6 +190,45 @@ suite "test link integration":
         check info.requires.len == 0
         check info.features["SiWin"] == @["gh:elcritch/siwin"]
 
+  test "link explains how to upgrade a project without an activation cache":
+      withDir "tests/ws_link_integration":
+        let linkedNimble = (paths.getCurrentDir() /
+          Path"../ws_link_semver/ws_link_semver.nimble").absolutePath
+        let activeCache = activationCacheFileFor(linkedNimble)
+        let oldCache = Path($activeCache & ".test-backup")
+        let legacyCache = linkedNimble.parentDir() / Path"deps/atlas.cache.json"
+        let oldLegacyCache = Path($legacyCache & ".test-backup")
+        let savedNimble = readFile("ws_link_integration.nimble")
+        let hadActiveCache = fileExists($activeCache)
+        let hadLegacyCache = fileExists($legacyCache)
+        defer:
+          writeFile("ws_link_integration.nimble", savedNimble)
+          if hadActiveCache and fileExists($oldCache):
+            moveFile($oldCache, $activeCache)
+          if hadLegacyCache and fileExists($oldLegacyCache):
+            moveFile($oldLegacyCache, $legacyCache)
+          elif fileExists($legacyCache):
+            removeFile($legacyCache)
+
+        if fileExists($oldCache):
+          removeFile($oldCache)
+        if fileExists($oldLegacyCache):
+          removeFile($oldLegacyCache)
+        if hadActiveCache:
+          moveFile($activeCache, $oldCache)
+        if hadLegacyCache:
+          moveFile($legacyCache, $oldLegacyCache)
+        writeFile($legacyCache, "{}")
+
+        try:
+          atlasRun(@["link", "../ws_link_semver"])
+          check false
+        except AtlasFatalError as err:
+          check err.msg.contains("linked project has no current activation cache")
+          check err.msg.contains("Run `atlas install`")
+          check err.msg.contains("retry `atlas link`")
+        check readFile("ws_link_integration.nimble") == savedNimble
+
   test "expand using link files part 2":
       setAtlasVerbosity(Warning)
       withDir "tests/ws_link_integration":

--- a/tests/tlinks.nims
+++ b/tests/tlinks.nims
@@ -1,0 +1,1 @@
+--d:atlasUnitTests

--- a/tests/tserde.nim
+++ b/tests/tserde.nim
@@ -1,5 +1,5 @@
-import std/[unittest, json, jsonutils, sets, tables, os, times, paths, strutils]
-import basic/[context, sattypes, pkgurls, deptypes, nimblecontext, dependencycache]
+import std/[unittest, json, jsonutils, sets, tables, os, osproc, times, paths, strutils]
+import basic/[context, sattypes, pkgurls, deptypes, nimblecontext, dependencycache, gitops]
 import basic/[deptypesjson, versions]
 import confighandler
 
@@ -137,7 +137,7 @@ suite "json serde":
       @[(VersionTag(v: Version"1.0.0", c: current).toPkgVer, release)]
     )
     let cache = parseFile($packageReleaseCachePath(pkg))
-    check cache["cacheVersion"].getInt() == 4
+    check cache["cacheVersion"].getInt() == 5
     check cache["shortName"].getStr() == "foobar"
     check cache["fullName"].getStr() == "foobar.nimble-test.github.com"
     check "packageName" notin cache
@@ -222,7 +222,45 @@ suite "json serde":
 
     savePackageReleaseCache(pkg, current, @[(version, release)])
     let regeneratedCache = parseFile($cachePath)
-    check regeneratedCache["cacheVersion"].getInt() == 4
+    check regeneratedCache["cacheVersion"].getInt() == 5
+
+  test "package release cache rejects a tag added at the current commit":
+    let oldCtx = context()
+    let ws = Path(getTempDir()) / Path("atlas_release_cache_tags_" & $int(epochTime()))
+    let repo = ws / Path"repo"
+    defer:
+      setContext(oldCtx)
+      if dirExists($ws):
+        removeDir($ws)
+
+    createDir($repo)
+    discard execCmdEx("git -C " & quoteShell($repo) & " init")
+    discard execCmdEx("git -C " & quoteShell($repo) & " config user.name test-user")
+    discard execCmdEx("git -C " & quoteShell($repo) & " config user.email test@example.com")
+    writeFile($(repo / Path"foobar.nimble"), "version = \"0.7.0\"\n")
+    discard execCmdEx("git -C " & quoteShell($repo) & " add foobar.nimble")
+    discard execCmdEx("git -C " & quoteShell($repo) & " commit -m initial")
+    discard execCmdEx("git -C " & quoteShell($repo) & " tag v0.7.0")
+
+    setContext(AtlasContext(projectDir: ws, depsDir: Path"deps"))
+    let url = nc.createUrl("foobar")
+    let current = currentGitCommit(repo)
+    let pkg = Package(url: url, ondisk: repo, originHead: current)
+    let release = NimbleRelease(version: Version"0.7.0", requirements: @[], status: Normal)
+    let version = VersionTag(v: Version"0.7.0", c: current).toPkgVer
+    let tagRefs = tagRefsSnapshot(loadRepoMetadata(repo, isLocalOnly = true))
+    savePackageReleaseCache(pkg, current, @[(version, release)], tagRefs)
+    check parseFile($packageReleaseCachePath(pkg))["tagRefs"].getStr() == tagRefs
+
+    var entries: seq[PackageReleaseCacheEntry]
+    check loadPackageReleaseCache(pkg, current, entries, tagRefs)
+
+    discard execCmdEx("git -C " & quoteShell($repo) & " tag v0.7.2")
+    let updatedTagRefs = tagRefsSnapshot(loadRepoMetadata(repo, isLocalOnly = true))
+    check updatedTagRefs != tagRefs
+    entries.setLen(0)
+    check not loadPackageReleaseCache(pkg, current, entries, updatedTagRefs)
+    check entries.len == 0
 
   test "package release cache lifts stable metadata":
     let oldCtx = context()

--- a/tests/tunlink.nim
+++ b/tests/tunlink.nim
@@ -1,0 +1,123 @@
+import std/[os, paths, sequtils, strutils, times, unittest, uri]
+
+import atlas, confighandler
+import basic/[compiledpatterns, configutils, context, pkgurls]
+
+type
+  UnlinkWorkspace = object
+    path: Path
+    linkedUrl, childUrl, keptUrl: PkgUrl
+
+proc setupUnlinkWorkspace(name: string; keptNeedsChild = false): UnlinkWorkspace =
+  result.path = Path(getTempDir()) / Path(name & "_" & $int(epochTime()))
+  if dirExists($result.path):
+    removeDir($result.path)
+  createDir($result.path)
+  setContext AtlasContext(projectDir: result.path, depsDir: Path"deps")
+
+  let deps = result.path / Path"deps"
+  let linked = result.path / Path"linked"
+  let child = result.path / Path"child"
+  let kept = result.path / Path"kept"
+  for dir in [deps, linked, child, kept]:
+    createDir($dir)
+    createDir($(dir / Path"src"))
+
+  let nimbleFile = result.path / Path"project.nimble"
+  let linkedNimble = linked / Path"linked.nimble"
+  let childNimble = child / Path"child.nimble"
+  let keptNimble = kept / Path"kept.nimble"
+  result.linkedUrl = toPkgUriRaw(parseUri("link://" & $linkedNimble.absolutePath()))
+  result.childUrl = toPkgUriRaw(parseUri("https://example.com/child"))
+  result.keptUrl = toPkgUriRaw(parseUri("https://example.com/kept"))
+
+  writeFile($nimbleFile, "requires \"linked\"\nrequires \"https://example.com/kept\"\n")
+  writeFile($linkedNimble, "requires \"https://example.com/child\"\n")
+  writeFile($childNimble, "")
+  if keptNeedsChild:
+    writeFile($keptNimble, "requires \"https://example.com/child\"\n")
+  else:
+    writeFile($keptNimble, "")
+  writeDefaultConfigFile()
+  discard context().nameOverrides.addPattern(
+    result.linkedUrl.projectName, $result.linkedUrl.url)
+  writeConfig()
+
+  createNimbleLink(result.linkedUrl, linkedNimble, CfgPath"src")
+  createNimbleLink(result.childUrl, childNimble, CfgPath"src")
+  createNimbleLink(result.keptUrl, keptNimble, CfgPath"src")
+  writeActivationCache(ActivationCache(packages: @[
+    ActivatedPackage(
+      url: toPkgUriRaw(parseUri("atlas://project")), ondisk: result.path,
+      srcDir: Path"src", isRoot: true
+    ),
+    ActivatedPackage(url: result.linkedUrl, ondisk: linked, srcDir: Path"src"),
+    ActivatedPackage(url: result.childUrl, ondisk: child, srcDir: Path"src"),
+    ActivatedPackage(url: result.keptUrl, ondisk: kept, srcDir: Path"src")
+  ]))
+  patchNimCfg(@[
+    CfgPath(linked / Path"src"),
+    CfgPath(child / Path"src"),
+    CfgPath(kept / Path"src")
+  ], CfgPath(result.path))
+
+proc runAtlas(ws: Path; params: seq[string]) =
+  let oldDir = paths.getCurrentDir()
+  try:
+    setCurrentDir($ws)
+    atlasRun(params)
+  finally:
+    setCurrentDir($oldDir)
+
+suite "unlink":
+  test "removes a linked package, its children, and activation-cache entries":
+    let ws = setupUnlinkWorkspace("atlas_unlink_all")
+    defer: removeDir($ws.path)
+
+    runAtlas(ws.path, @["unlink", "linked"])
+
+    let nimbleFile = ws.path / Path"project.nimble"
+    check readFile($nimbleFile) == "requires \"https://example.com/kept\"\n"
+    check not fileExists($ws.linkedUrl.toLinkPath())
+    check not fileExists($ws.childUrl.toLinkPath())
+    check fileExists($ws.keptUrl.toLinkPath())
+
+    let cache = loadActivationCache(nimbleFile.absolutePath())
+    check cache.packages.len == 2
+    check cache.packages.allIt(it.url.projectName != "linked")
+    check cache.packages.allIt(it.url.projectName != "child")
+    check cache.packages.anyIt(it.url.projectName == "kept")
+
+    let cfg = readFile($(ws.path / Path"nim.cfg"))
+    check "linked/src" notin cfg
+    check "child/src" notin cfg
+    check "kept/src" in cfg
+    check "linked" notin readFile($(ws.path / Path"deps/atlas.config"))
+
+  test "keeps a child that another active package requires":
+    let ws = setupUnlinkWorkspace("atlas_unlink_shared", keptNeedsChild = true)
+    defer: removeDir($ws.path)
+
+    runAtlas(ws.path, @["unlink", "linked"])
+
+    let nimbleFile = ws.path / Path"project.nimble"
+    check not fileExists($ws.linkedUrl.toLinkPath())
+    check fileExists($ws.childUrl.toLinkPath())
+    let cache = loadActivationCache(nimbleFile.absolutePath())
+    check cache.packages.anyIt(it.url.projectName == "child")
+    check "child/src" in readFile($(ws.path / Path"nim.cfg"))
+
+  test "--only leaves child links and activation-cache entries":
+    let ws = setupUnlinkWorkspace("atlas_unlink_only")
+    defer: removeDir($ws.path)
+
+    runAtlas(ws.path, @["unlink", "--only", "linked"])
+
+    let nimbleFile = ws.path / Path"project.nimble"
+    check not fileExists($ws.linkedUrl.toLinkPath())
+    check fileExists($ws.childUrl.toLinkPath())
+
+    let cache = loadActivationCache(nimbleFile.absolutePath())
+    check cache.packages.allIt(it.url.projectName != "linked")
+    check cache.packages.anyIt(it.url.projectName == "child")
+    check "child/src" in readFile($(ws.path / Path"nim.cfg"))


### PR DESCRIPTION
## Summary

- add `atlas unlink <package>` with recursive child-link cleanup and `--only`
- prune activation-cache entries, generated `nim.cfg` paths, stale graph caches, Nimble requirements, and link overrides
- preserve child links still required by another active dependency
- add integration coverage and documentation

## Validation

- `nim c -r tests/tunlink.nim`
- `nim c -d:release -r tests/tunlink.nim`
- `nim c -d:danger -r tests/tunlink.nim`
- `nim c -r tests/tlinks.nim`
- `nim c -r tests/tnimbleparser.nim`
- `nim c -r tests/tserde.nim`
- `nim build`
- `nim docs`