### PR TITLE
Show version details for pinned commits

### DIFF
--- a/doc/atlas.md
+++ b/doc/atlas.md
@@ -62,8 +62,10 @@ metadata does not change SemVer precedence, so it still satisfies requirements
 for `1.2.3` while making the checkout's distance from the version bump visible.
 This display is also used when a `#head` requirement selects that commit; the
 resolved version is shown once with a trailing `^`, rather than as a separate
-`#head` release. Commit requirements retain their full hashes internally but
-are shortened to eight characters in version-selection output.
+`#head` release. An explicit commit requirement uses the same nearest-version
+display and adds `[pinned]`, for example `1.2.3+5@abcdef12 [pinned]`. Commit
+requirements retain their full hashes internally but are shortened to eight
+characters in version-selection output.
 
 Atlas uses URLs internally; Nimble package names are translated to URLs
 via Nimble's  `packages.json` file. Atlas uses "shortnames" for known URLs from

--- a/src/basic/versions.nim
+++ b/src/basic/versions.nim
@@ -45,7 +45,7 @@ type
   VersionTag* = object
     c*: CommitHash
     v*: Version
-    isTip*: bool
+    isTip*, isPinned*: bool
 
   CommitOrigin* = enum
     FromNone, FromHead, FromGitTag, FromDep, FromNimbleFile, FromLockfile

--- a/src/dependencies.nim
+++ b/src/dependencies.nim
@@ -176,7 +176,7 @@ proc traverseDependency*(
     pkg.versions.clear()
 
   for (ver, rel) in releaseInfo.releases:
-    if mode == ExplicitVersions and (ver.vtag.isTip or ver.version.isCommit()):
+    if mode == ExplicitVersions and (ver.vtag.isTip or ver.vtag.isPinned):
       var versionsAtCommit: seq[PackageVersion]
       var hasRegularVersion = false
       for existing in pkg.versions.keys:
@@ -193,9 +193,14 @@ proc traverseDependency*(
             pkg.versions.del(existing)
         if hasRegularVersion:
           continue
-      elif versionsAtCommit.len > 0:
-        # A commit requirement already matches any release at that commit.
-        continue
+      else:
+        for existing in versionsAtCommit:
+          if existing.version.string.len == 0 or existing.version.string[0] != '#':
+            existing.vtag.isPinned = true
+          elif existing.version.isHead() or existing.version.isCommit():
+            pkg.versions.del(existing)
+        if hasRegularVersion:
+          continue
 
     if mode != ExplicitVersions and ver in pkg.versions:
       error pkg.url.projectName, "duplicate release found:", $ver.vtag, "new:", repr(rel)

--- a/src/depgraphs.nim
+++ b/src/depgraphs.nim
@@ -459,8 +459,13 @@ proc toFormular*(graph: var DepGraph; algo: ResolutionAlgorithm): Form =
   result.formula = toForm(b)
 
 
+proc formatVersionSelection*(pkg: Package; version: PackageVersion): string =
+  result = "(" & pkg.url.projectName & ", " & $version & ")"
+  if version.vtag.isPinned:
+    result.add " [pinned]"
+
 proc toString(info: SatVarInfo): string =
-  "(" & info.pkg.url.projectName & ", " & $info.version & ")"
+  formatVersionSelection(info.pkg, info.version)
 
 proc debugFormular*(graph: var DepGraph; form: Form; solution: Solution) =
   echo "FORM:\n\t", form.formula

--- a/src/releaseinfo.nim
+++ b/src/releaseinfo.nim
@@ -17,6 +17,8 @@ import std / [os, strutils, tables, sequtils, sets, algorithm, paths]
 import basic/[context, deptypes, versions, nimbleparser, reporters, gitops, pkgurls, nimblecontext, dependencycache]
 
 type
+  VersionRun = tuple[version: Version, base: CommitHash]
+
   PackageReleaseInfo* = object
     currentCommit*: CommitHash
     expandedExplicitVersions*: seq[VersionTag]
@@ -83,12 +85,14 @@ proc addRelease(
   ## Parses one release candidate and appends it to the pending version list.
   ## The returned release version is normalized against tag or Nimble-file metadata.
   var pkgver = vtag.toPkgVer()
+  pkgver.vtag.isPinned = vtag.v.isCommit()
   trace pkg.url.projectName, "Adding Nimble version:", $vtag
   try:
     let release = nc.processNimbleRelease(pkg, vtag)
 
     if vtag.v.string == "" or
-        (vtag.v.isHead() and not pkg.isRoot and release.version.string != ""):
+        ((vtag.v.isHead() or vtag.v.isCommit()) and not pkg.isRoot and
+          release.version.string != ""):
       pkgver.vtag.v = release.version
       if vtag.v.isHead():
         pkgver.vtag.isTip = true
@@ -119,7 +123,8 @@ proc loadInferredReleases(
     nc: var NimbleContext;
     pkg: Package;
     commits: seq[VersionTag];
-    versionBases: var Table[string, CommitHash]
+    versionBases: var Table[string, CommitHash];
+    versionRuns: var seq[VersionRun]
 ): seq[(PackageVersion, NimbleRelease)] =
   ## Loads Nimble-file commits in chronological order and records the commit
   ## where each run of an exact version string began.
@@ -132,9 +137,34 @@ proc loadInferredReleases(
       if result.len == 0 or version != previousVersion:
         versionBase = commit.c
         versionBases[version] = versionBase
+        versionRuns.add((release[0][1].version, versionBase))
       addCommitDistance(pkg, versionBase, release[0][0])
       result.add(release[0])
       previousVersion = version
+
+proc loadInferredReleases(
+    nc: var NimbleContext;
+    pkg: Package;
+    commits: seq[VersionTag];
+    versionBases: var Table[string, CommitHash]
+): seq[(PackageVersion, NimbleRelease)] =
+  var versionRuns: seq[VersionRun]
+  result = nc.loadInferredReleases(pkg, commits, versionBases, versionRuns)
+
+proc findVersionBase(
+    pkg: Package;
+    versionRuns: openArray[VersionRun];
+    version: Version;
+    target: CommitHash
+): CommitHash =
+  ## Finds the nearest run of `version` that is an ancestor of `target`.
+  var nearestDistance = high(int)
+  for run in versionRuns:
+    if run.version == version:
+      let distance = commitDistance(pkg.ondisk, run.base, target)
+      if distance >= 0 and distance < nearestDistance:
+        nearestDistance = distance
+        result = run.base
 
 proc deduplicateReleases(
     pkg: Package;
@@ -207,9 +237,10 @@ proc loadPackageReleaseInfo*(
       debug pkg.url.projectName, "explicit version:", $version, "vtag:", repr vtag
 
     var versionBases: Table[string, CommitHash]
-    if result.expandedExplicitVersions.anyIt(it.isTip):
+    var versionRuns: seq[VersionRun]
+    if result.expandedExplicitVersions.anyIt(it.isTip or it.version.isCommit()):
       let nimbleCommits = nc.collectNimbleVersions(pkg, repo)
-      discard nc.loadInferredReleases(pkg, nimbleCommits, versionBases)
+      discard nc.loadInferredReleases(pkg, nimbleCommits, versionBases, versionRuns)
 
     for version in result.expandedExplicitVersions:
       debug pkg.url.projectName, "check explicit version:", repr version
@@ -222,6 +253,11 @@ proc loadPackageReleaseInfo*(
           let releaseVersion = releases[0][1].version.string
           if version.isTip and versionBases.hasKey(releaseVersion):
             addCommitDistance(pkg, versionBases[releaseVersion], releases[0][0])
+          elif version.version.isCommit():
+            let versionBase = findVersionBase(
+              pkg, versionRuns, releases[0][1].version, version.commit)
+            if not versionBase.isEmpty():
+              addCommitDistance(pkg, versionBase, releases[0][0])
           result.releases.add(releases[0])
 
   of AllReleases:

--- a/tests/texplicit_history_leak.nim
+++ b/tests/texplicit_history_leak.nim
@@ -184,11 +184,72 @@ suite "historical explicit transitive pins":
       check widgetUrl in graph.pkgs
 
       if widgetUrl in graph.pkgs:
-        check graph.pkgs[widgetUrl].active
-        if graph.pkgs[widgetUrl].active:
-          check $graph.pkgs[widgetUrl].activeVersion.version == "1.0.0"
-          check graph.pkgs[widgetUrl].activeVersion.commit.h == pinnedCommit
-          check graph.pkgs[widgetUrl].activeVersion.commit.h != newerCommit
+        let widget = graph.pkgs[widgetUrl]
+        check widget.active
+        if widget.active:
+          check $widget.activeVersion == "1.0.0@" & pinnedCommit[0..7]
+          check widget.activeVersion.vtag.isPinned
+          check not widget.activeVersion.vtag.isTip
+          check widget.activeVersion.commit.h == pinnedCommit
+          check widget.activeVersion.commit.h != newerCommit
+          check formatVersionSelection(widget, widget.activeVersion) ==
+            "(widget, 1.0.0@" & pinnedCommit[0..7] & ") [pinned]"
+
+          var commitAliases = 0
+          for version in widget.versions.keys:
+            if version.commit.h == pinnedCommit and version.version.isCommit():
+              inc commitAliases
+          check commitAliases == 0
+
+  test "root explicit commit reports nearest version distance":
+    let ws = "tests/ws_explicit_history_leak"
+    removeDir(ws)
+    createDir(ws)
+
+    withDir ws:
+      project(paths.getCurrentDir())
+      context().flags = {KeepWorkspace, ListVersions}
+      context().defaultAlgo = SemVer
+      discard context().nameOverrides.addPattern("$+", "file://./buildGraph/$#")
+
+      createDir("buildGraph")
+
+      var pinnedCommit = ""
+
+      withDir "buildGraph":
+        createDir("widget")
+        withDir "widget":
+          writePackage("widget", "1.2.3")
+          initGitRepo()
+          commitAll("widget-version")
+
+          for i in 1..5:
+            writeFile("widget.nim", "discard " & $i & "\n")
+            commitAll("widget-source-" & $i)
+          pinnedCommit = gitHead()
+
+          writePackage("widget", "2.0.0")
+          commitAll("widget-newer")
+
+      writeFile("ws_explicit_history_leak.nimble", [
+        "version = \"0.1.0\"",
+        "requires \"widget#" & pinnedCommit[0..7] & "\"",
+        ""
+      ].join("\n"))
+
+      var nc = createNimbleContext()
+      var graph = loadWorkspace(project(), nc, AllReleases, DoClone, doSolve = true)
+      let widgetUrl = nc.createUrl("widget")
+
+      check widgetUrl in graph.pkgs
+      if widgetUrl in graph.pkgs:
+        let widget = graph.pkgs[widgetUrl]
+        check widget.active
+        if widget.active:
+          check $widget.activeVersion == "1.2.3+5@" & pinnedCommit[0..7]
+          check widget.activeVersion.vtag.isPinned
+          check formatVersionSelection(widget, widget.activeVersion) ==
+            "(widget, 1.2.3+5@" & pinnedCommit[0..7] & ") [pinned]"
 
   test "old explicit transitive pin from historical release does not leak into selected explicit commit":
     let ws = "tests/ws_explicit_history_leak"


### PR DESCRIPTION
## Motivation

Explicit commit requirements still appeared as a redundant `#commit@commit` pair after #238. That form hides the Nimble version nearest to the pinned revision and could coexist with a regular release for the same commit.

Follow-up to #238.

## Approach

- Preserve whether a resolved version came from an explicit commit requirement.
- Normalize pinned commits to the Nimble version at that revision.
- Find the nearest matching Nimble version run and add the commit distance as SemVer build metadata.
- Append `[pinned]` outside the version tuple and keep hashes at eight characters in selection output.
- Reuse a regular release at the same commit and remove redundant `#commit`/`#head` aliases.
- Document the pinned display.

## CLI output

Before:

```text
[Notice] (atlas:resolved) [x] (bearssl_pkey_decoder, #546f8d9b@546f8d9b)
```

After, when pinned at the version commit:

```text
[Notice] (atlas:resolved) [x] (bearssl_pkey_decoder, 0.1.0@546f8d9b) [pinned]
```

After five commits beyond the nearest version bump:

```text
[Notice] (atlas:resolved) [x] (widget, 1.2.3+5@43cc2fc4) [pinned]
```

## Test coverage

- Extends the explicit historical-pin regression to assert normalization, `[pinned]`, short hashes, and removal of the duplicate commit alias.
- Adds a historical pin five commits after version `1.2.3`, with a newer `2.0.0` release present.
- `nim build`
- `nim unitTests`
- `nim tester`