### PR TITLE
Fix links for package names that differ from repository slugs

### DIFF
--- a/atlas.nimble
+++ b/atlas.nimble
@@ -1,5 +1,5 @@
 # Package
-version = "0.14.11"
+version = "0.14.12"
 author = "Araq"
 description = "Atlas is a simple package cloner tool. It manages an isolated project."
 license = "MIT"

--- a/src/basic/pkgurls.nim
+++ b/src/basic/pkgurls.nim
@@ -185,19 +185,25 @@ proc toDirectoryPath(pkgUrl: PkgUrl, packageName: string, isLinkFile: bool): Pat
   else:
     result = depsDir() / Path(dirName)
   
-  if not isLinkFile and not dirExists(result) and fileExists(result.linkPath()):
-    # prefer the directory path if it exists (?)
-    let linkPath = result.linkPath()
-    let link = readFile($linkPath)
-    let lines = link.split("\n")
-    if lines.len != 2:
-      warn pkgUrl.projectName(), "invalid link file:", $linkPath
-    else:
-      let nimble = Path(lines[0])
-      result = nimble.splitFile().dir
-      if not result.isAbsolute():
-        result = linkPath.parentDir() / result
-      debug pkgUrl.projectName(), "link file to:", $result
+  if not isLinkFile and not dirExists(result):
+    var linkPath = result.linkPath()
+    if not fileExists(linkPath) and packageName.len > 0:
+      # Link files use the URL slug, which can differ from the registry package name.
+      let urlLinkPath = (depsDir() / Path(pkgUrl.projectName())).linkPath()
+      if urlLinkPath != linkPath and fileExists(urlLinkPath):
+        linkPath = urlLinkPath
+
+    if fileExists(linkPath):
+      let link = readFile($linkPath)
+      let lines = link.split("\n")
+      if lines.len != 2:
+        warn pkgUrl.projectName(), "invalid link file:", $linkPath
+      else:
+        let nimble = Path(lines[0])
+        result = nimble.splitFile().dir
+        if not result.isAbsolute():
+          result = linkPath.parentDir() / result
+        debug pkgUrl.projectName(), "link file to:", $result
 
   result = result.absolutePath
   trace pkgUrl, "found directory path:", $result

--- a/tests/tbasics.nim
+++ b/tests/tbasics.nim
@@ -292,6 +292,18 @@ suite "urls and naming":
     echo "LINKPATH: ", upkg.toLinkPath()
     check upkg.toLinkPath().fileExists()
 
+  test "package name resolves URL-named link file":
+    let upkg = nc.createUrl("https://github.com/status-im/nim-chronicles")
+    let nimbleFile = ws / Path"remote-deps" / Path"foobar" / Path"foobar.nimble"
+    let linkFile = upkg.toLinkPath()
+    defer: removeFile(linkFile)
+
+    createNimbleLink(upkg, nimbleFile, CfgPath(nimbleFile.parentDir()))
+
+    check linkFile == ws / Path"deps" / Path"nim-chronicles.nimble-link"
+    check not fileExists(ws / Path"deps" / Path"chronicles.nimble-link")
+    check upkg.toDirectoryPath("chronicles") == nimbleFile.parentDir()
+
   test "print names":
     let upkg = nc.createUrl("https://github.com/disruptek/balls.git")
     echo "\nNimbleContext:urlToNames: "


### PR DESCRIPTION
## Motivation

Atlas link creates transitive nimble-link files from repository URL slugs. Packages such as chronicles are registered under a package name that differs from the nim-chronicles repository slug, so dependency loading looked for deps/chronicles while the imported link was deps/nim-chronicles.nimble-link. The package was then marked local but missing, making the linked graph unsatisfiable.

## Approach

- Preserve the existing package-directory and package-named-link precedence.
- When those are absent, fall back to the link filename derived from the package URL slug.
- Add a regression test covering chronicles versus nim-chronicles.
- Bump Atlas to 0.14.12.

