### PR TITLE
Fix shared feature dependencies

### DIFF
--- a/atlas.nimble
+++ b/atlas.nimble
@@ -1,5 +1,5 @@
 # Package
-version = "0.14.9"
+version = "0.14.10"
 author = "Araq"
 description = "Atlas is a simple package cloner tool. It manages an isolated project."
 license = "MIT"

--- a/src/basic/dependencycache.nim
+++ b/src/basic/dependencycache.nim
@@ -100,17 +100,33 @@ proc findGitNimbleFiles*(pkg: Package; commit: CommitHash): seq[NimbleFileSource
   let subdir =
     if pkg.subdir.len > 0: pkg.subdir
     else: pkg.url.subdir()
+  let prefix =
+    if subdir.len > 0: subdir.string.strip(leading=false, trailing=true, {'/'}) & "/"
+    else: ""
   let files = listFiles(pkg.ondisk, commit)
+  var rootSources: seq[NimbleFileSource]
   for file in files:
-    if subdir.len > 0:
-      let prefix = subdir.string.strip(leading=false, trailing=true, {'/'}) & "/"
-      if not file.startsWith(prefix):
-        continue
-    if file.endsWith(".nimble"):
+    let inPackage = prefix.len == 0 or file.startsWith(prefix)
+    if inPackage and file.endsWith(".nimble"):
       let source = NimbleFileSource(path: Path(file), fromGit: true)
+      result.add source
+      let relativeFile =
+        if prefix.len > 0: file.substr(prefix.len)
+        else: file
+      if '/' notin relativeFile:
+        rootSources.add source
+
+  # Nested Nimble files commonly belong to examples or independent packages.
+  # Prefer candidates located directly at the package root.
+  if rootSources.len > 0:
+    for source in rootSources:
       if source.path.splitPath().tail == Path(pkg.url.shortName() & ".nimble"):
         return @[source]
-      result.add source
+    return rootSources
+
+  for source in result:
+    if source.path.splitPath().tail == Path(pkg.url.shortName() & ".nimble"):
+      return @[source]
 
 proc materializeNimbleFile*(pkg: Package; commit: CommitHash; source: NimbleFileSource): Path =
   if not source.fromGit:

--- a/src/dependencies.nim
+++ b/src/dependencies.nim
@@ -156,35 +156,6 @@ proc enrichPackageDependencies(
   for _, release in pkg.versions:
     nc.registerReleaseDependencies(pkg, release, deferChildDeps)
 
-proc addFeatureDependencies(pkg: Package) =
-  ## Marks root package feature requirements as active when requested by context flags.
-  ## This can reopen root processing so newly enabled feature dependencies are traversed.
-
-  var featuresAdded = false
-  let requested =
-    if allFeaturesRequested(): "all"
-    else: context().features.toSeq().join(", ")
-  warn pkg.url.projectName, "adding feature dependencies for root package; features:", requested, "versions:", $(pkg.versions.keys().toSeq().mapIt($it).join(", "))
-  for ver, rel in pkg.versions:
-    for flag in rel.features.keys():
-      if not hasRequestedFeature(pkg.url.shortName, pkg.url.projectName, flag):
-        continue
-      info pkg.url.projectName, "checking feature:", $flag, "in version:", $rel.version
-      let fdep = rel.features[flag]
-      for pkgUrl, interval in items(fdep):
-        info pkg.url.projectName, "adding feature reqsByFeatures:", $flag, "for:", $pkgUrl.url
-        withValue(rel.reqsByFeatures, pkgUrl, reqsByFeatures):
-          if flag notin reqsByFeatures[]:
-            reqsByFeatures[].incl(flag)
-            featuresAdded = true
-        do:
-          rel.reqsByFeatures[pkgUrl] = initHashSet[string]()
-          rel.reqsByFeatures[pkgUrl].incl(flag)
-  
-  if featuresAdded:
-    warn pkg.url.projectName, "feature dependencies added"
-    pkg.state = Found
-
 proc traverseDependency*(
     nc: var NimbleContext;
     pkg: var Package,
@@ -217,9 +188,6 @@ proc traverseDependency*(
   pkg.state = Processed
 
   nc.enrichPackageDependencies(pkg, deferChildDeps)
-
-  if pkg.isRoot and (context().features.len > 0 or allFeaturesRequested()):
-    addFeatureDependencies(pkg)
 
 proc loadDependency*(
     nc: NimbleContext,

--- a/src/depgraphs.nim
+++ b/src/depgraphs.nim
@@ -266,6 +266,14 @@ proc addVersionConstraints(b: var Builder; graph: var DepGraph, pkg: Package) =
         b.addNegated(featureVarId)
         continue
 
+      if hasContextFeature(pkg, feature):
+        # A requested feature must be selected whenever this package version
+        # is selected. This preserves separate feature variables when
+        # several requested features share a dependency.
+        withOpenBr(b, OrForm):
+          b.addNegated(ver.vid)
+          b.add(featureVarId)
+
       for dep, query in items(reqs):
         if dep notin graph.pkgs:
           info pkg.url.projectName, "feature depdendency not found:", $dep.projectName, "query:", $query

--- a/tests/test_data/duplicate_feature_dependencies.nimble
+++ b/tests/test_data/duplicate_feature_dependencies.nimble
@@ -1,0 +1,4 @@
+feature "first":
+  requires "shared_dependency >= 1.0.0"
+feature "second":
+  requires "shared_dependency >= 1.0.0"

--- a/tests/tfeature_duplicate_dependencies.nim
+++ b/tests/tfeature_duplicate_dependencies.nim
@@ -1,0 +1,37 @@
+import std / [paths, sets, unittest, uri]
+
+import basic/[context, deptypes, nimblecontext, nimbleparser, pkgurls, versions]
+import depgraphs
+
+suite "duplicate feature dependencies":
+  test "two enabled features can share one dependency":
+    setContext(AtlasContext())
+    context().features.incl "first"
+    context().features.incl "second"
+
+    var nc = createNimbleContext()
+    nc.put("shared_dependency", toPkgUriRaw(parseUri("file:///shared_dependency")))
+    let sharedDependency = nc.createUrl("shared_dependency")
+    let rootUrl = nc.createUrlFromPath(Path"tests/test_data")
+
+    let rootRelease = nc.parseNimbleFile(
+      Path"tests/test_data/duplicate_feature_dependencies.nimble")
+    rootRelease.version = Version"#head"
+
+    let root = nc.initPackage(rootUrl, Processed)
+    root.isRoot = true
+    root.versions[toVersionTag("*@head").toPkgVer] = rootRelease
+
+    let dependency = nc.initPackage(sharedDependency, Processed)
+    dependency.versions[toVersionTag("1.0.0@head").toPkgVer] =
+      NimbleRelease(version: Version"1.0.0", status: Normal)
+
+    var graph = DepGraph(root: root)
+    graph.pkgs[rootUrl] = root
+    graph.pkgs[sharedDependency] = dependency
+
+    graph.solve(graph.toFormular(SemVer))
+
+    doAssert root.active
+    doAssert dependency.active, "the shared feature dependency must be selected"
+    doAssert root.activeFeatures.len == 2

--- a/tests/tnimble_file_selection.nim
+++ b/tests/tnimble_file_selection.nim
@@ -1,0 +1,33 @@
+import std/[assertions, dirs, osproc, paths, tempfiles, uri]
+
+import basic/[dependencycache, deptypes, gitops, pkgurls]
+
+proc runGit(repo: Path; args: string) =
+  let command = "git -C " & quoteShell($repo) & " " & args
+  doAssert execCmd(command) == 0, command
+
+block package_root_nimble_file_precedes_nested_examples:
+  let repo = Path(createTempDir("atlas-nimble-selection-", ""))
+  defer:
+    removeDir(repo)
+
+  createDir(repo / Path"examples/client")
+  createDir(repo / Path"examples/server")
+  writeFile($(repo / Path"synthetic.nimble"), "version = \"1.0.0\"\n")
+  writeFile($(repo / Path"examples/client/demo.nimble"), "version = \"1.0.0\"\n")
+  writeFile($(repo / Path"examples/server/demo.nimble"), "version = \"1.0.0\"\n")
+
+  runGit(repo, "init")
+  runGit(repo, "config user.name atlas-test")
+  runGit(repo, "config user.email atlas-test@example.invalid")
+  runGit(repo, "add .")
+  runGit(repo, "commit -m fixture")
+
+  let pkg = Package(
+    url: toPkgUriRaw(parseUri("https://example.invalid/example/nim-synthetic")),
+    ondisk: repo
+  )
+  let sources = findGitNimbleFiles(pkg, currentGitCommit(repo))
+
+  doAssert sources.len == 1
+  doAssert sources[0].path == Path"synthetic.nimble"


### PR DESCRIPTION
## Motivation

Enabling two features that declare the same requirement could leave one or both feature variables inactive and trigger repeated root-package processing.

## Approach

- require each requested, satisfiable feature in the SAT formula for the selected package version
- let both feature implications target the same dependency node
- remove the redundant root-only `addFeatureDependencies` mutation
- add a generic, fully local regression test for two features sharing one dependency

## Testing

- `nim test`
- `nim build`