### PR TITLE
feat: support custom Git Nim environments

### DIFF
--- a/doc/atlas.md
+++ b/doc/atlas.md
@@ -286,7 +286,7 @@ normal selectors to remove matching tests from the selected set.
 ```
 atlas-run tests
 atlas-run tests --jobs:4
-atlas-run tests --nimcache:.nimcache/atlas-run
+atlas-run tests --nimcache:deps/.nimcache/atlas-run
 atlas-run tests --no-shuffle
 atlas-run tests --only-errors
 atlas-run tests --compiler-output
@@ -413,6 +413,22 @@ checksum, and extraction failures are reported rather than falling back to a sou
 build. The source path uses Nim's standard `build_all.sh` script on UNIX and
 `build_all.bat` on Windows. The `devel` version is always built from source, and
 `atlas env devel --binary` is an error.
+
+To build a custom Nim checkout, pass `--git-ref` with a branch, tag, commit SHA,
+or explicit Git ref. This implies a source build. The environment name is local
+to the workspace, so use a name without path separators. By default Atlas uses
+the upstream Nim repository; pass `--git-url` to build a fork or other remote:
+
+```
+atlas env nim-develop --git-ref=devel
+atlas env nim-fix --git-ref=4fcb2ea7b9be2a40b5679c1ba4d41f2bd1b2247f
+atlas env my-nim --git-url=https://github.com/me/Nim.git --git-ref=fix/windows
+```
+
+`--git-url` requires `--git-ref`, and Git source selection cannot be combined
+with `--binary`. Atlas resolves the requested ref to a full commit SHA, checks it
+out detached, and records the URL, requested ref, and SHA under `nimEnvs` in
+`atlas.config`.
 
 In GitHub Actions, use `--github-path` to append the installed Nim `bin` directory
 to the runner's `GITHUB_PATH` environment file. Nim will then be available on

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -51,7 +51,7 @@ Commands:
   changed [atlas.lock]  list any packages that differ from the lock file
   outdated              list the packages that are outdated
   deps                  list the currently selected dependencies
-  env <nimversion>      setup a Nim virtual environment
+  env <env-name>        setup a Nim virtual environment
 
 Options:
   --help, -h            show this help
@@ -72,6 +72,8 @@ Options:
   --keepworkspace       keep generated workspace artifacts
   --binary              for `env`, require a prebuilt Nim release
   --source              for `env`, build Nim from source
+  --git-ref=ref         for `env`, build this Git branch, tag, or commit from source
+  --git-url=url         for `env --git-ref`, use this Nim Git repository
   --github-path         for `env`, add Nim's bin directory to $GITHUB_PATH
   --ignoreerrors        continue even when errors were recorded
   --dumpformular        dump SAT formula for debugging
@@ -118,6 +120,10 @@ proc parseParallelCloneWorkers(value: string): int =
     writeHelp()
   if result < 1:
     writeHelp()
+
+type
+  EnvOptions = object
+    gitRef, gitUrl: string
 
 proc addRequestedFeature(rawFeature: string) =
   # Package-scoped features use `<pkg>.<feature>` and are normalized to
@@ -663,7 +669,8 @@ proc update(filter: string) =
   if updatedAny:
     notice project(), "dependency refs updated, run `atlas install` to update"
 
-proc parseAtlasOptions(params: seq[string], action: var string, args: var seq[string]) =
+proc parseAtlasOptions(params: seq[string], action: var string, args: var seq[string];
+                       envOptions: var EnvOptions) =
   var autoinit = true
   if existsEnv("NO_COLOR") or not isatty(stdout) or (getEnv("TERM") == "dumb"):
     setAtlasNoColors(true)
@@ -683,6 +690,14 @@ proc parseAtlasOptions(params: seq[string], action: var string, args: var seq[st
       of "allfeatures": context().flags.incl AllFeatures
       of "binary": context().flags.incl BinaryNimEnv
       of "source": context().flags.incl SourceNimEnv
+      of "gitref", "git-ref":
+        if val.len == 0:
+          writeHelp()
+        envOptions.gitRef = val
+      of "giturl", "git-url":
+        if val.len == 0:
+          writeHelp()
+        envOptions.gitUrl = val
       of "githubpath", "github-path": context().flags.incl GitHubPath
       of "project", "p":
         context().flags.incl(ManualProjectArg)
@@ -786,6 +801,7 @@ proc parseAtlasOptions(params: seq[string], action: var string, args: var seq[st
 proc atlasRun*(params: seq[string]) =
   var action = ""
   var args: seq[string] = @[]
+  var envOptions: EnvOptions
   template singleArg() =
     if args.len != 1:
       fatal action & " command takes a single package name"
@@ -796,16 +812,22 @@ proc atlasRun*(params: seq[string]) =
     elif args.len != 1:
       fatal action & " command takes a single package name"
 
-  parseAtlasOptions(params, action, args)
+  parseAtlasOptions(params, action, args, envOptions)
 
   if UpdateBeforeInstall in context().flags and action != "install":
     fatal "--update option is only valid with `install`"
   if UnlinkOnly in context().flags and action != "unlink":
     fatal "--only option is only valid with `unlink`"
-  if {BinaryNimEnv, SourceNimEnv, GitHubPath} * context().flags != {} and action != "env":
-    fatal "--binary, --source, and --github-path options are only valid with `env`"
+  if ({BinaryNimEnv, SourceNimEnv, GitHubPath} * context().flags != {} or
+      envOptions.gitRef.len > 0 or envOptions.gitUrl.len > 0) and action != "env":
+    fatal "--binary, --source, --git-ref, --git-url, and --github-path " &
+      "options are only valid with `env`"
   if {BinaryNimEnv, SourceNimEnv} <= context().flags:
     fatal "--binary and --source cannot be used together"
+  if envOptions.gitUrl.len > 0 and envOptions.gitRef.len == 0:
+    fatal "--git-url requires --git-ref"
+  if envOptions.gitRef.len > 0 and BinaryNimEnv in context().flags:
+    fatal "--binary cannot be used with --git-ref"
   if GitHubPath in context().flags and getEnv("GITHUB_PATH").len == 0:
     fatal "--github-path requires the GITHUB_PATH environment variable"
 
@@ -907,7 +929,8 @@ proc atlasRun*(params: seq[string]) =
       if BinaryNimEnv in context().flags: NimEnvMode.Binary
       elif SourceNimEnv in context().flags: NimEnvMode.Source
       else: NimEnvMode.Auto
-    let installed = setupNimEnv(args[0], KeepNimEnv in context().flags, mode)
+    let source = NimSourceSpec(remoteUrl: envOptions.gitUrl, gitRef: envOptions.gitRef)
+    let installed = setupNimEnv(args[0], KeepNimEnv in context().flags, mode, source)
     if installed and GitHubPath in context().flags:
       discard addNimEnvToGitHubPath(args[0])
   of "outdated":

--- a/src/basic/context.nim
+++ b/src/basic/context.nim
@@ -26,6 +26,10 @@ const
 type
   CfgPath* = distinct string # put into a config `--path:"../x"`
 
+  NimEnvConfig* = object
+    ## The source revision used to build a Nim environment.
+    url*, gitRef*, sha*: string
+
   SemVerField* = enum
     major, minor, patch
 
@@ -79,6 +83,7 @@ type
     overridesFile*: Path
     pluginsFile*: Path
     proxy*: Uri
+    nimEnvs*: Table[string, NimEnvConfig]
     parallelCloneWorkers*: int = DefaultParallelCloneWorkers
     features*: HashSet[string]
 

--- a/src/confighandler.nim
+++ b/src/confighandler.nim
@@ -25,6 +25,7 @@ type
     plugins*: string
     resolver*: string
     graph*: JsonNode
+    nimEnvs*: Table[string, NimEnvConfig]
 
   ActivatedPackage* = object
     url*: PkgUrl
@@ -52,11 +53,14 @@ proc writeDefaultConfigFile*() =
     nameOverrides: initTable[string, string](),
     urlOverrides: initTable[string, string](),
     pkgOverrides: initTable[string, string](),
+    nimEnvs: initTable[string, NimEnvConfig](),
     resolver: $SemVer,
     graph: newJNull()
   )
   let configFile = getProjectConfig()
-  writeFile($configFile, pretty %*config)
+  let json = %*config
+  json.delete("nimEnvs")
+  writeFile($configFile, pretty json)
 
 proc readConfigFile*(configFile: Path): JsonConfig =
   var f = newFileStream($configFile, fmRead)
@@ -77,6 +81,8 @@ proc readAtlasContext*(ctx: var AtlasContext, projectDir: Path) =
   let m = readConfigFile(configFile)
 
   ctx.projectDir = projectDir
+  ctx.nimEnvs =
+    if m.nimEnvs.len > 0: m.nimEnvs else: initTable[string, NimEnvConfig]()
 
   if m.deps.len > 0:
     ctx.depsDir = m.deps.Path.expandTilde()
@@ -120,11 +126,14 @@ proc writeConfig*() =
     pkgOverrides: context().pkgOverrides.pairs().toSeq().mapIt((it[0], $it[1])).toTable(),
     plugins: $context().pluginsFile,
     resolver: $context().defaultAlgo,
-    graph: newJNull()
+    graph: newJNull(),
+    nimEnvs: context().nimEnvs
   )
 
   let jcfg = toJson(config)
   doAssert not jcfg.isNil()
+  if context().nimEnvs.len == 0:
+    jcfg.delete("nimEnvs")
   let configFile = getProjectConfig()
   debug "atlas", "writing config file: ", $configFile
   writeFile($configFile, pretty(jcfg))

--- a/src/nimenv.nim
+++ b/src/nimenv.nim
@@ -8,10 +8,13 @@
 
 ## Implementation of the "Nim virtual environment" (`atlas env`) feature.
 import std/[files, dirs, strscans, os, strutils, uri, json, options,
-            httpclient, tempfiles, osproc, streams]
+            httpclient, tempfiles, osproc, streams, tables]
 import basic/[context, osutils, versions, gitops, httpclientutils, sha256]
+import confighandler
 
-const NimReleasesUrl* = "https://nim-lang.org/releases.json"
+const
+  NimReleasesUrl* = "https://nim-lang.org/releases.json"
+  NimRepositoryUrl* = "https://github.com/nim-lang/nim"
 
 type
   NimEnvMode* {.pure.} = enum
@@ -19,6 +22,10 @@ type
 
   NimBinaryRelease* = object
     url*, digest*: string
+
+  NimSourceSpec* = object
+    ## A Git source used to build a custom Nim environment.
+    remoteUrl*, gitRef*: string
 
 when defined(windows):
   const
@@ -188,17 +195,46 @@ proc removeBootstrapSources(nimDir: Path) =
       if dirExists($cCode):
         removeDir($cCode)
 
-proc setupNimFromSource(nimVersion: string; nimDest: Path; keepCsources: bool): bool =
-  let url = "https://github.com/nim-lang/nim"
+proc hasGitRef(source: NimSourceSpec): bool =
+  source.gitRef.len > 0
+
+proc sourceUrl(source: NimSourceSpec): string =
+  if source.remoteUrl.len > 0: source.remoteUrl else: NimRepositoryUrl
+
+proc checkoutGitRef(nimDest: Path; gitRef: string): CommitHash =
+  let (fetchOutput, fetchStatus) = gitops.exec(
+    GitFetch, nimDest, ["--no-tags", "origin", gitRef], Warning)
+  if fetchStatus != RES_OK:
+    error nimDest, "cannot fetch git ref " & gitRef & ": " & fetchOutput.strip()
+    return
+
+  let (output, status) = gitops.exec(GitRevParse, nimDest, ["FETCH_HEAD^{commit}"], Warning)
+  if status != RES_OK:
+    error nimDest, "cannot resolve git ref " & gitRef
+    return
+  result = initCommitHash(output.strip(), FromHead)
+  if not result.isFull():
+    error nimDest, "git ref " & gitRef & " did not resolve to a full commit SHA"
+    return
+  if not checkoutGitCommit(nimDest, result):
+    result = initCommitHash("", FromNone)
+
+proc setupNimFromSource(nimVersion: string; nimDest: Path; keepCsources: bool;
+                        source = NimSourceSpec()): bool =
+  let url = source.sourceUrl()
   withDir $depsDir():
     let (status, msg) = gitops.clone(url.parseUri(), nimDest)
     if status != Ok:
       error nimDest, "failed to clone: " & url & " (" & $status & "): " & msg
       return false
-    discard gitops.fetchRemoteTags(nimDest)
 
   let nimDir = depsDir() / nimDest
-  if nimVersion != "devel":
+  if source.hasGitRef():
+    if checkoutGitRef(nimDir, source.gitRef).isEmpty():
+      return false
+  else:
+    discard gitops.fetchRemoteTags(nimDest)
+  if not source.hasGitRef() and nimVersion != "devel":
     let query = createQueryEq(Version(nimVersion))
     let commit = versionToCommit(nimDir, algo = SemVer, query = query)
     if commit.isEmpty():
@@ -227,6 +263,32 @@ proc setupNimFromSource(nimVersion: string; nimDest: Path; keepCsources: bool): 
   if not keepCsources:
     removeBootstrapSources(nimDir)
   result = true
+
+proc validNimEnvName*(name: string): bool =
+  ## Returns whether `name` is safe to use as a single environment directory name.
+  if name.len == 0:
+    return false
+  for ch in name:
+    if not (ch.isAlphaNumeric() or ch in {'-', '_', '.'}):
+      return false
+  true
+
+proc recordNimEnv(nimName: string; source: NimSourceSpec) =
+  let commit = currentGitCommit(depsDir() / Path("nim-" & nimName))
+  if not commit.isFull():
+    error nimName, "cannot record a Nim environment without a full Git commit SHA"
+    return
+  if context().nimEnvs.len == 0:
+    context().nimEnvs = initTable[string, NimEnvConfig]()
+  context().nimEnvs[nimName] = NimEnvConfig(
+    url: source.sourceUrl(), gitRef: source.gitRef, sha: $commit)
+  writeConfig()
+
+proc matchesRecordedNimEnv(nimName: string; source: NimSourceSpec): bool =
+  if context().nimEnvs.len == 0 or nimName notin context().nimEnvs:
+    return true
+  let recorded = context().nimEnvs[nimName]
+  result = recorded.url == source.sourceUrl() and recorded.gitRef == source.gitRef
 
 proc extractBinaryArchive(archive, destination: string): tuple[output: string, exitCode: int] =
   when defined(windows):
@@ -339,24 +401,41 @@ proc addNimEnvToGitHubPath*(nimVersion: string): bool =
   result = true
 
 proc setupNimEnv*(nimVersion: string; keepCsources: bool;
-                  mode = NimEnvMode.Auto): bool {.discardable.} =
+                  mode = NimEnvMode.Auto;
+                  source = NimSourceSpec()): bool {.discardable.} =
+  if source.remoteUrl.len > 0 and not source.hasGitRef():
+    error "nim", "--git-url requires --git-ref"
+    return
+  if source.hasGitRef() and mode == NimEnvMode.Binary:
+    error "nim", "--binary cannot be used with --git-ref"
+    return
+  if source.hasGitRef() and not validNimEnvName(nimVersion):
+    error "nim", "custom Nim environment names may only contain letters, digits, '.', '-', and '_'"
+    return
+
   let nimDest = Path("nim-" & nimVersion)
   if dirExists(depsDir() / nimDest):
     if not fileExists(depsDir() / nimDest / ActivationFile):
       info nimDest, "already exists; remove or rename and try again"
     else:
+      if source.hasGitRef():
+        if not matchesRecordedNimEnv(nimVersion, source):
+          error nimDest,
+            "already exists for a different Git source; use a different environment name"
+          return
+        recordNimEnv(nimVersion, source)
       infoAboutActivation nimDest, nimVersion
       result = true
     return
 
-  if nimVersion != "devel":
+  if not source.hasGitRef() and nimVersion != "devel":
     var major, minor, patch: int
     if not scanf(nimVersion, "$i.$i.$i", major, minor, patch):
       error "nim", "cannot parse version requirement"
       return
 
   var installed = false
-  if mode != NimEnvMode.Source and nimVersion != "devel":
+  if mode != NimEnvMode.Source and not source.hasGitRef() and nimVersion != "devel":
     let release =
       try:
         fetchBinaryRelease(nimVersion)
@@ -378,9 +457,11 @@ proc setupNimEnv*(nimVersion: string; keepCsources: bool;
     return
 
   if not installed:
-    installed = setupNimFromSource(nimVersion, nimDest, keepCsources)
+    installed = setupNimFromSource(nimVersion, nimDest, keepCsources, source)
 
   if installed:
     writeActivation(nimDest, nimVersion)
+    if source.hasGitRef():
+      recordNimEnv(nimVersion, source)
     infoAboutActivation nimDest, nimVersion
   result = installed

--- a/src/testrunner.nim
+++ b/src/testrunner.nim
@@ -387,7 +387,7 @@ proc effectiveNimcacheRoot(projectDir, nimcacheDir: Path): Path =
     else:
       result = projectDir / expanded
   else:
-    result = projectDir / Path".nimcache" / Path"atlas-run"
+    result = projectDir / Path"deps/.nimcache" / Path"atlas-run"
 
 proc testNimcacheDir(projectDir, nimcacheRoot, path: Path): Path =
   let relativeTest = path.relativePath(projectDir, '/').changeFileExt("")

--- a/tests/tatlasrun.nim
+++ b/tests/tatlasrun.nim
@@ -314,7 +314,7 @@ writeFile("ran.out", "ran")
       showOutput = false
     ))
     check code == 0
-    check fileExists($(dir / Path".nimcache" / Path"atlas-run" /
+    check fileExists($(dir / Path"deps/.nimcache" / Path"atlas-run" /
       Path"tests" / Path"tcompileonly" / Path("tcompileonly".addFileExt(ExeExt))))
     check not fileExists($(dir / Path"ran.out"))
 
@@ -341,9 +341,9 @@ writeFile("ran-two.out", "ran")
       showOutput = false
     ))
     check code == 0
-    check fileExists($(dir / Path".nimcache" / Path"atlas-run" /
+    check fileExists($(dir / Path"deps/.nimcache" / Path"atlas-run" /
       Path"examples" / Path"one" / Path("one".addFileExt(ExeExt))))
-    check fileExists($(dir / Path".nimcache" / Path"atlas-run" /
+    check fileExists($(dir / Path"deps/.nimcache" / Path"atlas-run" /
       Path"examples" / Path"two" / Path("two".addFileExt(ExeExt))))
     check not fileExists($(dir / Path"ran-one.out"))
     check not fileExists($(dir / Path"ran-two.out"))
@@ -422,8 +422,8 @@ writeFile("two.out", "ok")
     check code == 0
     check readFile($(dir / Path"one.out")) == "ok"
     check readFile($(dir / Path"two.out")) == "ok"
-    check dirExists($(dir / Path".nimcache" / Path"atlas-run" / Path"tests" / Path"tone"))
-    check dirExists($(dir / Path".nimcache" / Path"atlas-run" / Path"tests" / Path"ttwo"))
+    check dirExists($(dir / Path"deps/.nimcache" / Path"atlas-run" / Path"tests" / Path"tone"))
+    check dirExists($(dir / Path"deps/.nimcache" / Path"atlas-run" / Path"tests" / Path"ttwo"))
 
   test "non-interactive runs print progress summaries":
     let dir = freshDir("atlas_run_only_errors_summaries")

--- a/tests/tnimenv.nim
+++ b/tests/tnimenv.nim
@@ -1,6 +1,8 @@
-import std/[unittest, envvars, options, os, paths, strutils, tempfiles]
+import std/[unittest, envvars, options, os, osproc, paths, strutils, tables, tempfiles]
 
 import basic/[context, sha256]
+import atlas
+import confighandler
 import nimenv
 
 const ReleaseIndex = """
@@ -17,6 +19,11 @@ const ReleaseIndex = """
   }
 }
 """
+
+proc runGit(dir: Path; args: string): string =
+  let (output, code) = execCmdEx("git -C " & quoteShell($dir) & " " & args)
+  doAssert code == 0, output
+  result = output.strip()
 
 suite "Nim environments":
   test "maps every binary release platform":
@@ -111,3 +118,53 @@ suite "Nim environments":
 
     check addNimEnvToGitHubPath("2.2.10")
     check readFile($githubPath) == "already-present\n" & $binDir.absolutePath() & "\n"
+
+  test "builds custom Git refs and records their SHAs":
+    let oldContext = context()
+    let projectDir = Path(genTempPath("atlas nim env project ", ""))
+    let repoDir = Path(genTempPath("atlas nim env repo ", ""))
+    defer:
+      setContext(oldContext)
+      if dirExists($projectDir):
+        removeDir($projectDir)
+      if dirExists($repoDir):
+        removeDir($repoDir)
+
+    createDir($projectDir)
+    createDir($repoDir)
+    writeFile($(projectDir / Path"atlas.config"), "{}\n")
+    discard runGit(repoDir, "init")
+    discard runGit(repoDir, "config user.email atlas@example.invalid")
+    discard runGit(repoDir, "config user.name Atlas")
+    when defined(windows):
+      writeFile($(repoDir / Path"build_all.bat"), "@echo off\nmkdir bin\ntype nul > bin\\nim.exe\n")
+    else:
+      writeFile($(repoDir / Path"build_all.sh"), "mkdir -p bin\ntouch bin/nim\n")
+    writeFile($(repoDir / Path"compiler.nim"), "discard\n")
+    discard runGit(repoDir, "add .")
+    discard runGit(repoDir, "commit -m initial")
+    discard runGit(repoDir, "checkout -b custom")
+    writeFile($(repoDir / Path"compiler.nim"), "echo \"custom\"\n")
+    discard runGit(repoDir, "commit -am custom")
+    let sha = runGit(repoDir, "rev-parse HEAD")
+
+    let branchSource = NimSourceSpec(remoteUrl: $repoDir, gitRef: "custom")
+    setContext(AtlasContext())
+    atlasRun(@[
+      "--project=" & $projectDir,
+      "env",
+      "custom-branch",
+      "--git-url=" & branchSource.remoteUrl,
+      "--git-ref=" & branchSource.gitRef
+    ])
+    setContext(AtlasContext(projectDir: projectDir, depsDir: Path"deps"))
+    readConfig()
+    let shaSource = NimSourceSpec(remoteUrl: $repoDir, gitRef: sha)
+    check setupNimEnv("custom-sha", false, source = shaSource)
+
+    let config = readConfigFile(projectDir / Path"atlas.config")
+    check config.nimEnvs["custom-branch"].url == $repoDir
+    check config.nimEnvs["custom-branch"].gitRef == "custom"
+    check config.nimEnvs["custom-branch"].sha == sha
+    check config.nimEnvs["custom-sha"].sha == sha
+    check "\"sha\": \"" & sha & "\"" in readFile($(projectDir / Path"atlas.config"))


### PR DESCRIPTION
## Summary
- add `atlas env --git-ref` and `--git-url` for building Nim branches, tags, and commit SHAs
- persist custom environment URLs, refs, and resolved SHAs in `atlas.config`
- place default `atlas-run tests` compiler caches under `deps/.nimcache/atlas-run`

## Validation
- `nim c -r --hints:off tests/tnimenv.nim`
- `nim c -r --hints:off tests/tatlasrun.nim`
- `nim c -r --hints:off tests/tlinks.nim`
- `nim build`