### PR TITLE
Align to Nimble's dependency feature syntax

### DIFF
--- a/atlas.nimble
+++ b/atlas.nimble
@@ -1,5 +1,5 @@
 # Package
-version = "0.14.14"
+version = "0.15.0"
 author = "Araq"
 description = "Atlas is a simple package cloner tool. It manages an isolated project."
 license = "MIT"

--- a/doc/atlas.md
+++ b/doc/atlas.md
@@ -228,6 +228,12 @@ feature "testing":
 
 Features are lazily cloned by Atlas until they are specified by either a requires feature or passed from the command line.
 
+Atlas automatically enables the root package's `dev` and `patch` features, matching
+Nimble. Declare development-only dependencies with `dev:`; `patch` uses a regular
+`feature "patch":` block. Compiler defines use the package name declared in its
+Nimble file, for example `--define:features.my_package.testing`, even when the
+repository or dependency alias has a different name.
+
 In Nimble files you can enable features for a a given package like so:
 ```nim
 requires "somelib >= 1.0[testing]"

--- a/doc/atlas.md
+++ b/doc/atlas.md
@@ -230,9 +230,13 @@ Features are lazily cloned by Atlas until they are specified by either a require
 
 In Nimble files you can enable features for a a given package like so:
 ```nim
-require "somelib[testing]"
-require "anotherlib[testing, async]"
+requires "somelib >= 1.0[testing]"
+requires "anotherlib >= 2.0 [testing, async]"
 ```
+
+Atlas also accepts the older `somelib[testing] >= 1.0` placement, but warns when
+a version constraint follows the feature list. Move the feature list to the end
+of the requirement to match Nimble's syntax.
 
 
 ### Search <term term2 term3 ...>

--- a/doc/atlas.md
+++ b/doc/atlas.md
@@ -244,6 +244,10 @@ Atlas also accepts the older `somelib[testing] >= 1.0` placement, but warns when
 a version constraint follows the feature list. Move the feature list to the end
 of the requirement to match Nimble's syntax.
 
+As with Nimble, requesting a dependency feature always emits its compiler define.
+The dependency does not need to declare the feature; a declaration is only needed
+when activating the feature should add more package requirements.
+
 
 ### Search <term term2 term3 ...>
 

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -127,14 +127,16 @@ type
 
 proc addRequestedFeature(rawFeature: string) =
   # Package-scoped features use `<pkg>.<feature>` and are normalized to
-  # `feature.<pkg>.<feature>` internally for nim.cfg defines.
+  # `features.<pkg>.<feature>` internally for nim.cfg defines.
   let raw = rawFeature.strip().toLowerAscii()
   if raw.len == 0:
     writeHelp()
-  elif raw.startsWith("feature."):
+  elif raw.startsWith(FeatureDefinePrefix):
     context().features.incl raw
+  elif raw.startsWith(LegacyFeatureDefinePrefix):
+    context().features.incl FeatureDefinePrefix & raw[LegacyFeatureDefinePrefix.len..^1]
   elif '.' in raw:
-    context().features.incl "feature." & raw
+    context().features.incl FeatureDefinePrefix & raw
   else:
     # Root-package feature shorthand.
     context().features.incl raw
@@ -496,11 +498,11 @@ proc activationCachePaths(cache: ActivationCache): tuple[
   for pkg in cache.packages:
     if pkg.isRoot:
       for feature in pkg.features:
-        result.features.addUniqueFeature "feature." & pkg.url.projectName & "." & feature
+        result.features.addUniqueFeature FeatureDefinePrefix & pkg.url.projectName & "." & feature
     else:
       result.paths.add CfgPath(pkg.ondisk / pkg.srcDir)
       for feature in pkg.features:
-        result.features.addUniqueFeature "feature." & pkg.url.shortName & "." & feature
+        result.features.addUniqueFeature FeatureDefinePrefix & pkg.url.shortName & "." & feature
   result.paths.sort(proc (a, b: CfgPath): int = cmp(a.string, b.string))
 
 proc linkFileFor(pkg: ActivatedPackage): Path =

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -496,13 +496,15 @@ proc linkedPackageClosure(cache: ActivationCache; packageIndex: int;
 proc activationCachePaths(cache: ActivationCache): tuple[
     paths: seq[CfgPath], features: seq[string]] =
   for pkg in cache.packages:
+    let packageName = featurePackageName(pkg.name,
+      if pkg.isRoot: pkg.url.projectName else: pkg.url.shortName)
     if pkg.isRoot:
       for feature in pkg.features:
-        result.features.addUniqueFeature FeatureDefinePrefix & pkg.url.projectName & "." & feature
+        result.features.addUniqueFeature FeatureDefinePrefix & packageName & "." & feature
     else:
       result.paths.add CfgPath(pkg.ondisk / pkg.srcDir)
       for feature in pkg.features:
-        result.features.addUniqueFeature FeatureDefinePrefix & pkg.url.shortName & "." & feature
+        result.features.addUniqueFeature FeatureDefinePrefix & packageName & "." & feature
   result.paths.sort(proc (a, b: CfgPath): int = cmp(a.string, b.string))
 
 proc linkFileFor(pkg: ActivatedPackage): Path =

--- a/src/basic/configutils.nim
+++ b/src/basic/configutils.nim
@@ -29,6 +29,11 @@ proc patchNimCfg*(deps: seq[CfgPath]; cfgPath: CfgPath; features: seq[string] = 
       paths.add "--path:\"" & x & "\"\n"
   for feature in features:
     paths.add "--define:\"" & feature & "\"\n"
+    # Remove this singular alias when support for legacy `foo[bar] > 3.0`
+    # requirements is removed.
+    if feature.startsWith(FeatureDefinePrefix):
+      let legacyFeature = LegacyFeatureDefinePrefix & feature[FeatureDefinePrefix.len..^1]
+      paths.add "--define:\"" & legacyFeature & "\"\n"
   var cfgContent = configPatternBegin & paths & configPatternEnd
 
   let cfg = Path(cfgPath.string / "nim.cfg")
@@ -75,5 +80,7 @@ proc parseNimCfgFeatures*(cfgPath: CfgPath): seq[string] =
 
     if x.len >= 2 and x[0] == '"' and x[^1] == '"':
       x = x[1 .. ^2]
-    if x.startsWith("feature.") and x notin result:
+    if x.startsWith(LegacyFeatureDefinePrefix):
+      x = FeatureDefinePrefix & x[LegacyFeatureDefinePrefix.len..^1]
+    if x.startsWith(FeatureDefinePrefix) and x notin result:
       result.add x.toLowerAscii()

--- a/src/basic/context.nim
+++ b/src/basic/context.nim
@@ -153,16 +153,27 @@ proc addUniqueFeature*(features: var seq[string]; feature: string) =
   if not features.containsFeature(feature):
     features.add feature
 
-proc hasRequestedFeature*(pkgShortName, pkgProjectName, feature: string): bool =
+func featurePackageName*(declaredName, fallbackName: string): string =
+  ## Returns the Nimble package name used in compiler feature symbols.
+  if declaredName.len > 0: declaredName
+  else: fallbackName
+
+proc hasRequestedFeature*(pkgShortName, pkgProjectName, pkgDeclaredName,
+                          feature: string; isRoot: bool): bool =
   initAtlasContext()
-  if AllFeatures in atlasContext.flags:
+  if AllFeatures in atlasContext.flags or
+      (isRoot and feature in ["dev", "patch"]):
     return true
-  let scopedByShortName = FeatureDefinePrefix & pkgShortName & "." & feature
-  let scopedByProjectName = FeatureDefinePrefix & pkgProjectName & "." & feature
-  result =
-    atlasContext.features.containsFeature(feature) or
-    atlasContext.features.containsFeature(scopedByShortName) or
-    atlasContext.features.containsFeature(scopedByProjectName)
+  if atlasContext.features.containsFeature(feature):
+    return true
+  for pkgName in [pkgShortName, pkgProjectName, pkgDeclaredName]:
+    if pkgName.len > 0 and atlasContext.features.containsFeature(
+        FeatureDefinePrefix & pkgName & "." & feature):
+      return true
+
+proc hasRequestedFeature*(pkgShortName, pkgProjectName, feature: string): bool =
+  ## Compatibility overload for callers without release metadata.
+  hasRequestedFeature(pkgShortName, pkgProjectName, "", feature, false)
 
 proc packagesDirectory*(): Path =
   depsDir() / DefaultPackagesSubDir

--- a/src/basic/context.nim
+++ b/src/basic/context.nim
@@ -21,6 +21,8 @@ const
   DefaultCachesSubDir* = Path".cache"
   DefaultNimbleCachesSubDir* = Path"_nimbles"
   DefaultParallelCloneWorkers* = 3
+  FeatureDefinePrefix* = "features."
+  LegacyFeatureDefinePrefix* = "feature."
 
 
 type
@@ -155,8 +157,8 @@ proc hasRequestedFeature*(pkgShortName, pkgProjectName, feature: string): bool =
   initAtlasContext()
   if AllFeatures in atlasContext.flags:
     return true
-  let scopedByShortName = "feature." & pkgShortName & "." & feature
-  let scopedByProjectName = "feature." & pkgProjectName & "." & feature
+  let scopedByShortName = FeatureDefinePrefix & pkgShortName & "." & feature
+  let scopedByProjectName = FeatureDefinePrefix & pkgProjectName & "." & feature
   result =
     atlasContext.features.containsFeature(feature) or
     atlasContext.features.containsFeature(scopedByShortName) or

--- a/src/basic/nimbleparser.nim
+++ b/src/basic/nimbleparser.nim
@@ -19,7 +19,12 @@ proc processRequirement(nc: var NimbleContext;
                         req: string;
                         feature: string;
                         result: var NimbleRelease) =
-    let (name, reqsByFeatures, verIdx) = extractRequirementName(req)
+    let (name, reqsByFeatures, _) = extractRequirementName(req)
+    let requirement = removeRequirementFeatures(req)
+    let (_, _, verIdx) = extractRequirementName(requirement)
+    if usesLegacyRequirementFeatureSyntax(req):
+      warn nimbleFile, "deprecated dependency feature syntax:", req,
+        "; use", requirementWithFeaturesAtEnd(req)
 
     var url: PkgUrl
     try:
@@ -32,7 +37,7 @@ proc processRequirement(nc: var NimbleContext;
       url = toPkgUriRaw(parseUri("error://" & name))
 
     var err = false
-    let query = parseVersionInterval(req, verIdx, err) # update err
+    let query = parseVersionInterval(requirement, verIdx, err) # update err
     if err:
       if result.status != HasBrokenDep:
         warn nimbleFile, "broken nimble file: " & name

--- a/src/basic/parse_requires.nim
+++ b/src/basic/parse_requires.nim
@@ -332,6 +332,10 @@ proc extract(n: PNode; conf: ConfigRef; currFeature: string; result: var NimbleF
           for f in features:
             result.features[f] = newSeq[string]()
             extract(n[^1], conf, f, result)
+      of "dev":
+        if n.len >= 2:
+          result.features["dev"] = newSeq[string]()
+          extract(n[^1], conf, "dev", result)
       else:
         discard
   of nkAsgn, nkFastAsgn:

--- a/src/basic/versions.nim
+++ b/src/basic/versions.nim
@@ -632,6 +632,48 @@ proc matches*(pattern: VersionInterval; v: Version): bool =
   else:
     result = matches(pattern.a, v)
 
+proc requirementFeatures(req: string): tuple[features: seq[string], first, last: int] =
+  result = (@[], req.find('['), -1)
+  if result.first < 0:
+    return
+  result.last = req.find(']', result.first + 1)
+  if result.last < 0:
+    return
+  for rawFeature in req[result.first + 1 ..< result.last].split(','):
+    let feature = rawFeature.strip()
+    if feature.len > 0:
+      result.features.add(feature)
+
+proc removeRequirementFeatures*(req: string): string =
+  ## Removes the feature list from a Nimble requirement.
+  let (_, first, last) = requirementFeatures(req)
+  if last < 0:
+    return req
+  if first > 0:
+    result.add(req[0..<first])
+  if last + 1 < req.len:
+    result.add(req[last + 1..^1])
+
+proc usesLegacyRequirementFeatureSyntax*(req: string): bool =
+  ## Returns whether features appear before a version constraint.
+  let (_, first, last) = requirementFeatures(req)
+  if last < 0 or last + 1 >= req.len:
+    return false
+
+  const verChars = {'#', '<', '=', '>', '^', '~', '['}
+  var nameEnd = 0
+  while nameEnd < req.len and req[nameEnd] notin verChars + Whitespace:
+    inc nameEnd
+  result = first == nameEnd and req[last + 1..^1].strip().len > 0
+
+proc requirementWithFeaturesAtEnd*(req: string): string =
+  ## Rewrites the legacy feature placement to Nimble's feature suffix syntax.
+  let (_, first, last) = requirementFeatures(req)
+  if last < 0:
+    return req
+  result = removeRequirementFeatures(req).strip()
+  result.add(req[first..last])
+
 proc extractRequirementName*(req: string): (string, seq[string], int) =
   const verChars = {'#', '<', '=', '>', '^', '~', '['}
   proc isScpStyleGitUrl(name: string): bool =
@@ -651,19 +693,11 @@ proc extractRequirementName*(req: string): (string, seq[string], int) =
     #       so it occurs rarely but breaks things for atlas
     raise newException(ValueError, "Invalid requirements name: " & req)
 
-  if i < req.len and req[i] == '[':
-    inc i
-    var features: seq[string]
-    while i < req.len and req[i] notin verChars + {']'}:
-      while i < req.len and req[i] in verChars + {','} + Whitespace:
-        inc i
-      let start = i
-      while i < req.len and req[i] notin verChars + {',', ']'} + Whitespace:
-        inc i
-      features.add req.substr(start, i-1)
-    result = (name, features, i+1)
+  let (features, first, last) = requirementFeatures(req)
+  if i < req.len and req[i] == '[' and first == i and last >= 0:
+    result = (name, features, last + 1)
   else:
-    result = (name, @[], i)
+    result = (name, features, i)
 
 proc extractSpecificCommit*(pattern: VersionInterval): CommitHash =
   if not pattern.isInterval and pattern.a.r == verEq and pattern.a.v.isSpecial: # and pattern.a.v.string.len >= MinCommitLen:

--- a/src/dependencies.nim
+++ b/src/dependencies.nim
@@ -137,12 +137,16 @@ proc registerReleaseDependencies(
         nc.explicitVersions.mgetOrPut(pkgUrl, initHashSet[VersionTag]()).incl(VersionTag(v: Version($(interval)), c: commit))
       if pkgUrl notin nc.packageToDependency:
         let state =
-          if not hasRequestedFeature(pkg.url.shortName, pkg.url.projectName, feature): LazyDeferred
+          if not hasRequestedFeature(pkg.url.shortName, pkg.url.projectName,
+                                     release.name, feature, pkg.isRoot): LazyDeferred
           else: childDependencyState(pkg, deferChildDeps)
         debug pkg.url.projectName, "Found new feature pkg:", pkgUrl.projectName, "url:", $pkgUrl.url, "projectName:", $pkgUrl.projectName, "state:", $state
         let pkgDep = nc.initPackage(pkgUrl, state)
         nc.packageToDependency[pkgUrl] = pkgDep
-      elif hasRequestedFeature(pkg.url.shortName, pkg.url.projectName, feature) and nc.packageToDependency[pkgUrl].state == LazyDeferred and childDependencyState(pkg, deferChildDeps) != LazyDeferred:
+      elif hasRequestedFeature(pkg.url.shortName, pkg.url.projectName,
+                               release.name, feature, pkg.isRoot) and
+          nc.packageToDependency[pkgUrl].state == LazyDeferred and
+          childDependencyState(pkg, deferChildDeps) != LazyDeferred:
         warn pkg.url.projectName, "Changing LazyDeferred feature pkg to DoLoad:", $pkgUrl.url
         nc.packageToDependency[pkgUrl].state = DoLoad
 

--- a/src/depgraphs.nim
+++ b/src/depgraphs.nim
@@ -82,8 +82,48 @@ proc addCompatibleVersionChoice(b: var Builder; compatibleVersions: seq[VarId]) 
   var featureVersions: Table[VarId, seq[VarId]]
   b.addCompatibleVersionChoice(compatibleVersions, featureVersions)
 
-proc hasContextFeature(pkg: Package; feature: string): bool =
-  result = hasRequestedFeature(pkg.url.shortName, pkg.url.projectName, feature)
+proc packageFeatureName(pkg: Package; rel: NimbleRelease): string =
+  let fallbackName =
+    if pkg.isRoot: pkg.url.projectName
+    else: pkg.url.shortName
+  let declaredName =
+    if rel.isNil: ""
+    else: rel.name
+  result = featurePackageName(declaredName, fallbackName)
+
+proc matchesFeaturePackageName(pkg: Package; rel: NimbleRelease;
+                               name: string): bool =
+  for candidate in [pkg.url.shortName, pkg.url.projectName, rel.name]:
+    if candidate.len > 0 and sameFeature(candidate, name):
+      return true
+
+proc canonicalFeatureDefine(graph: DepGraph; feature: string): string =
+  if not feature.startsWith(FeatureDefinePrefix):
+    if graph.root.isNil or graph.root.activeNimbleRelease().isNil:
+      return feature
+    return FeatureDefinePrefix &
+      graph.root.packageFeatureName(graph.root.activeNimbleRelease()) & "." & feature
+
+  let parts = feature.split(".")
+  if parts.len < 3:
+    return feature
+  let requestedPackage = parts[1]
+  let requestedFeature = parts[2..^1].join(".")
+  for pkg in allActiveNodes(graph):
+    let rel = pkg.activeNimbleRelease()
+    if rel.isNil:
+      continue
+    if pkg.matchesFeaturePackageName(rel, requestedPackage):
+      let declaredFeature = rel.features.findFeature(requestedFeature)
+      let featureName =
+        if declaredFeature.len > 0: declaredFeature
+        else: requestedFeature
+      return FeatureDefinePrefix & pkg.packageFeatureName(rel) & "." & featureName
+  result = feature
+
+proc hasContextFeature(pkg: Package; rel: NimbleRelease; feature: string): bool =
+  result = hasRequestedFeature(pkg.url.shortName, pkg.url.projectName,
+                               rel.name, feature, pkg.isRoot)
 
 proc requirementMatches*(query: VersionInterval; depVer: PackageVersion; depRel: NimbleRelease): bool =
   ## Match semver constraints against nimble-declared release versions, while
@@ -126,16 +166,24 @@ proc collectUnsatisfiedContextFeatures(graph: DepGraph): seq[string] =
       if rel.isNil:
         continue
       for featName in rel.features.keys():
-        requested.addUnique(FeatureDefinePrefix & pkg.url.projectName & "." & featName)
+        requested.addUnique(FeatureDefinePrefix & pkg.packageFeatureName(rel) & "." & featName)
   else:
     requested = context().features.toSeq()
+    if not graph.root.isNil:
+      let rel = graph.root.activeNimbleRelease()
+      if not rel.isNil:
+        for feature in ["dev", "patch"]:
+          if feature in rel.features:
+            requested.addUnique(FeatureDefinePrefix &
+              graph.root.packageFeatureName(rel) & "." & feature)
   requested.sort()
   for raw in requested:
     let qualified =
       if raw.startsWith(FeatureDefinePrefix):
         raw
-      elif not graph.root.isNil:
-        FeatureDefinePrefix & graph.root.url.projectName & "." & raw
+      elif not graph.root.isNil and not graph.root.activeNimbleRelease().isNil:
+        FeatureDefinePrefix &
+          graph.root.packageFeatureName(graph.root.activeNimbleRelease()) & "." & raw
       else:
         FeatureDefinePrefix & raw
 
@@ -152,11 +200,11 @@ proc collectUnsatisfiedContextFeatures(graph: DepGraph): seq[string] =
     var declaredInNimble = false
     var featureSatisfied = false
     for pkg in allActiveNodes(graph):
-      if pkg.url.shortName == pkgName or pkg.url.projectName == pkgName:
+      let rel = pkg.activeNimbleRelease()
+      if rel.isNil:
+        continue
+      if pkg.matchesFeaturePackageName(rel, pkgName):
         matchedPkg = true
-        let rel = pkg.activeNimbleRelease()
-        if rel.isNil:
-          continue
         let declaredFeature = rel.features.findFeature(featName)
         if declaredFeature.len > 0:
           declaredInNimble = true
@@ -266,7 +314,7 @@ proc addVersionConstraints(b: var Builder; graph: var DepGraph, pkg: Package) =
         b.addNegated(featureVarId)
         continue
 
-      if hasContextFeature(pkg, feature):
+      if hasContextFeature(pkg, rel, feature):
         # A requested feature must be selected whenever this package version
         # is selected. This preserves separate feature variables when
         # several requested features share a dependency.
@@ -297,7 +345,7 @@ proc addVersionConstraints(b: var Builder; graph: var DepGraph, pkg: Package) =
           debug pkg.url.projectName, "added compatVer feature dep variables:", $compatibleVersions.mapIt($it).join(", ")
         
         # Add implictations for globally set features
-        if hasContextFeature(pkg, feature):
+        if hasContextFeature(pkg, rel, feature):
           debug pkg.url.projectName, "checking global feature:", $feature, "in version:", $ver, "context().features:", $context().features.toSeq().mapIt($it).join(", ")
           var featureVersions: Table[VarId, seq[VarId]]
           for depVer, nimbleRelease in depNode.validVersions():
@@ -388,7 +436,7 @@ proc collectLazyDeferredPackagesForUnsatRetry(graph: DepGraph): seq[Package] =
 
       includeLazyDeps(rel.requirements, $pkg.url.projectName & ":" & $ver)
       for feature, reqs in rel.features:
-        if hasContextFeature(pkg, feature):
+        if hasContextFeature(pkg, rel, feature):
           includeLazyDeps(reqs, $pkg.url.projectName & ":" & feature)
 
 proc toFormular*(graph: var DepGraph; algo: ResolutionAlgorithm): Form =
@@ -702,7 +750,7 @@ proc solve*(graph: var DepGraph; form: Form, rerun: var bool) =
 
       for feature, reqs in rel.features:
         var isFeatureEnabled = false
-        if hasContextFeature(pkg, feature):
+        if hasContextFeature(pkg, rel, feature):
           isFeatureEnabled = true
         elif feature in rel.featureVars and solution.isTrue(rel.featureVars[feature]):
           isFeatureEnabled = true
@@ -832,12 +880,7 @@ proc activateGraph*(graph: DepGraph): tuple[paths: seq[CfgPath], features: seq[s
 
   # Add feature defines for --feature:FOO flags (root project features without prefix)
   for feature in context().features:
-    if feature.startsWith(FeatureDefinePrefix):
-      # Already in full format: features.$PKG.$FEATURE
-      result.features.addUniqueFeature feature
-    else:
-      # Short format: FOO -> features.$ROOT.FOO
-      result.features.addUniqueFeature FeatureDefinePrefix & graph.root.url.projectName & "." & feature
+    result.features.addUniqueFeature graph.canonicalFeatureDefine(feature)
 
   # Apply global feature flags to activeFeatures for introspection/tests.
   for pkg in graph.pkgs.values():
@@ -847,19 +890,24 @@ proc activateGraph*(graph: DepGraph): tuple[paths: seq[CfgPath], features: seq[s
     if rel.isNil:
       continue
     for featName in rel.features.keys():
-      if hasContextFeature(pkg, featName) and hasSatisfiedFeatureDeps(graph, rel, featName):
+      if hasContextFeature(pkg, rel, featName) and
+          hasSatisfiedFeatureDeps(graph, rel, featName):
         pkg.activeFeatures.addUniqueFeature(featName)
 
   if not graph.root.isNil and graph.root.active:
+    let rel = graph.root.activeNimbleRelease()
     for feature in graph.root.activeFeatures:
-      result.features.addUniqueFeature FeatureDefinePrefix & graph.root.url.projectName & "." & feature
+      result.features.addUniqueFeature FeatureDefinePrefix &
+        graph.root.packageFeatureName(rel) & "." & feature
 
   for pkg in allActiveNodes(graph):
     if pkg.isRoot: continue
     trace pkg.url.projectName, "adding CfgPath:", $relativeToWorkspace(toDestDir(graph, pkg) / getCfgPath(graph, pkg).Path)
     result.paths.add CfgPath(toDestDir(graph, pkg) / getCfgPath(graph, pkg).Path)
+    let rel = pkg.activeNimbleRelease()
     for feature in pkg.activeFeatures:
-      result.features.addUniqueFeature FeatureDefinePrefix & pkg.url.shortName & "." & feature
+      result.features.addUniqueFeature FeatureDefinePrefix &
+        pkg.packageFeatureName(rel) & "." & feature
 
   result.paths.sort(proc (a, b: CfgPath): int =
     cmp(a.string, b.string)

--- a/src/depgraphs.nim
+++ b/src/depgraphs.nim
@@ -97,6 +97,26 @@ proc matchesFeaturePackageName(pkg: Package; rel: NimbleRelease;
     if candidate.len > 0 and sameFeature(candidate, name):
       return true
 
+proc activateRequiredDependencyFeatures(graph: DepGraph) =
+  ## Records every feature requested on an active dependency requirement.
+  ## Nimble emits the define even when the selected dependency does not declare
+  ## the feature; only declared features contribute additional requirements.
+  for pkg in allActiveNodes(graph):
+    let rel = pkg.activeNimbleRelease()
+    if not rel.isNil:
+      for depUrl, requestedFeatures in rel.reqsByFeatures:
+        if depUrl in graph.pkgs:
+          let depPkg = graph.pkgs[depUrl]
+          if depPkg.active and not depPkg.activeVersion.isNil:
+            let depRel = depPkg.activeNimbleRelease()
+            if not depRel.isNil:
+              for requestedFeature in requestedFeatures:
+                let declaredFeature = depRel.features.findFeature(requestedFeature)
+                let feature =
+                  if declaredFeature.len > 0: declaredFeature
+                  else: requestedFeature
+                depPkg.activeFeatures.addUniqueFeature(feature)
+
 proc canonicalFeatureDefine(graph: DepGraph; feature: string): string =
   if not feature.startsWith(FeatureDefinePrefix):
     if graph.root.isNil or graph.root.activeNimbleRelease().isNil:
@@ -766,6 +786,8 @@ proc solve*(graph: var DepGraph; form: Form, rerun: var bool) =
 
       rerun = true
       return
+
+    graph.activateRequiredDependencyFeatures()
 
     if ListVersions in context().flags and ListVersionsOff notin context().flags:
       printVersionSelections(graph, solution, form)

--- a/src/depgraphs.nim
+++ b/src/depgraphs.nim
@@ -126,20 +126,20 @@ proc collectUnsatisfiedContextFeatures(graph: DepGraph): seq[string] =
       if rel.isNil:
         continue
       for featName in rel.features.keys():
-        requested.addUnique("feature." & pkg.url.projectName & "." & featName)
+        requested.addUnique(FeatureDefinePrefix & pkg.url.projectName & "." & featName)
   else:
     requested = context().features.toSeq()
   requested.sort()
   for raw in requested:
     let qualified =
-      if raw.startsWith("feature."):
+      if raw.startsWith(FeatureDefinePrefix):
         raw
       elif not graph.root.isNil:
-        "feature." & graph.root.url.projectName & "." & raw
+        FeatureDefinePrefix & graph.root.url.projectName & "." & raw
       else:
-        "feature." & raw
+        FeatureDefinePrefix & raw
 
-    if not qualified.startsWith("feature."):
+    if not qualified.startsWith(FeatureDefinePrefix):
       continue
 
     let parts = qualified.split(".")
@@ -258,7 +258,7 @@ proc addVersionConstraints(b: var Builder; graph: var DepGraph, pkg: Package) =
     for feature, reqs in rel.features:
       let featureVarId = rel.featureVars[feature]
       let featDepCheck = checkDeps(graph, ver, reqs)
-      let qualifiedFeature = "feature." & pkg.url.projectName & "." & feature
+      let qualifiedFeature = FeatureDefinePrefix & pkg.url.projectName & "." & feature
 
       debug pkg.url.projectName, "checking feature dep:", $feature, "query:", $reqs, "compat versions:", $featDepCheck.allDepsCompatible
       if not featDepCheck.allDepsCompatible:
@@ -832,12 +832,12 @@ proc activateGraph*(graph: DepGraph): tuple[paths: seq[CfgPath], features: seq[s
 
   # Add feature defines for --feature:FOO flags (root project features without prefix)
   for feature in context().features:
-    if feature.startsWith("feature."):
-      # Already in full format: feature.$PKG.$FEATURE
+    if feature.startsWith(FeatureDefinePrefix):
+      # Already in full format: features.$PKG.$FEATURE
       result.features.addUniqueFeature feature
     else:
-      # Short format: FOO -> feature.$ROOT.FOO
-      result.features.addUniqueFeature "feature." & graph.root.url.projectName & "." & feature
+      # Short format: FOO -> features.$ROOT.FOO
+      result.features.addUniqueFeature FeatureDefinePrefix & graph.root.url.projectName & "." & feature
 
   # Apply global feature flags to activeFeatures for introspection/tests.
   for pkg in graph.pkgs.values():
@@ -852,14 +852,14 @@ proc activateGraph*(graph: DepGraph): tuple[paths: seq[CfgPath], features: seq[s
 
   if not graph.root.isNil and graph.root.active:
     for feature in graph.root.activeFeatures:
-      result.features.addUniqueFeature "feature." & graph.root.url.projectName & "." & feature
+      result.features.addUniqueFeature FeatureDefinePrefix & graph.root.url.projectName & "." & feature
 
   for pkg in allActiveNodes(graph):
     if pkg.isRoot: continue
     trace pkg.url.projectName, "adding CfgPath:", $relativeToWorkspace(toDestDir(graph, pkg) / getCfgPath(graph, pkg).Path)
     result.paths.add CfgPath(toDestDir(graph, pkg) / getCfgPath(graph, pkg).Path)
     for feature in pkg.activeFeatures:
-      result.features.addUniqueFeature "feature." & pkg.url.shortName & "." & feature
+      result.features.addUniqueFeature FeatureDefinePrefix & pkg.url.shortName & "." & feature
 
   result.paths.sort(proc (a, b: CfgPath): int =
     cmp(a.string, b.string)

--- a/tests/tbasics.nim
+++ b/tests/tbasics.nim
@@ -475,6 +475,14 @@ suite "versions":
 
     check extractRequirementName("mypackage[feature1]") == ("mypackage", @["feature1"], 19)
 
+    check extractRequirementName("mypackage >= 1.0[feature1]") ==
+      ("mypackage", @["feature1"], 9)
+    check extractRequirementName("mypackage >= 1.0 [feature1] ") ==
+      ("mypackage", @["feature1"], 9)
+    check extractRequirementName("mypackage >= 1.0 [feature1, feature2]") ==
+      ("mypackage", @["feature1", "feature2"], 9)
+    check extractRequirementName("mypackage >= 1.0 [feature1,feature2]") ==
+      ("mypackage", @["feature1", "feature2"], 9)
     check extractRequirementName("mypackage[feature1, feature2]") == ("mypackage", @["feature1", "feature2"], 29)
     check extractRequirementName("mypackage[feature1, feature2] >= 1.0") == ("mypackage", @["feature1", "feature2"], 29)
     check extractRequirementName("mypackage[feature1, feature2] <= 2.0") == ("mypackage", @["feature1", "feature2"], 29)

--- a/tests/test_data/automatic_features.nimble
+++ b/tests/test_data/automatic_features.nimble
@@ -1,0 +1,7 @@
+name = "declared_root"
+
+dev:
+  requires "shared_dependency"
+
+feature "patch":
+  requires "shared_dependency"

--- a/tests/test_data/undeclared_dependency_feature.nimble
+++ b/tests/test_data/undeclared_dependency_feature.nimble
@@ -1,0 +1,3 @@
+name = "feature_consumer"
+
+requires "shared_dependency >= 1.0 [future]"

--- a/tests/tfeature_duplicate_dependencies.nim
+++ b/tests/tfeature_duplicate_dependencies.nim
@@ -35,3 +35,33 @@ suite "duplicate feature dependencies":
     doAssert root.active
     doAssert dependency.active, "the shared feature dependency must be selected"
     doAssert root.activeFeatures.len == 2
+
+  test "root dev and patch features are enabled automatically":
+    setContext(AtlasContext())
+
+    var nc = createNimbleContext()
+    nc.put("shared_dependency", toPkgUriRaw(parseUri("file:///shared_dependency")))
+    let sharedDependency = nc.createUrl("shared_dependency")
+    let rootUrl = nc.createUrlFromPath(Path"tests/test_data")
+
+    let rootRelease = nc.parseNimbleFile(
+      Path"tests/test_data/automatic_features.nimble")
+    rootRelease.version = Version"#head"
+
+    let root = nc.initPackage(rootUrl, Processed)
+    root.isRoot = true
+    root.versions[toVersionTag("*@head").toPkgVer] = rootRelease
+
+    let dependency = nc.initPackage(sharedDependency, Processed)
+    dependency.versions[toVersionTag("1.0.0@head").toPkgVer] =
+      NimbleRelease(version: Version"1.0.0", status: Normal)
+
+    var graph = DepGraph(root: root)
+    graph.pkgs[rootUrl] = root
+    graph.pkgs[sharedDependency] = dependency
+
+    graph.solve(graph.toFormular(SemVer))
+
+    doAssert root.active
+    doAssert dependency.active, "automatic feature dependencies must be selected"
+    doAssert root.activeFeatures.toHashSet == ["dev", "patch"].toHashSet

--- a/tests/tfeature_duplicate_dependencies.nim
+++ b/tests/tfeature_duplicate_dependencies.nim
@@ -65,3 +65,38 @@ suite "duplicate feature dependencies":
     doAssert root.active
     doAssert dependency.active, "automatic feature dependencies must be selected"
     doAssert root.activeFeatures.toHashSet == ["dev", "patch"].toHashSet
+
+  test "required dependency features need not be declared":
+    setContext(AtlasContext())
+    context().flags.incl NoExec
+
+    var nc = createNimbleContext()
+    nc.put("shared_dependency", toPkgUriRaw(parseUri("file:///shared_dependency")))
+    let sharedDependency = nc.createUrl("shared_dependency")
+    let rootUrl = nc.createUrlFromPath(Path"tests/test_data")
+
+    let rootRelease = nc.parseNimbleFile(
+      Path"tests/test_data/undeclared_dependency_feature.nimble")
+    rootRelease.version = Version"#head"
+
+    let root = nc.initPackage(rootUrl, Processed)
+    root.isRoot = true
+    root.versions[toVersionTag("*@head").toPkgVer] = rootRelease
+
+    let dependency = nc.initPackage(sharedDependency, Processed)
+    dependency.versions[toVersionTag("1.0.0@-").toPkgVer] = NimbleRelease(
+      name: "declared_dependency",
+      version: Version"1.0.0",
+      status: Normal)
+
+    var graph = DepGraph(root: root)
+    graph.pkgs[rootUrl] = root
+    graph.pkgs[sharedDependency] = dependency
+
+    graph.solve(graph.toFormular(SemVer))
+
+    doAssert root.active
+    doAssert dependency.active
+    doAssert dependency.activeFeatures == @["future"]
+    let (_, features) = graph.activateGraph()
+    doAssert "features.declared_dependency.future" in features

--- a/tests/tfeatures.nim
+++ b/tests/tfeatures.nim
@@ -283,6 +283,7 @@ suite "test global features":
 
         withDir "deps" / "proj_a":
           writeFile("proj_a.nimble", dedent"""
+          name = "declared_proj_a"
           requires "proj_b >= 1.1.0"
           feature "Test_Ing":
             requires "$1 >= 1.0.0"
@@ -303,8 +304,8 @@ suite "test global features":
         check dirExists("deps" / "proj_feature_dep")
         let nimCfg = readFile("nim.cfg")
         check "deps/proj_feature_dep" in nimCfg
-        check "features.proj_a.testing" in nimCfg
-        check "feature.proj_a.testing" in nimCfg
+        check "features.declared_proj_a.Test_Ing" in nimCfg
+        check "feature.declared_proj_a.Test_Ing" in nimCfg
         check fileExists("deps" / ".cache" / "atlas.active.json")
         check not fileExists("deps" / "atlas.cache.json")
 
@@ -720,6 +721,32 @@ suite "test global features":
         requires "proj_a >= 9.9.9"
       """)
       check runInstallWithFeature("siwin") > 0
+
+      # 4) Root dev and patch features activate without CLI flags and use the
+      # declared package name in compiler defines.
+      if dirExists("deps"):
+        removeDir("deps")
+      writeFile(rootNimble, dedent"""
+      name = "declared_root"
+      dev:
+        requires "proj_a >= 1.1.0"
+      feature "patch":
+        requires "proj_a >= 1.1.0"
+      """)
+      resetFeatureTestContext()
+      let errorsBefore = atlasErrors()
+      atlasRun(@[
+        "--deps=deps",
+        "--proxy=http://localhost:4242/",
+        "--dumbproxy",
+        "install"
+      ])
+      check atlasErrors() == errorsBefore
+      check dirExists("deps" / "proj_a")
+      let nimCfg = readFile("nim.cfg")
+      for feature in ["dev", "patch"]:
+        check "features.declared_root." & feature in nimCfg
+        check "feature.declared_root." & feature in nimCfg
 
   test "unsat root dependency should not trigger lazy historical retry":
     ## Expected behavior:

--- a/tests/tfeatures.nim
+++ b/tests/tfeatures.nim
@@ -193,7 +193,7 @@ suite "test global features":
         context().flags = {ListVersions}
         context().defaultAlgo = SemVer
         context().flags.incl DumpFormular
-        context().features.incl "feature.proj_a.testing"
+        context().features.incl "features.proj_a.testing"
 
         expectedVersionWithGitTags()
         var nc = createNimbleContext()
@@ -303,6 +303,7 @@ suite "test global features":
         check dirExists("deps" / "proj_feature_dep")
         let nimCfg = readFile("nim.cfg")
         check "deps/proj_feature_dep" in nimCfg
+        check "features.proj_a.testing" in nimCfg
         check "feature.proj_a.testing" in nimCfg
         check fileExists("deps" / ".cache" / "atlas.active.json")
         check not fileExists("deps" / "atlas.cache.json")
@@ -381,8 +382,8 @@ suite "test global features":
         check dirExists("deps" / "proj_feature_dep")
         let nimCfg = readFile("nim.cfg")
         check "deps/proj_feature_dep" in nimCfg
-        check "feature.proj_a.testing" in nimCfg
-        check "feature.proj_a.marker" in nimCfg
+        check "features.proj_a.testing" in nimCfg
+        check "features.proj_a.marker" in nimCfg
 
   test "atlasRun install activates package feature deps from --allFeatures":
       setAtlasVerbosity(Error)
@@ -449,8 +450,8 @@ suite "test global features":
         check dirExists("deps" / "proj_feature_dep")
         let nimCfg = readFile("nim.cfg")
         check "deps/proj_feature_dep" in nimCfg
-        check "feature.proj_a.testing" in nimCfg
-        check "feature.proj_a.marker" in nimCfg
+        check "features.proj_a.testing" in nimCfg
+        check "features.proj_a.marker" in nimCfg
 
   test "requires dependency feature activates empty feature declaration":
       setAtlasVerbosity(Error)
@@ -512,18 +513,20 @@ suite "test global features":
         check graph.pkgs[nc2.createUrl("proj_a")].activeFeatures == @["marker"]
 
         let (_, features) = graph.activateGraph()
-        check "feature.proj_a.marker" in features
+        check "features.proj_a.marker" in features
 
   test "parse features from nim.cfg":
       withDir "tests/ws_features_global":
         writeFile("nim.cfg", dedent"""
-        --define:"feature.proj_a.testing"
-        -d:feature.proj_b.extra
+        --define:"features.proj_a.testing"
+        -d:features.proj_b.extra
+        --define:"feature.proj_c.legacy"
         --define:"not_a_feature"
         """)
 
         check parseNimCfgFeatures(CfgPath paths.getCurrentDir()).toHashSet ==
-          ["feature.proj_a.testing", "feature.proj_b.extra"].toHashSet
+          ["features.proj_a.testing", "features.proj_b.extra",
+           "features.proj_c.legacy"].toHashSet
 
   test "atlasRun install keeps features from nim.cfg with -k":
       setAtlasVerbosity(Error)
@@ -572,7 +575,7 @@ suite "test global features":
           exec "git tag v1.2.0"
 
         writeFile("nim.cfg", dedent"""
-        --define:"feature.proj_a.testing"
+        --define:"features.proj_a.testing"
         """)
 
         setContext(AtlasContext())
@@ -642,8 +645,8 @@ suite "test global features":
         context().flags = {DumbProxy, ListVersions}
         context().depsDir = Path "deps"
         context().defaultAlgo = SemVer
-        context().features.incl "feature.proj_a.testing"
-        context().features.incl "feature.proj_a.broken"
+        context().features.incl "features.proj_a.testing"
+        context().features.incl "features.proj_a.broken"
         project(paths.getCurrentDir())
 
         var nc2 = createNimbleContext()

--- a/tests/tnimbleparser.nim
+++ b/tests/tnimbleparser.nim
@@ -1,5 +1,6 @@
-import std/[unittest, os, algorithm, strutils, importutils, terminal, tables]
-import basic/[context, pkgurls, deptypes, nimblecontext, compiledpatterns, osutils, versions]
+import std/[unittest, os, algorithm, strutils, importutils, terminal, tables, sets, tempfiles]
+import basic/[context, pkgurls, deptypes, nimblecontext, compiledpatterns, osutils,
+              reporters, versions]
 import basic/nimbleparser
 import basic/parse_requires
 import runners
@@ -55,6 +56,43 @@ suite "nimbleparser":
     check res.features.hasKey("useOldAsyncTools")
     check res.features["useOldAsyncTools"].len == 1
     check res.features["useOldAsyncTools"][0] == "asynctools >= 0.1.0"
+
+  test "parses Nimble feature suffixes and warns for the legacy placement":
+    let nimbleFile = Path(genTempPath("atlas_feature_requirements_", ".nimble"))
+    defer:
+      removeFile($nimbleFile)
+    writeFile($nimbleFile, dedent"""
+    version = "0.1.0"
+    requires "chroniclers >= 0.3.0 [chronicles]"
+    requires "chronicles >= 0.3.0 [logging] "
+    requires "spaced >= 1.0 [bar, bazz]"
+    requires "compact >= 1.0 [bar,baz]"
+    requires "legacy[old] >= 1.0"
+    """)
+
+    var nc = createUnfilledNimbleContext()
+    let chroniclers = toPkgUriRaw(parseUri "https://example.com/chroniclers")
+    let chronicles = toPkgUriRaw(parseUri "https://example.com/chronicles")
+    let spaced = toPkgUriRaw(parseUri "https://example.com/spaced")
+    let compact = toPkgUriRaw(parseUri "https://example.com/compact")
+    let legacy = toPkgUriRaw(parseUri "https://example.com/legacy")
+    discard nc.put("chroniclers", chroniclers)
+    discard nc.put("chronicles", chronicles)
+    discard nc.put("spaced", spaced)
+    discard nc.put("compact", compact)
+    discard nc.put("legacy", legacy)
+
+    let warningsBefore = atlasReporter.warnings
+    let release = nc.parseNimbleFile(nimbleFile)
+    check release.requirements.len == 5
+    check release.requirements[0][1].matches(Version"0.3.0")
+    check not release.requirements[0][1].matches(Version"0.2.9")
+    check release.reqsByFeatures[chroniclers].contains("chronicles")
+    check release.reqsByFeatures[chronicles].contains("logging")
+    check release.reqsByFeatures[spaced] == ["bar", "bazz"].toHashSet()
+    check release.reqsByFeatures[compact] == ["bar", "baz"].toHashSet()
+    check release.reqsByFeatures[legacy].contains("old")
+    check atlasReporter.warnings == warningsBefore + 1
 
   test "parse nimble file preserves empty features":
     let nimbleFile = Path("tests" / "test_data" / "empty_feature.nimble")


### PR DESCRIPTION
## Motivation

Atlas currently expects dependency features before the version constraint, while Nimble places them after it. This makes valid Nimble requirements lose their feature activation when Atlas parses them.

## Syntax

Nimble syntax specification (such as it is) uses `requires "foo > 3.0 [bar]"`. Atlas uses `requires "foo[bar] > 3.0 "`.

This PR fixes Atlas to align to Nimble's format, while still accepting Atlas's previous form while printing a deprecation warning. 

Similarly Atlas now emits the plural form of `--define:features.foo.bar` to match Nimble. 