### PR TITLE
Show commit distance for inferred versions

### DIFF
--- a/atlas.nimble
+++ b/atlas.nimble
@@ -1,5 +1,5 @@
 # Package
-version = "0.14.10"
+version = "0.14.11"
 author = "Araq"
 description = "Atlas is a simple package cloner tool. It manages an isolated project."
 license = "MIT"

--- a/doc/atlas.md
+++ b/doc/atlas.md
@@ -60,6 +60,10 @@ the number of intervening commits as SemVer build metadata. For example, the
 fifth commit after version `1.2.3` is displayed as `1.2.3+5@abcdef12`. Build
 metadata does not change SemVer precedence, so it still satisfies requirements
 for `1.2.3` while making the checkout's distance from the version bump visible.
+This display is also used when a `#head` requirement selects that commit; the
+resolved version is shown once with a trailing `^`, rather than as a separate
+`#head` release. Commit requirements retain their full hashes internally but
+are shortened to eight characters in version-selection output.
 
 Atlas uses URLs internally; Nimble package names are translated to URLs
 via Nimble's  `packages.json` file. Atlas uses "shortnames" for known URLs from

--- a/doc/atlas.md
+++ b/doc/atlas.md
@@ -55,6 +55,11 @@ edit these manually too, Atlas doesn't touch what should be left untouched.
 
 Atlas uses git commits internally; version requirements are translated
 to git commits via git tags and a fallback of searching Nimble file commits.
+When Atlas identifies an untagged commit after a Nimble version bump, it shows
+the number of intervening commits as SemVer build metadata. For example, the
+fifth commit after version `1.2.3` is displayed as `1.2.3+5@abcdef12`. Build
+metadata does not change SemVer precedence, so it still satisfies requirements
+for `1.2.3` while making the checkout's distance from the version bump visible.
 
 Atlas uses URLs internally; Nimble package names are translated to URLs
 via Nimble's  `packages.json` file. Atlas uses "shortnames" for known URLs from

--- a/src/basic/dependencycache.nim
+++ b/src/basic/dependencycache.nim
@@ -47,7 +47,7 @@ type
     releases*: seq[PackageReleaseCacheEntry]
 
 const
-  PackageReleaseCacheVersion = 5
+  PackageReleaseCacheVersion = 6
 
 proc sanitizeCacheStem(stem: var string) =
   for c in mitems(stem):

--- a/src/basic/dependencycache.nim
+++ b/src/basic/dependencycache.nim
@@ -47,7 +47,7 @@ type
     releases*: seq[PackageReleaseCacheEntry]
 
 const
-  PackageReleaseCacheVersion = 6
+  PackageReleaseCacheVersion = 7
 
 proc sanitizeCacheStem(stem: var string) =
   for c in mitems(stem):

--- a/src/basic/gitops.nim
+++ b/src/basic/gitops.nim
@@ -32,6 +32,7 @@ type
     GitPull = "git -C $DIR pull",
     GitCurrentCommit = "git -C $DIR log -n1 --format=%H"
     GitMergeBase = "git -C $DIR merge-base"
+    GitRevList = "git -C $DIR rev-list"
     GitLsFiles = "git -C $DIR ls-files"
     GitLog = "git -C $DIR log --format=%H"
     GitLogLocal = "git -C $DIR log --format=%H HEAD"
@@ -500,6 +501,27 @@ proc clone*(url: Uri, dest: Path; retries = 5): (CloneStatus, string) =
 proc gitDescribeRefTag*(path: Path, commit: string): string =
   let (lt, status) = exec(GitDescribe, path, ["--tags", commit])
   result = if status == RES_OK: strutils.strip(lt) else: ""
+
+proc commitDistance*(path: Path; base, target: CommitHash): int =
+  ## Returns the number of commits after `base` leading to `target`.
+  ## Returns -1 when the commits are missing or `base` is not an ancestor.
+  if base.isEmpty() or target.isEmpty():
+    return -1
+
+  let (_, ancestorStatus) = exec(
+    GitMergeBase, path, ["--is-ancestor", base.h, target.h], Debug)
+  if ancestorStatus != RES_OK:
+    return -1
+
+  let (count, countStatus) = exec(
+    GitRevList, path, ["--count", base.h & ".." & target.h], Debug)
+  if countStatus == RES_OK:
+    try:
+      result = parseInt(count.strip())
+    except ValueError:
+      result = -1
+  else:
+    result = -1
 
 proc tipFromRef(path: Path; remoteName, remoteRef: string; errorReportLevel: MsgKind; isLocalOnly: bool): VersionTag =
   let commit =

--- a/src/basic/versions.nim
+++ b/src/basic/versions.nim
@@ -62,7 +62,9 @@ proc `$`*(c: CommitHash): string =
   if result == "":
     result = "-"
 
-const ValidChars = {'a'..'f', '0'..'9'}
+const
+  ValidChars = {'a'..'f', '0'..'9'}
+  MinCommitLen = len("#baca3")
 
 proc isLowerAlphaNum*(s: string): bool =
   for c in s:
@@ -92,8 +94,15 @@ proc short*(c: CommitHash): string =
   elif c.h.len() == 0: "-"
   else: "!"&c.h[0..<c.h.len()]
 
+proc isCommit*(v: Version): bool =
+  ## Returns whether a special version names a Git commit.
+  result = v.string.len >= MinCommitLen and v.string[0] == '#' and
+    v.string.substr(1).isLowerAlphaNum()
+
 proc `$`*(vt: VersionTag): string =
-  if vt.v.string != "":
+  if vt.v.isCommit() and vt.v.string.len > 9:
+    result = vt.v.string[0..8]
+  elif vt.v.string != "":
     result = $vt.v
   else: result = "~"
   result &= "@" & vt.c.short()
@@ -655,9 +664,6 @@ proc extractRequirementName*(req: string): (string, seq[string], int) =
     result = (name, features, i+1)
   else:
     result = (name, @[], i)
-
-const
-  MinCommitLen = len("#baca3")
 
 proc extractSpecificCommit*(pattern: VersionInterval): CommitHash =
   if not pattern.isInterval and pattern.a.r == verEq and pattern.a.v.isSpecial: # and pattern.a.v.string.len >= MinCommitLen:

--- a/src/basic/versions.nim
+++ b/src/basic/versions.nim
@@ -288,6 +288,16 @@ proc compareVersions(a, b: string): int =
     return 0
   compareNumericCore(a, b)
 
+proc withCommitDistance*(v: Version; distance: Natural): Version =
+  ## Adds a Git-style commit distance as SemVer build metadata.
+  ##
+  ## Build metadata does not affect SemVer precedence, so inferred commits
+  ## remain compatible with requirements for the version declared by Nimble.
+  if distance == 0 or not parseSemVerLike(v.string).valid:
+    return v
+  let separator = if '+' in v.string: "." else: "+"
+  result = Version(v.string & separator & $distance)
+
 proc `<`*(a, b: Version): bool =
   # Handling for special versions such as "#head" or "#branch".
   if a.isSpecial or b.isSpecial:

--- a/src/dependencies.nim
+++ b/src/dependencies.nim
@@ -176,6 +176,27 @@ proc traverseDependency*(
     pkg.versions.clear()
 
   for (ver, rel) in releaseInfo.releases:
+    if mode == ExplicitVersions and (ver.vtag.isTip or ver.version.isCommit()):
+      var versionsAtCommit: seq[PackageVersion]
+      var hasRegularVersion = false
+      for existing in pkg.versions.keys:
+        if existing.commit == ver.commit:
+          versionsAtCommit.add(existing)
+          if existing.version.string.len == 0 or existing.version.string[0] != '#':
+            hasRegularVersion = true
+
+      if ver.vtag.isTip:
+        for existing in versionsAtCommit:
+          if existing.version.string.len == 0 or existing.version.string[0] != '#':
+            existing.vtag.isTip = true
+          elif existing.version.isHead() or existing.version.isCommit():
+            pkg.versions.del(existing)
+        if hasRegularVersion:
+          continue
+      elif versionsAtCommit.len > 0:
+        # A commit requirement already matches any release at that commit.
+        continue
+
     if mode != ExplicitVersions and ver in pkg.versions:
       error pkg.url.projectName, "duplicate release found:", $ver.vtag, "new:", repr(rel)
       error pkg.url.projectName, "... existing: ", repr(pkg.versions[ver])

--- a/src/releaseinfo.nim
+++ b/src/releaseinfo.nim
@@ -87,8 +87,11 @@ proc addRelease(
   try:
     let release = nc.processNimbleRelease(pkg, vtag)
 
-    if vtag.v.string == "":
+    if vtag.v.string == "" or
+        (vtag.v.isHead() and not pkg.isRoot and release.version.string != ""):
       pkgver.vtag.v = release.version
+      if vtag.v.isHead():
+        pkgver.vtag.isTip = true
       trace pkg.url.projectName, "updating release tag information:", $pkgver.vtag
     elif release.version.string == "":
       warn pkg.url.projectName, "nimble file missing version information:", $pkgver.vtag
@@ -203,13 +206,23 @@ proc loadPackageReleaseInfo*(
       version = vtag
       debug pkg.url.projectName, "explicit version:", $version, "vtag:", repr vtag
 
+    var versionBases: Table[string, CommitHash]
+    if result.expandedExplicitVersions.anyIt(it.isTip):
+      let nimbleCommits = nc.collectNimbleVersions(pkg, repo)
+      discard nc.loadInferredReleases(pkg, nimbleCommits, versionBases)
+
     for version in result.expandedExplicitVersions:
       debug pkg.url.projectName, "check explicit version:", repr version
       if version.commit.isEmpty():
         warn pkg.url.projectName, "explicit version has empty commit:", $version
       elif version.toPkgVer() notin pkg.versions:
         debug pkg.url.projectName, "add explicit version:", $version
-        discard result.releases.addRelease(nc, pkg, version)
+        var releases: seq[(PackageVersion, NimbleRelease)]
+        if releases.addRelease(nc, pkg, version):
+          let releaseVersion = releases[0][1].version.string
+          if version.isTip and versionBases.hasKey(releaseVersion):
+            addCommitDistance(pkg, versionBases[releaseVersion], releases[0][0])
+          result.releases.add(releases[0])
 
   of AllReleases:
     try:

--- a/src/releaseinfo.nim
+++ b/src/releaseinfo.nim
@@ -103,6 +103,36 @@ proc addRelease(
     info pkg.url.projectName, "error processing nimble release:", $vtag, "error:", $e.msg
     return false
 
+proc addCommitDistance(
+    pkg: Package;
+    versionBase: CommitHash;
+    version: PackageVersion
+) =
+  let distance = commitDistance(pkg.ondisk, versionBase, version.commit)
+  if distance > 0:
+    version.vtag.v = version.vtag.v.withCommitDistance(Natural(distance))
+
+proc loadInferredReleases(
+    nc: var NimbleContext;
+    pkg: Package;
+    commits: seq[VersionTag];
+    versionBases: var Table[string, CommitHash]
+): seq[(PackageVersion, NimbleRelease)] =
+  ## Loads Nimble-file commits in chronological order and records the commit
+  ## where each run of an exact version string began.
+  var previousVersion = ""
+  var versionBase: CommitHash
+  for commit in commits:
+    var release: seq[(PackageVersion, NimbleRelease)]
+    if release.addRelease(nc, pkg, commit):
+      let version = release[0][1].version.string
+      if result.len == 0 or version != previousVersion:
+        versionBase = commit.c
+        versionBases[version] = versionBase
+      addCommitDistance(pkg, versionBase, release[0][0])
+      result.add(release[0])
+      previousVersion = version
+
 proc deduplicateReleases(
     pkg: Package;
     versions: seq[(PackageVersion, NimbleRelease)]
@@ -185,7 +215,7 @@ proc loadPackageReleaseInfo*(
     try:
       var uniqueCommits: HashSet[CommitHash]
       var nimbleVersions: HashSet[Version]
-      var nimbleCommits = nc.collectNimbleVersions(pkg, repo)
+      let nimbleCommits = nc.collectNimbleVersions(pkg, repo)
 
       debug pkg.url.projectName, "nimble explicit versions:", $explicitVersions
       for version in explicitVersions:
@@ -204,19 +234,22 @@ proc loadPackageReleaseInfo*(
       if tags.len() == 0 or IncludeTagsAndNimbleCommits in context().flags:
         # Use Nimble-file commit versions only when tags are absent or explicitly requested.
         # Otherwise deleted tags could be reintroduced as inferred releases.
+        var versionBases: Table[string, CommitHash]
+        var inferredReleases = nc.loadInferredReleases(pkg, nimbleCommits, versionBases)
         if NimbleCommitsMax in context().flags:
           # Reverse the order so the newest commit is preferred for each version.
-          nimbleCommits.reverse()
+          inferredReleases.reverse()
 
-        debug pkg.url.projectName, "nimble commits:", $nimbleCommits
-        for tag in nimbleCommits:
-          if not uniqueCommits.containsOrIncl(tag.c):
-            var vers: seq[(PackageVersion, NimbleRelease)]
-            let added = vers.addRelease(nc, pkg, tag)
-            if added and not nimbleVersions.containsOrIncl(vers[0][0].vtag.v):
-              result.releases.add(vers)
+        debug pkg.url.projectName, "nimble commits:", $inferredReleases.mapIt(it[0].vtag)
+        for inferred in inferredReleases:
+          if not uniqueCommits.containsOrIncl(inferred[0].commit):
+            if not nimbleVersions.containsOrIncl(inferred[1].version):
+              result.releases.add(inferred)
           else:
-            error pkg.url.projectName, "traverseDependency skipping nimble commit:", $tag, "uniqueCommits:", $(tag.c in uniqueCommits), "nimbleVersions:", $(tag.v in nimbleVersions)
+            error pkg.url.projectName, "traverseDependency skipping nimble commit:",
+              $inferred[0].vtag, "uniqueCommits:",
+              $(inferred[0].commit in uniqueCommits), "nimbleVersions:",
+              $(inferred[1].version in nimbleVersions)
 
         if not result.currentCommit.isEmpty() and not uniqueCommits.containsOrIncl(result.currentCommit):
           # Existing checkouts can be detached or on a non-default branch.
@@ -224,8 +257,12 @@ proc loadPackageReleaseInfo*(
           var vers: seq[(PackageVersion, NimbleRelease)]
           let currentTag = VersionTag(v: Version"", c: result.currentCommit)
           let added = vers.addRelease(nc, pkg, currentTag)
-          if added and not nimbleVersions.containsOrIncl(vers[0][0].vtag.v):
-            result.releases.add(vers)
+          if added:
+            let currentVersion = vers[0][1].version
+            if versionBases.hasKey(currentVersion.string):
+              addCommitDistance(pkg, versionBases[currentVersion.string], vers[0][0])
+            if not nimbleVersions.containsOrIncl(currentVersion):
+              result.releases.add(vers)
 
       if result.releases.len() == 0:
         let vtag = VersionTag(v: Version"#head", c: initCommitHash(result.currentCommit, FromHead))

--- a/tests/integration_test_utils.nim
+++ b/tests/integration_test_utils.nim
@@ -130,16 +130,17 @@ template expectedVersionWithNoGitTagsMaxVer*() =
 
     # note: this variant uses the last commit where a given nimble version was found
     #       when the nimble file was changed, the version was the same
+    #       +1 records that this edit is one commit after the version bump
 
     let projAnimbles {.inject.} = dedent"""
     2a630f98c20f54b828f95e824e2a1b2da50fe687 1.1.0
-    62fca4fd4062087d937146fd5d8f9ab7e1e5c22b 1.0.0
+    62fca4fd4062087d937146fd5d8f9ab7e1e5c22b 1.0.0+1
     """.parseTaggedVersions(false)
     let projAtags {.inject.} = projAnimbles.filterIt(it.v.string != "")
 
     let projBnimbles {.inject.} = dedent"""
     05b2f46caf8ae7322c855a482ad297c399b5d185 1.1.0
-    4cee9aed9623f4142a7b15bb96a1d582c8b87250 1.0.0
+    4cee9aed9623f4142a7b15bb96a1d582c8b87250 1.0.0+1
     """.parseTaggedVersions(false)
     let projBtags {.inject.} = projBnimbles.filterIt(it.v.string != "")
 

--- a/tests/tbasics.nim
+++ b/tests/tbasics.nim
@@ -498,6 +498,13 @@ suite "versions":
     let v4 = VersionTag(v: Version"#head", c: initCommitHash("", FromGitTag))
     check v4 == v3
 
+  test "commit distance uses SemVer build metadata":
+    check $Version"1.2.3".withCommitDistance(5) == "1.2.3+5"
+    check $Version"1.2.3-beta.1".withCommitDistance(5) == "1.2.3-beta.1+5"
+    check $Version"1.2.3+linux".withCommitDistance(5) == "1.2.3+linux.5"
+    check $Version"1.2.3".withCommitDistance(0) == "1.2.3"
+    check Version"1.2.3+5" == Version"1.2.3"
+
 
 import basic/[versions]
 import depgraphs

--- a/tests/tbasics.nim
+++ b/tests/tbasics.nim
@@ -498,6 +498,12 @@ suite "versions":
     let v4 = VersionTag(v: Version"#head", c: initCommitHash("", FromGitTag))
     check v4 == v3
 
+    let v5 = VersionTag(v: Version("#" & c1.h), c: c1)
+    check $v5 == "#24870f48@24870f48"
+    check repr(v5) ==
+      "#24870f48c40da2146ce12ff1e675e6e7b9748355@" &
+      "24870f48c40da2146ce12ff1e675e6e7b9748355"
+
   test "commit distance uses SemVer build metadata":
     check $Version"1.2.3".withCommitDistance(5) == "1.2.3+5"
     check $Version"1.2.3-beta.1".withCommitDistance(5) == "1.2.3-beta.1+5"

--- a/tests/texplicit_history_leak.nim
+++ b/tests/texplicit_history_leak.nim
@@ -43,6 +43,102 @@ suite "historical explicit transitive pins":
     context().depsDir = Path "deps"
     setAtlasErrorsColor(fgMagenta)
 
+  test "head uses the Nimble version and commit distance":
+    let ws = "tests/ws_explicit_history_leak"
+    removeDir(ws)
+    createDir(ws)
+
+    withDir ws:
+      project(paths.getCurrentDir())
+      context().flags = {KeepWorkspace, ListVersions}
+      context().defaultAlgo = SemVer
+      discard context().nameOverrides.addPattern("$+", "file://./buildGraph/$#")
+
+      createDir("buildGraph/headdep")
+      var headCommit = ""
+      withDir "buildGraph/headdep":
+        writePackage("headdep", "1.2.3")
+        initGitRepo()
+        commitAll("version bump")
+
+        for i in 1..5:
+          writeFile("headdep.nim", "discard \"" & $i & "\"\n")
+          commitAll("source change " & $i)
+        headCommit = gitHead()
+
+      writeFile("ws_explicit_history_leak.nimble", [
+        "version = \"0.1.0\"",
+        "requires \"headdep#head\"",
+        ""
+      ].join("\n"))
+
+      var nc = createNimbleContext()
+      var graph = loadWorkspace(project(), nc, AllReleases, DoClone, doSolve = true)
+      let headdepUrl = nc.createUrl("headdep")
+
+      check headdepUrl in graph.pkgs
+      if headdepUrl in graph.pkgs:
+        let headdep = graph.pkgs[headdepUrl]
+        check headdep.active
+        if headdep.active:
+          check $headdep.activeVersion ==
+            "1.2.3+5@" & headCommit[0..7] & "^"
+
+        var versionsAtHead = 0
+        for version in headdep.versions.keys:
+          check not version.version.isHead()
+          if version.commit.h == headCommit:
+            inc versionsAtHead
+        check versionsAtHead == 1
+
+  test "head reuses a regular release at the same commit":
+    let ws = "tests/ws_explicit_history_leak"
+    removeDir(ws)
+    createDir(ws)
+
+    withDir ws:
+      project(paths.getCurrentDir())
+      context().flags = {KeepWorkspace, ListVersions, NimbleCommitsMax}
+      context().defaultAlgo = SemVer
+      discard context().nameOverrides.addPattern("$+", "file://./buildGraph/$#")
+
+      createDir("buildGraph/headdep")
+      var headCommit = ""
+      withDir "buildGraph/headdep":
+        writePackage("headdep", "1.2.3")
+        initGitRepo()
+        commitAll("version bump")
+
+        for i in 1..4:
+          writeFile("headdep.nim", "discard \"" & $i & "\"\n")
+          commitAll("source change " & $i)
+        writeFile("headdep.nimble", [
+          "version = \"1.2.3\"",
+          "description = \"metadata update\"",
+          ""
+        ].join("\n"))
+        commitAll("nimble metadata")
+        headCommit = gitHead()
+
+      writeFile("ws_explicit_history_leak.nimble", [
+        "version = \"0.1.0\"",
+        "requires \"headdep#head\"",
+        ""
+      ].join("\n"))
+
+      var nc = createNimbleContext()
+      var graph = loadWorkspace(project(), nc, AllReleases, DoClone, doSolve = true)
+      let headdepUrl = nc.createUrl("headdep")
+
+      check headdepUrl in graph.pkgs
+      if headdepUrl in graph.pkgs:
+        let headdep = graph.pkgs[headdepUrl]
+        check headdep.active
+        check headdep.versions.len == 1
+        if headdep.active:
+          check $headdep.activeVersion ==
+            "1.2.3+5@" & headCommit[0..7] & "^"
+
   test "root explicit commit selects pinned release over newer semver releases":
     let ws = "tests/ws_explicit_history_leak"
     removeDir(ws)

--- a/tests/tgitops.nim
+++ b/tests/tgitops.nim
@@ -317,6 +317,22 @@ suite "Git Operations Tests":
       let untaggedDescription = gitDescribeRefTag(Path ".", newCommit)
       check(untaggedDescription.startsWith("v1.0.0-1-"))
 
+  test "commitDistance counts commits from an ancestor":
+    withDir testDir:
+      discard execCmd("git init")
+      writeFile("test.txt", "initial content")
+      discard execCmd("git add test.txt")
+      discard execCmd("git commit -m \"initial commit\"")
+      let base = currentGitCommit(Path ".")
+
+      for i in 1..3:
+        writeFile("test.txt", "content " & $i)
+        discard execCmd("git commit -am \"commit " & $i & "\"")
+
+      let target = currentGitCommit(Path ".")
+      check commitDistance(Path ".", base, target) == 3
+      check commitDistance(Path ".", target, base) == -1
+
   test "collectTaggedVersions functionality":
     withDir testDir:
       discard execCmd("git init")

--- a/tests/tserde.nim
+++ b/tests/tserde.nim
@@ -137,7 +137,7 @@ suite "json serde":
       @[(VersionTag(v: Version"1.0.0", c: current).toPkgVer, release)]
     )
     let cache = parseFile($packageReleaseCachePath(pkg))
-    check cache["cacheVersion"].getInt() == 5
+    check cache["cacheVersion"].getInt() == 6
     check cache["shortName"].getStr() == "foobar"
     check cache["fullName"].getStr() == "foobar.nimble-test.github.com"
     check "packageName" notin cache
@@ -222,7 +222,7 @@ suite "json serde":
 
     savePackageReleaseCache(pkg, current, @[(version, release)])
     let regeneratedCache = parseFile($cachePath)
-    check regeneratedCache["cacheVersion"].getInt() == 5
+    check regeneratedCache["cacheVersion"].getInt() == 6
 
   test "package release cache rejects a tag added at the current commit":
     let oldCtx = context()

--- a/tests/tserde.nim
+++ b/tests/tserde.nim
@@ -137,7 +137,7 @@ suite "json serde":
       @[(VersionTag(v: Version"1.0.0", c: current).toPkgVer, release)]
     )
     let cache = parseFile($packageReleaseCachePath(pkg))
-    check cache["cacheVersion"].getInt() == 6
+    check cache["cacheVersion"].getInt() == 7
     check cache["shortName"].getStr() == "foobar"
     check cache["fullName"].getStr() == "foobar.nimble-test.github.com"
     check "packageName" notin cache
@@ -222,7 +222,7 @@ suite "json serde":
 
     savePackageReleaseCache(pkg, current, @[(version, release)])
     let regeneratedCache = parseFile($cachePath)
-    check regeneratedCache["cacheVersion"].getInt() == 6
+    check regeneratedCache["cacheVersion"].getInt() == 7
 
   test "package release cache rejects a tag added at the current commit":
     let oldCtx = context()


### PR DESCRIPTION
## Summary

- display inferred dependency commits after a Nimble version bump as `1.2.3+5@abcdef12`
- encode commit distance as SemVer build metadata so version precedence and requirement matching remain unchanged
- resolve `#head` constraints to the tip commit's Nimble version and commit distance, marked with `^`
- reuse a normal release already discovered at the tip instead of adding a duplicate `#head` candidate
- shorten commit refs to eight characters in version-selection output while retaining full hashes internally
- invalidate stale release caches and document the representation

## Display convention

- `1.2.3@abcdef12` — exact version bump or tag
- `1.2.3+5@abcdef12` — five commits after the version bump
- `1.2.3+5@abcdef12^` — the same commit at repository head
- `1.2.3+5@abcdef12 [pinned]` — proposed follow-up display for an explicit commit requirement, replacing redundant output such as `#abcdef12@abcdef12`

The full commit remains available internally and in verbose/debug data. The normal resolved output should describe the version found at that commit; `[pinned]` explains why the exact commit was selected.

## Tests

- `nim build`
- `nim test`
- regression coverage for source-only head commits and an already-discovered tip release