### PR TITLE
Add binary Nim environment setup

### DIFF
--- a/doc/atlas.md
+++ b/doc/atlas.md
@@ -398,6 +398,30 @@ atlas env 1.6.12
 atlas env devel
 ```
 
+For a tagged release, Atlas downloads the prebuilt binary for the current platform
+from the Nim release index. If that version or platform has no binary, Atlas builds
+Nim from source instead. Use `--binary` to require a binary or `--source` to always
+build from source:
+
+```
+atlas env 2.2.10 --binary
+atlas env 2.2.10 --source
+```
+
+Binary downloads are verified when the release index provides a checksum. Download,
+checksum, and extraction failures are reported rather than falling back to a source
+build. The source path uses Nim's standard `build_all.sh` script on UNIX and
+`build_all.bat` on Windows. The `devel` version is always built from source, and
+`atlas env devel --binary` is an error.
+
+In GitHub Actions, use `--github-path` to append the installed Nim `bin` directory
+to the runner's `GITHUB_PATH` environment file. Nim will then be available on
+`PATH` in subsequent steps of the current job:
+
+```
+atlas env 2.2.10 --binary --github-path
+```
+
 When completed, run `source deps/nim-1.6.12/activate.sh` on UNIX and `deps\nim-1.6.12\activate.bat` on Windows.
 
 

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -70,6 +70,9 @@ Options:
   --list[=on|off]       list all available and installed versions
   --keepCommits         do not perform any `git checkouts`
   --keepworkspace       keep generated workspace artifacts
+  --binary              for `env`, require a prebuilt Nim release
+  --source              for `env`, build Nim from source
+  --github-path         for `env`, add Nim's bin directory to $GITHUB_PATH
   --ignoreerrors        continue even when errors were recorded
   --dumpformular        dump SAT formula for debugging
   --dumpgraphs          dump dependency graphs for debugging
@@ -678,6 +681,9 @@ proc parseAtlasOptions(params: seq[string], action: var string, args: var seq[st
       of "keepcommits": context().flags.incl KeepCommits
       of "keepfeatures", "k": context().flags.incl KeepFeatures
       of "allfeatures": context().flags.incl AllFeatures
+      of "binary": context().flags.incl BinaryNimEnv
+      of "source": context().flags.incl SourceNimEnv
+      of "githubpath", "github-path": context().flags.incl GitHubPath
       of "project", "p":
         context().flags.incl(ManualProjectArg)
         if val == ".":
@@ -796,6 +802,12 @@ proc atlasRun*(params: seq[string]) =
     fatal "--update option is only valid with `install`"
   if UnlinkOnly in context().flags and action != "unlink":
     fatal "--only option is only valid with `unlink`"
+  if {BinaryNimEnv, SourceNimEnv, GitHubPath} * context().flags != {} and action != "env":
+    fatal "--binary, --source, and --github-path options are only valid with `env`"
+  if {BinaryNimEnv, SourceNimEnv} <= context().flags:
+    fatal "--binary and --source cannot be used together"
+  if GitHubPath in context().flags and getEnv("GITHUB_PATH").len == 0:
+    fatal "--github-path requires the GITHUB_PATH environment variable"
 
   if action notin ["init", "tag", "search", "list"]:
     doAssert project().string != "" and project().dirExists(), "project was not set"
@@ -891,7 +903,13 @@ proc atlasRun*(params: seq[string]) =
     showSelectedDeps()
   of "env":
     singleArg()
-    setupNimEnv args[0], KeepNimEnv in context().flags
+    let mode =
+      if BinaryNimEnv in context().flags: NimEnvMode.Binary
+      elif SourceNimEnv in context().flags: NimEnvMode.Source
+      else: NimEnvMode.Auto
+    let installed = setupNimEnv(args[0], KeepNimEnv in context().flags, mode)
+    if installed and GitHubPath in context().flags:
+      discard addNimEnvToGitHubPath(args[0])
   of "outdated":
     listOutdated()
   else:

--- a/src/basic/context.nim
+++ b/src/basic/context.nim
@@ -36,6 +36,9 @@ type
     KeepCommits
     CfgHere
     KeepNimEnv
+    BinaryNimEnv
+    SourceNimEnv
+    GitHubPath
     KeepWorkspace
     ShowGraph
     AutoEnv

--- a/src/basic/httpclientutils.nim
+++ b/src/basic/httpclientutils.nim
@@ -13,8 +13,8 @@ import atlasversion
 
 const AtlasUserAgent* = "atlas/" & AtlasPackageVersion
 
-proc newAtlasHttpClient*(): HttpClient =
-  newHttpClient(headers = newHttpHeaders({
-    "User-Agent": AtlasUserAgent,
-    "Accept-Encoding": "gzip"
-  }))
+proc newAtlasHttpClient*(acceptGzip = true): HttpClient =
+  let headers = newHttpHeaders({"User-Agent": AtlasUserAgent})
+  if acceptGzip:
+    headers["Accept-Encoding"] = "gzip"
+  newHttpClient(headers = headers)

--- a/src/basic/sha256.nim
+++ b/src/basic/sha256.nim
@@ -1,0 +1,146 @@
+#
+#           Atlas Package Cloner
+#        (c) Copyright 2023 Andreas Rumpf
+#
+#    See the file "copying.txt", included in this
+#    distribution, for details about the copyright.
+#
+
+## Small, dependency-free SHA-256 implementation for downloaded release files.
+
+type Sha256State = object
+  buffer: array[64, byte]
+  bufferLen: int
+  bitLen: uint64
+  hash: array[8, uint32]
+
+const RoundConstants: array[64, uint32] = [
+  0x428a2f98'u32, 0x71374491'u32, 0xb5c0fbcf'u32, 0xe9b5dba5'u32,
+  0x3956c25b'u32, 0x59f111f1'u32, 0x923f82a4'u32, 0xab1c5ed5'u32,
+  0xd807aa98'u32, 0x12835b01'u32, 0x243185be'u32, 0x550c7dc3'u32,
+  0x72be5d74'u32, 0x80deb1fe'u32, 0x9bdc06a7'u32, 0xc19bf174'u32,
+  0xe49b69c1'u32, 0xefbe4786'u32, 0x0fc19dc6'u32, 0x240ca1cc'u32,
+  0x2de92c6f'u32, 0x4a7484aa'u32, 0x5cb0a9dc'u32, 0x76f988da'u32,
+  0x983e5152'u32, 0xa831c66d'u32, 0xb00327c8'u32, 0xbf597fc7'u32,
+  0xc6e00bf3'u32, 0xd5a79147'u32, 0x06ca6351'u32, 0x14292967'u32,
+  0x27b70a85'u32, 0x2e1b2138'u32, 0x4d2c6dfc'u32, 0x53380d13'u32,
+  0x650a7354'u32, 0x766a0abb'u32, 0x81c2c92e'u32, 0x92722c85'u32,
+  0xa2bfe8a1'u32, 0xa81a664b'u32, 0xc24b8b70'u32, 0xc76c51a3'u32,
+  0xd192e819'u32, 0xd6990624'u32, 0xf40e3585'u32, 0x106aa070'u32,
+  0x19a4c116'u32, 0x1e376c08'u32, 0x2748774c'u32, 0x34b0bcb5'u32,
+  0x391c0cb3'u32, 0x4ed8aa4a'u32, 0x5b9cca4f'u32, 0x682e6ff3'u32,
+  0x748f82ee'u32, 0x78a5636f'u32, 0x84c87814'u32, 0x8cc70208'u32,
+  0x90befffa'u32, 0xa4506ceb'u32, 0xbef9a3f7'u32, 0xc67178f2'u32
+]
+
+func rotateRight(value: uint32; bits: int): uint32 =
+  (value shr bits) or (value shl (32 - bits))
+
+proc transform(state: var Sha256State) =
+  var schedule: array[64, uint32]
+  for i in 0..<16:
+    let offset = i * 4
+    schedule[i] =
+      (uint32(state.buffer[offset]) shl 24) or
+      (uint32(state.buffer[offset + 1]) shl 16) or
+      (uint32(state.buffer[offset + 2]) shl 8) or
+      uint32(state.buffer[offset + 3])
+  for i in 16..<64:
+    let s0 = rotateRight(schedule[i - 15], 7) xor
+      rotateRight(schedule[i - 15], 18) xor (schedule[i - 15] shr 3)
+    let s1 = rotateRight(schedule[i - 2], 17) xor
+      rotateRight(schedule[i - 2], 19) xor (schedule[i - 2] shr 10)
+    schedule[i] = schedule[i - 16] + s0 + schedule[i - 7] + s1
+
+  var a = state.hash[0]
+  var b = state.hash[1]
+  var c = state.hash[2]
+  var d = state.hash[3]
+  var e = state.hash[4]
+  var f = state.hash[5]
+  var g = state.hash[6]
+  var h = state.hash[7]
+
+  for i in 0..<64:
+    let s1 = rotateRight(e, 6) xor rotateRight(e, 11) xor rotateRight(e, 25)
+    let choice = (e and f) xor ((not e) and g)
+    let temp1 = h + s1 + choice + RoundConstants[i] + schedule[i]
+    let s0 = rotateRight(a, 2) xor rotateRight(a, 13) xor rotateRight(a, 22)
+    let majority = (a and b) xor (a and c) xor (b and c)
+    let temp2 = s0 + majority
+
+    h = g
+    g = f
+    f = e
+    e = d + temp1
+    d = c
+    c = b
+    b = a
+    a = temp1 + temp2
+
+  state.hash[0] += a
+  state.hash[1] += b
+  state.hash[2] += c
+  state.hash[3] += d
+  state.hash[4] += e
+  state.hash[5] += f
+  state.hash[6] += g
+  state.hash[7] += h
+
+proc initSha256(): Sha256State =
+  result.hash = [
+    0x6a09e667'u32, 0xbb67ae85'u32, 0x3c6ef372'u32, 0xa54ff53a'u32,
+    0x510e527f'u32, 0x9b05688c'u32, 0x1f83d9ab'u32, 0x5be0cd19'u32
+  ]
+
+proc update(state: var Sha256State; data: openArray[byte]) =
+  for value in data:
+    state.buffer[state.bufferLen] = value
+    inc state.bufferLen
+    if state.bufferLen == state.buffer.len:
+      state.transform()
+      state.bitLen += 512
+      state.bufferLen = 0
+
+proc finish(state: var Sha256State): array[32, byte] =
+  let messageBits = state.bitLen + uint64(state.bufferLen * 8)
+  state.buffer[state.bufferLen] = 0x80
+  inc state.bufferLen
+
+  if state.bufferLen > 56:
+    while state.bufferLen < state.buffer.len:
+      state.buffer[state.bufferLen] = 0
+      inc state.bufferLen
+    state.transform()
+    state.bufferLen = 0
+
+  while state.bufferLen < 56:
+    state.buffer[state.bufferLen] = 0
+    inc state.bufferLen
+  for i in 0..<8:
+    state.buffer[63 - i] = byte(messageBits shr (i * 8))
+  state.transform()
+
+  for i, value in state.hash:
+    result[i * 4] = byte(value shr 24)
+    result[i * 4 + 1] = byte(value shr 16)
+    result[i * 4 + 2] = byte(value shr 8)
+    result[i * 4 + 3] = byte(value)
+
+proc sha256File*(path: string): string =
+  var state = initSha256()
+  var file = open(path, fmRead)
+  defer:
+    file.close()
+
+  var buffer: array[64 * 1024, byte]
+  while true:
+    let count = file.readBuffer(addr buffer[0], buffer.len)
+    if count == 0:
+      break
+    state.update(buffer.toOpenArray(0, count - 1))
+
+  const HexDigits = "0123456789abcdef"
+  for value in state.finish():
+    result.add HexDigits[int(value shr 4)]
+    result.add HexDigits[int(value and 0x0f)]

--- a/src/nimenv.nim
+++ b/src/nimenv.nim
@@ -8,8 +8,8 @@
 
 ## Implementation of the "Nim virtual environment" (`atlas env`) feature.
 import std/[files, dirs, strscans, os, strutils, uri, json, options,
-            httpclient, tempfiles, osproc, streams, openssl]
-import basic/[context, osutils, versions, gitops, httpclientutils]
+            httpclient, tempfiles, osproc, streams]
+import basic/[context, osutils, versions, gitops, httpclientutils, sha256]
 
 const NimReleasesUrl* = "https://nim-lang.org/releases.json"
 
@@ -148,38 +148,6 @@ proc findBinaryRelease*(manifest, nimVersion, platform: string): Option[NimBinar
   if url.len == 0:
     raise newException(ValueError, "Nim binary release has no download URL")
   result = some(NimBinaryRelease(url: url, digest: artifact.jsonString("digest")))
-
-proc sha256File*(path: string): string =
-  let digestContext = EVP_MD_CTX_create()
-  if digestContext == nil:
-    raise newException(IOError, "cannot create SHA-256 digest context")
-  defer:
-    EVP_MD_CTX_destroy(digestContext)
-
-  if EVP_DigestInit_ex(digestContext, EVP_sha256()) != 1:
-    raise newException(IOError, "cannot initialize SHA-256 digest")
-
-  var file = open(path, fmRead)
-  defer:
-    file.close()
-  var buffer: array[64 * 1024, byte]
-  while true:
-    let count = file.readBuffer(addr buffer[0], buffer.len)
-    if count == 0:
-      break
-    if EVP_DigestUpdate(digestContext, addr buffer[0], cuint(count)) != 1:
-      raise newException(IOError, "cannot update SHA-256 digest")
-
-  var digest: array[32, byte]
-  var digestLen: cuint
-  if EVP_DigestFinal_ex(digestContext, addr digest[0], addr digestLen) != 1 or
-      digestLen != cuint(digest.len):
-    raise newException(IOError, "cannot finish SHA-256 digest")
-
-  const HexDigits = "0123456789abcdef"
-  for value in digest:
-    result.add HexDigits[int(value shr 4)]
-    result.add HexDigits[int(value and 0x0f)]
 
 proc digestMatches*(path, expected: string): bool =
   let parts = expected.split(':', maxsplit = 1)

--- a/src/nimenv.nim
+++ b/src/nimenv.nim
@@ -7,8 +7,18 @@
 #
 
 ## Implementation of the "Nim virtual environment" (`atlas env`) feature.
-import std/[files, dirs, strscans, os, strutils, uri]
-import basic/[context, osutils, versions, gitops]
+import std/[files, dirs, strscans, os, strutils, uri, json, options,
+            httpclient, tempfiles, osproc, streams, openssl]
+import basic/[context, osutils, versions, gitops, httpclientutils]
+
+const NimReleasesUrl* = "https://nim-lang.org/releases.json"
+
+type
+  NimEnvMode* {.pure.} = enum
+    Auto, Binary, Source
+
+  NimBinaryRelease* = object
+    url*, digest*: string
 
 when defined(windows):
   const
@@ -72,6 +82,7 @@ deactivate() {
 
 const
   ActivationFile* = when defined(windows): Path "activate.bat" else: Path "activate.sh"
+  NimBuildScript* = when defined(windows): "build_all.bat" else: "build_all.sh"
 
 template withDir*(dir: string; body: untyped) =
   let old = paths.getCurrentDir()
@@ -88,89 +99,320 @@ proc infoAboutActivation(nimDest: Path, nimVersion: string) =
   else:
     info nimDest, "RUN\nsource nim-" & nimVersion & "/activate.sh"
 
-proc setupNimEnv*(nimVersion: string; keepCsources: bool) =
-    template isDevel(nimVersion: string): bool = nimVersion == "devel"
+proc releasePlatform*(osName, cpuName: string): string =
+  let osPart =
+    case osName.normalize()
+    of "linux": "linux"
+    of "macosx", "macos", "darwin": "macosx"
+    of "windows", "win32": "windows"
+    else: ""
+  let cpuPart =
+    case cpuName.normalize()
+    of "amd64", "x8664", "x64": "x64"
+    of "i386", "i686", "x86", "x32": "x32"
+    of "arm64", "aarch64": "arm64"
+    of "arm", "armv7", "armv7l": "armv7l"
+    else: ""
 
-    template exec(command: string) =
-      let cmd = command # eval once
-      if os.execShellCmd(cmd) != 0:
-        error ("nim-" & nimVersion), "failed: " & cmd
-        return
+  if osPart == "linux" and cpuPart in ["x64", "x32", "arm64", "armv7l"]:
+    result = osPart & "_" & cpuPart
+  elif osPart == "macosx" and cpuPart in ["x64", "arm64"]:
+    result = osPart & "_" & cpuPart
+  elif osPart == "windows" and cpuPart in ["x64", "x32"]:
+    result = osPart & "_" & cpuPart
 
-    let nimDest = Path("nim-" & nimVersion)
-    if dirExists(depsDir() / nimDest):
-      if not fileExists(depsDir() / nimDest / ActivationFile):
-        info nimDest, "already exists; remove or rename and try again"
-      else:
-        infoAboutActivation nimDest, nimVersion
+proc hostReleasePlatform*(): string =
+  releasePlatform(hostOS, hostCPU)
+
+proc jsonString(node: JsonNode; key: string): string =
+  if node.kind == JObject and node.hasKey(key) and node[key].kind == JString:
+    result = node[key].getStr()
+
+proc findBinaryRelease*(manifest, nimVersion, platform: string): Option[NimBinaryRelease] =
+  let root = parseJson(manifest)
+  if root.kind != JObject:
+    raise newException(ValueError, "Nim release index is not a JSON object")
+  if not root.hasKey(nimVersion):
+    return
+
+  let release = root[nimVersion]
+  if release.kind != JObject:
+    raise newException(ValueError, "Nim release entry is not a JSON object")
+  if not release.hasKey(platform):
+    return
+
+  let artifact = release[platform]
+  var url = artifact.jsonString("nimlang_url")
+  if url.len == 0:
+    url = artifact.jsonString("github_url")
+  if url.len == 0:
+    raise newException(ValueError, "Nim binary release has no download URL")
+  result = some(NimBinaryRelease(url: url, digest: artifact.jsonString("digest")))
+
+proc sha256File*(path: string): string =
+  let digestContext = EVP_MD_CTX_create()
+  if digestContext == nil:
+    raise newException(IOError, "cannot create SHA-256 digest context")
+  defer:
+    EVP_MD_CTX_destroy(digestContext)
+
+  if EVP_DigestInit_ex(digestContext, EVP_sha256()) != 1:
+    raise newException(IOError, "cannot initialize SHA-256 digest")
+
+  var file = open(path, fmRead)
+  defer:
+    file.close()
+  var buffer: array[64 * 1024, byte]
+  while true:
+    let count = file.readBuffer(addr buffer[0], buffer.len)
+    if count == 0:
+      break
+    if EVP_DigestUpdate(digestContext, addr buffer[0], cuint(count)) != 1:
+      raise newException(IOError, "cannot update SHA-256 digest")
+
+  var digest: array[32, byte]
+  var digestLen: cuint
+  if EVP_DigestFinal_ex(digestContext, addr digest[0], addr digestLen) != 1 or
+      digestLen != cuint(digest.len):
+    raise newException(IOError, "cannot finish SHA-256 digest")
+
+  const HexDigits = "0123456789abcdef"
+  for value in digest:
+    result.add HexDigits[int(value shr 4)]
+    result.add HexDigits[int(value and 0x0f)]
+
+proc digestMatches*(path, expected: string): bool =
+  let parts = expected.split(':', maxsplit = 1)
+  if parts.len != 2 or parts[0].cmpIgnoreCase("sha256") != 0:
+    raise newException(ValueError, "unsupported release digest: " & expected)
+  result = sha256File(path).cmpIgnoreCase(parts[1]) == 0
+
+proc runCommand(command: string; args: openArray[string]): tuple[output: string, exitCode: int] =
+  let process = startProcess(command, args = args,
+                             options = {poUsePath, poStdErrToStdOut})
+  try:
+    result.output = process.outputStream.readAll()
+    result.exitCode = process.waitForExit()
+  finally:
+    process.close()
+
+proc writeActivation(nimDest: Path; nimVersion: string) =
+  let nimDir = depsDir() / nimDest
+  let pathEntry = nimDir / Path"bin"
+  when defined(windows):
+    let winPath = replace($pathEntry, '/', '\\')
+    writeFile $(nimDir / Path"activate.bat"), BatchFile % [winPath, nimVersion]
+    writeFile $(nimDir / Path"activate.ps1"), PowerShellFile % [winPath, nimVersion]
+  else:
+    writeFile $(nimDir / Path"activate.sh"), ShellFile % [$pathEntry, nimVersion]
+
+proc removeBundledAtlas(nimDir: Path) =
+  let binDir = nimDir / Path"bin"
+  if cmpPaths(getAppDir(), $binDir) != 0:
+    let bundledAtlas = binDir / Path("atlas".addFileExt(ExeExt))
+    if fileExists($bundledAtlas):
+      removeFile($bundledAtlas)
+
+proc removeBootstrapSources(nimDir: Path) =
+  for kind, path in walkDir($nimDir):
+    if kind == pcDir and path.lastPathComponent().startsWith("csources"):
+      let cCode = Path(path) / Path"c_code"
+      if dirExists($cCode):
+        removeDir($cCode)
+
+proc setupNimFromSource(nimVersion: string; nimDest: Path; keepCsources: bool): bool =
+  let url = "https://github.com/nim-lang/nim"
+  withDir $depsDir():
+    let (status, msg) = gitops.clone(url.parseUri(), nimDest)
+    if status != Ok:
+      error nimDest, "failed to clone: " & url & " (" & $status & "): " & msg
+      return false
+    discard gitops.fetchRemoteTags(nimDest)
+
+  let nimDir = depsDir() / nimDest
+  if nimVersion != "devel":
+    let query = createQueryEq(Version(nimVersion))
+    let commit = versionToCommit(nimDir, algo = SemVer, query = query)
+    if commit.isEmpty():
+      error nimDest, "cannot resolve version to a commit"
+      return false
+    if not checkoutGitCommit(nimDir, commit):
+      error nimDest, "cannot check out version " & nimVersion
+      return false
+
+  info nimDest, "building Nim from source with " & NimBuildScript
+  let command = when defined(windows): "cmd" else: "sh"
+  let args = when defined(windows): @["/c", NimBuildScript] else: @[NimBuildScript]
+  var buildResult: tuple[output: string, exitCode: int]
+  try:
+    withDir $nimDir:
+      buildResult = runCommand(command, args)
+  except OSError as e:
+    error nimDest, "cannot run " & NimBuildScript & ": " & e.msg
+    return false
+  let (output, exitCode) = buildResult
+  if exitCode != 0:
+    error nimDest, "failed: " & NimBuildScript & "\n" & output
+    return false
+
+  removeBundledAtlas(nimDir)
+  if not keepCsources:
+    removeBootstrapSources(nimDir)
+  result = true
+
+proc extractBinaryArchive(archive, destination: string): tuple[output: string, exitCode: int] =
+  when defined(windows):
+    if findExe("tar").len > 0:
+      try:
+        result = runCommand("tar", ["-xf", archive, "-C", destination])
+        if result.exitCode == 0:
+          return
+      except OSError as e:
+        result = (e.msg, 1)
+
+    let tarOutput = result.output
+    try:
+      result = runCommand("powershell", ["-NoProfile", "-NonInteractive", "-Command",
+        "Expand-Archive", "-LiteralPath", archive, "-DestinationPath", destination, "-Force"])
+      if result.exitCode != 0 and tarOutput.len > 0:
+        result.output = tarOutput & "\n" & result.output
+    except OSError as e:
+      result = (tarOutput & "\n" & e.msg, 1)
+  else:
+    try:
+      result = runCommand("tar", ["-xJf", archive, "-C", destination])
+    except OSError as e:
+      result = (e.msg, 1)
+
+proc setupNimFromBinary(nimVersion: string; nimDest: Path;
+                        release: NimBinaryRelease): bool =
+  let tempDir = createTempDir(".atlas-nim-", "", $depsDir())
+  defer:
+    if dirExists(tempDir):
+      removeDir(tempDir)
+
+  let archiveExt = when defined(windows): ".zip" else: ".tar.xz"
+  let archive = tempDir / ("nim-" & nimVersion & archiveExt)
+  let extractDir = tempDir / "extract"
+  createDir(extractDir)
+
+  info nimDest, "downloading " & release.url
+  let client = newAtlasHttpClient(acceptGzip = false)
+  try:
+    client.downloadFile(release.url, archive)
+  except CatchableError as e:
+    error nimDest, "cannot download binary release: " & e.msg
+    return false
+  finally:
+    client.close()
+
+  if release.digest.len > 0:
+    try:
+      if not digestMatches(archive, release.digest):
+        error nimDest, "binary release checksum does not match " & release.digest
+        return false
+    except CatchableError as e:
+      error nimDest, "cannot verify binary release: " & e.msg
+      return false
+  else:
+    warn nimDest, "binary release has no checksum in " & NimReleasesUrl
+
+  let (output, exitCode) = extractBinaryArchive(archive, extractDir)
+  if exitCode != 0:
+    error nimDest, "cannot extract binary release\n" & output
+    return false
+
+  let extracted = Path(extractDir) / nimDest
+  let nimExe = extracted / Path"bin" / Path("nim".addFileExt(ExeExt))
+  if not dirExists($extracted) or not fileExists($nimExe):
+    error nimDest, "binary release has an unexpected directory layout"
+    return false
+
+  moveDir($extracted, $(depsDir() / nimDest))
+  removeBundledAtlas(depsDir() / nimDest)
+  result = true
+
+proc fetchBinaryRelease(nimVersion: string): Option[NimBinaryRelease] =
+  let platform = hostReleasePlatform()
+  if platform.len == 0:
+    return
+
+  let client = newAtlasHttpClient(acceptGzip = false)
+  try:
+    result = findBinaryRelease(client.getContent(NimReleasesUrl), nimVersion, platform)
+  finally:
+    client.close()
+
+proc addNimEnvToGitHubPath*(nimVersion: string): bool =
+  let nimDest = Path("nim-" & nimVersion)
+  let binDir = (depsDir() / nimDest / Path"bin").absolutePath()
+  if not dirExists($binDir):
+    error nimDest, "cannot add missing Nim bin directory to GITHUB_PATH"
+    return false
+
+  let githubPath = getEnv("GITHUB_PATH")
+  if githubPath.len == 0:
+    error nimDest, "GITHUB_PATH environment variable is not set"
+    return false
+  if '\n' in $binDir or '\r' in $binDir:
+    error nimDest, "cannot add a path containing a newline to GITHUB_PATH"
+    return false
+
+  try:
+    var file = open(githubPath, fmAppend)
+    defer:
+      file.close()
+    file.write($binDir & "\n")
+  except CatchableError as e:
+    error nimDest, "cannot append to GITHUB_PATH: " & e.msg
+    return false
+
+  info nimDest, "added " & $binDir & " to GITHUB_PATH"
+  result = true
+
+proc setupNimEnv*(nimVersion: string; keepCsources: bool;
+                  mode = NimEnvMode.Auto): bool {.discardable.} =
+  let nimDest = Path("nim-" & nimVersion)
+  if dirExists(depsDir() / nimDest):
+    if not fileExists(depsDir() / nimDest / ActivationFile):
+      info nimDest, "already exists; remove or rename and try again"
+    else:
+      infoAboutActivation nimDest, nimVersion
+      result = true
+    return
+
+  if nimVersion != "devel":
+    var major, minor, patch: int
+    if not scanf(nimVersion, "$i.$i.$i", major, minor, patch):
+      error "nim", "cannot parse version requirement"
       return
 
-    var major, minor, patch: int
-    if nimVersion != "devel":
-      if not scanf(nimVersion, "$i.$i.$i", major, minor, patch):
-        error "nim", "cannot parse version requirement"
+  var installed = false
+  if mode != NimEnvMode.Source and nimVersion != "devel":
+    let release =
+      try:
+        fetchBinaryRelease(nimVersion)
+      except CatchableError as e:
+        error nimDest, "cannot read " & NimReleasesUrl & ": " & e.msg
         return
-    let csourcesVersion =
-      if nimVersion.isDevel or (major == 1 and minor >= 9) or major >= 2:
-        # already uses csources_v2
-        "csources_v2"
-      elif major == 0:
-        "csources" # has some chance of working
-      else:
-        "csources_v1"
-
-    proc cloneOrReturn(url: string; dest: Path; fetchTags = false): bool =
-      let (status, msg) = gitops.clone(url.parseUri(), dest)
-      if status != Ok:
-        error dest, "failed to clone: " & url & " (" & $status & "): " & msg
-        return false
-      if fetchTags:
-        discard gitops.fetchRemoteTags(dest)
-      true
-
-    withDir $depsDir():
-      if not dirExists(csourcesVersion):
-        if not cloneOrReturn("https://github.com/nim-lang/" & csourcesVersion, Path(csourcesVersion)):
-          return
-      if not cloneOrReturn("https://github.com/nim-lang/nim", nimDest, fetchTags = true):
+    if release.isSome():
+      installed = setupNimFromBinary(nimVersion, nimDest, release.get())
+      if not installed:
         return
-    withDir $depsDir() / csourcesVersion:
-      when defined(windows):
-        exec "build.bat"
-      else:
-        let makeExe = findExe("make")
-        if makeExe.len == 0:
-          exec "sh build.sh"
-        else:
-          exec "make"
-    let nimExe0 = ".." / csourcesVersion / "bin" / "nim".addFileExt(ExeExt)
-    let dir = depsDir() / nimDest
-    withDir $(depsDir() / nimDest):
-      let nimExe = "bin" / "nim".addFileExt(ExeExt)
-      copyFileWithPermissions nimExe0, nimExe
-      let query = createQueryEq(if nimVersion.isDevel: Version"#head" else: Version(nimVersion))
-      if not nimVersion.isDevel:
-        let commit = versionToCommit(dir, algo = SemVer, query = query)
-        if commit.isEmpty():
-          error nimDest, "cannot resolve version to a commit"
-          return
-        discard checkoutGitCommit(dir, commit)
-      exec nimExe & " c --noNimblePath --skipUserCfg --skipParentCfg --hints:off koch"
-      let kochExe = when defined(windows): "koch.exe" else: "./koch"
-      exec kochExe & " boot -d:release --skipUserCfg --skipParentCfg --hints:off"
-      exec kochExe & " tools --skipUserCfg --skipParentCfg --hints:off"
-      # remove any old atlas binary that we now would end up using:
-      if cmpPaths(getAppDir(), $(depsDir() / nimDest / "bin".Path)) != 0:
-        removeFile "bin" / "atlas".addFileExt(ExeExt)
-      # unless --keep is used delete the csources because it takes up about 2GB and
-      # is not necessary afterwards:
-      if not keepCsources:
-        removeDir $depsDir() / csourcesVersion / "c_code"
-      let pathEntry = depsDir() / nimDest / "bin".Path
-      when defined(windows):
-        let winPath = replace($pathEntry, '/', '\\')
-        writeFile "activate.bat", BatchFile % [winPath, nimVersion]
-        writeFile "activate.ps1", PowerShellFile % [winPath, nimVersion]
-      else:
-        writeFile "activate.sh", ShellFile % [$pathEntry, nimVersion]
-      infoAboutActivation nimDest, nimVersion
+    elif mode == NimEnvMode.Binary:
+      let platform = hostReleasePlatform()
+      let detail = if platform.len > 0: " for " & platform else: " for this platform"
+      error nimDest, "no binary release is available" & detail
+      return
+
+  if mode == NimEnvMode.Binary and nimVersion == "devel":
+    error nimDest, "binary releases are not available for devel"
+    return
+
+  if not installed:
+    installed = setupNimFromSource(nimVersion, nimDest, keepCsources)
+
+  if installed:
+    writeActivation(nimDest, nimVersion)
+    infoAboutActivation nimDest, nimVersion
+  result = installed

--- a/tests/tnimenv.nim
+++ b/tests/tnimenv.nim
@@ -1,6 +1,6 @@
 import std/[unittest, envvars, options, os, paths, strutils, tempfiles]
 
-import basic/context
+import basic/[context, sha256]
 import nimenv
 
 const ReleaseIndex = """
@@ -62,13 +62,25 @@ suite "Nim environments":
     defer:
       if fileExists(path):
         removeFile(path)
-    writeFile(path, "abc")
 
-    const Expected = "ba7816bf8f01cfea414140de5dae2223" &
+    const AbcDigest = "ba7816bf8f01cfea414140de5dae2223" &
       "b00361a396177a9cb410ff61f20015ad"
-    check sha256File(path) == Expected
-    check digestMatches(path, "sha256:" & Expected)
+    writeFile(path, "abc")
+    check sha256File(path) == AbcDigest
+    check digestMatches(path, "sha256:" & AbcDigest)
     check not digestMatches(path, "sha256:" & repeat('0', 64))
+
+    writeFile(path, "")
+    check sha256File(path) == "e3b0c44298fc1c149afbf4c8996fb924" &
+      "27ae41e4649b934ca495991b7852b855"
+
+    writeFile(path, "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")
+    check sha256File(path) == "248d6a61d20638b8e5c026930c3e6039" &
+      "a33ce45964ff2167f6ecedd419db06c1"
+
+    writeFile(path, repeat('a', 1_000_000))
+    check sha256File(path) == "cdc76e5c9914fb9281a1c7e284d73e67" &
+      "f1809a48a497200e046d39ccc7112cd0"
 
   test "uses Nim's standard build script":
     when defined(windows):

--- a/tests/tnimenv.nim
+++ b/tests/tnimenv.nim
@@ -1,0 +1,101 @@
+import std/[unittest, envvars, options, os, paths, strutils, tempfiles]
+
+import basic/context
+import nimenv
+
+const ReleaseIndex = """
+{
+  "2.2.10": {
+    "linux_arm64": {
+      "github_url": "https://example.invalid/github.tar.xz",
+      "nimlang_url": "https://example.invalid/nimlang.tar.xz",
+      "digest": "sha256:abc123"
+    },
+    "windows_x64": {
+      "github_url": "https://example.invalid/nim.zip"
+    }
+  }
+}
+"""
+
+suite "Nim environments":
+  test "maps every binary release platform":
+    check releasePlatform("linux", "amd64") == "linux_x64"
+    check releasePlatform("linux", "i386") == "linux_x32"
+    check releasePlatform("linux", "arm64") == "linux_arm64"
+    check releasePlatform("linux", "arm") == "linux_armv7l"
+    check releasePlatform("macosx", "amd64") == "macosx_x64"
+    check releasePlatform("darwin", "aarch64") == "macosx_arm64"
+    check releasePlatform("windows", "amd64") == "windows_x64"
+    check releasePlatform("win32", "i686") == "windows_x32"
+    check releasePlatform("freebsd", "amd64") == ""
+    check releasePlatform("macosx", "i386") == ""
+
+  test "maps the current host when it has binary releases":
+    when defined(linux) or defined(macosx) or defined(windows):
+      when defined(amd64) or defined(i386) or defined(arm64) or defined(arm):
+        check hostReleasePlatform().len > 0
+
+  test "prefers the nim-lang download URL":
+    let release = findBinaryRelease(ReleaseIndex, "2.2.10", "linux_arm64")
+    require release.isSome()
+    check release.get().url == "https://example.invalid/nimlang.tar.xz"
+    check release.get().digest == "sha256:abc123"
+
+  test "falls back to the GitHub download URL":
+    let release = findBinaryRelease(ReleaseIndex, "2.2.10", "windows_x64")
+    require release.isSome()
+    check release.get().url == "https://example.invalid/nim.zip"
+    check release.get().digest == ""
+
+  test "reports unavailable versions and platforms":
+    check findBinaryRelease(ReleaseIndex, "2.2.8", "linux_arm64").isNone()
+    check findBinaryRelease(ReleaseIndex, "2.2.10", "macosx_arm64").isNone()
+
+  test "rejects a release without a download URL":
+    expect ValueError:
+      discard findBinaryRelease(
+        "{\"2.2.10\":{\"linux_x64\":{}}}", "2.2.10", "linux_x64")
+
+  test "computes and checks SHA-256 release digests":
+    let path = genTempPath("atlas_sha256_", ".txt")
+    defer:
+      if fileExists(path):
+        removeFile(path)
+    writeFile(path, "abc")
+
+    const Expected = "ba7816bf8f01cfea414140de5dae2223" &
+      "b00361a396177a9cb410ff61f20015ad"
+    check sha256File(path) == Expected
+    check digestMatches(path, "sha256:" & Expected)
+    check not digestMatches(path, "sha256:" & repeat('0', 64))
+
+  test "uses Nim's standard build script":
+    when defined(windows):
+      check NimBuildScript == "build_all.bat"
+    else:
+      check NimBuildScript == "build_all.sh"
+
+  test "adds the absolute Nim bin directory to GITHUB_PATH":
+    let oldContext = context()
+    let hadGitHubPath = existsEnv("GITHUB_PATH")
+    let oldGitHubPath = getEnv("GITHUB_PATH")
+    let projectDir = Path(genTempPath("atlas github path ", ""))
+    let githubPath = projectDir / Path"github_path"
+    let binDir = projectDir / Path"deps" / Path"nim-2.2.10" / Path"bin"
+    defer:
+      setContext(oldContext)
+      if hadGitHubPath:
+        putEnv("GITHUB_PATH", oldGitHubPath)
+      else:
+        delEnv("GITHUB_PATH")
+      if dirExists($projectDir):
+        removeDir($projectDir)
+
+    createDir($binDir)
+    writeFile($githubPath, "already-present\n")
+    putEnv("GITHUB_PATH", $githubPath)
+    setContext(AtlasContext(projectDir: projectDir, depsDir: Path"deps"))
+
+    check addNimEnvToGitHubPath("2.2.10")
+    check readFile($githubPath) == "already-present\n" & $binDir.absolutePath() & "\n"

--- a/tests/tpackageinfos.nim
+++ b/tests/tpackageinfos.nim
@@ -112,6 +112,11 @@ doAssert not AtlasIsDirty
     check client.headers["User-Agent"] == "atlas/" & AtlasPackageVersion
     check client.headers["Accept-Encoding"] == "gzip"
 
+    let uncompressedClient = newAtlasHttpClient(acceptGzip = false)
+    defer: uncompressedClient.close()
+    check uncompressedClient.headers["User-Agent"] == "atlas/" & AtlasPackageVersion
+    check not uncompressedClient.headers.hasKey("Accept-Encoding")
+
   test "gzip encoded package list is decompressed with gzip":
     if findExe("gzip").len == 0:
       skip()


### PR DESCRIPTION
## Summary

- install tagged Nim environments from releases.json on supported CI platforms
- add strict --binary and --source modes while retaining source fallback in automatic mode
- verify release checksums, use Nim's standard source build scripts, and support --github-path

## Testing

- nim build
- nim unitTests
- nim c -r tests/tnimenv.nim
- nim c -r tests/tpackageinfos.nim
- nim check --os:linux --cpu:amd64 --hints:off src/atlas.nim
- nim check --os:windows --cpu:amd64 --hints:off src/atlas.nim
- end-to-end binary install of Nim 2.2.10 on macOS ARM64