### PR TITLE
Fix package names in feature defines

### DIFF
--- a/atlas.nimble
+++ b/atlas.nimble
@@ -1,5 +1,5 @@
 # Package
-version = "0.15.0"
+version = "0.15.1"
 author = "Araq"
 description = "Atlas is a simple package cloner tool. It manages an isolated project."
 license = "MIT"

--- a/doc/atlas.md
+++ b/doc/atlas.md
@@ -230,9 +230,10 @@ Features are lazily cloned by Atlas until they are specified by either a require
 
 Atlas automatically enables the root package's `dev` and `patch` features, matching
 Nimble. Declare development-only dependencies with `dev:`; `patch` uses a regular
-`feature "patch":` block. Compiler defines use the package name declared in its
-Nimble file, for example `--define:features.my_package.testing`, even when the
-repository or dependency alias has a different name.
+`feature "patch":` block. Compiler defines use the Nimble package name, defaulting
+to the `.nimble` filename when no name is declared. For example,
+`--define:features.my_package.testing` is independent of the repository or
+dependency alias name.
 
 In Nimble files you can enable features for a a given package like so:
 ```nim

--- a/src/basic/context.nim
+++ b/src/basic/context.nim
@@ -159,17 +159,22 @@ func featurePackageName*(declaredName, fallbackName: string): string =
   else: fallbackName
 
 proc hasRequestedFeature*(pkgShortName, pkgProjectName, pkgDeclaredName,
-                          feature: string; isRoot: bool): bool =
+                          pkgName, feature: string; isRoot: bool): bool =
   initAtlasContext()
   if AllFeatures in atlasContext.flags or
       (isRoot and feature in ["dev", "patch"]):
     return true
   if atlasContext.features.containsFeature(feature):
     return true
-  for pkgName in [pkgShortName, pkgProjectName, pkgDeclaredName]:
-    if pkgName.len > 0 and atlasContext.features.containsFeature(
-        FeatureDefinePrefix & pkgName & "." & feature):
+  for candidate in [pkgShortName, pkgProjectName, pkgDeclaredName, pkgName]:
+    if candidate.len > 0 and atlasContext.features.containsFeature(
+        FeatureDefinePrefix & candidate & "." & feature):
       return true
+
+proc hasRequestedFeature*(pkgShortName, pkgProjectName, pkgDeclaredName,
+                          feature: string; isRoot: bool): bool =
+  hasRequestedFeature(pkgShortName, pkgProjectName, pkgDeclaredName, "",
+                      feature, isRoot)
 
 proc hasRequestedFeature*(pkgShortName, pkgProjectName, feature: string): bool =
   ## Compatibility overload for callers without release metadata.

--- a/src/confighandler.nim
+++ b/src/confighandler.nim
@@ -189,12 +189,16 @@ proc toActivationCache*(g: DepGraph): ActivationCache =
       continue
 
     let rel = pkg.activeNimbleRelease()
+    let fallbackName =
+      if pkg.name.len > 0: pkg.name
+      elif pkg.isRoot: pkg.url.projectName
+      else: pkg.url.shortName
     var features = pkg.activeFeatures
     features.sort()
 
     result.packages.add ActivatedPackage(
       url: pkg.url,
-      name: if rel.isNil: "" else: rel.name,
+      name: featurePackageName(if rel.isNil: "" else: rel.name, fallbackName),
       version: repr(pkg.activeVersion.vtag),
       author: if rel.isNil: "" else: rel.author,
       description: if rel.isNil: "" else: rel.description,

--- a/src/dependencies.nim
+++ b/src/dependencies.nim
@@ -138,13 +138,14 @@ proc registerReleaseDependencies(
       if pkgUrl notin nc.packageToDependency:
         let state =
           if not hasRequestedFeature(pkg.url.shortName, pkg.url.projectName,
-                                     release.name, feature, pkg.isRoot): LazyDeferred
+                                     release.name, pkg.name, feature,
+                                     pkg.isRoot): LazyDeferred
           else: childDependencyState(pkg, deferChildDeps)
         debug pkg.url.projectName, "Found new feature pkg:", pkgUrl.projectName, "url:", $pkgUrl.url, "projectName:", $pkgUrl.projectName, "state:", $state
         let pkgDep = nc.initPackage(pkgUrl, state)
         nc.packageToDependency[pkgUrl] = pkgDep
       elif hasRequestedFeature(pkg.url.shortName, pkg.url.projectName,
-                               release.name, feature, pkg.isRoot) and
+                               release.name, pkg.name, feature, pkg.isRoot) and
           nc.packageToDependency[pkgUrl].state == LazyDeferred and
           childDependencyState(pkg, deferChildDeps) != LazyDeferred:
         warn pkg.url.projectName, "Changing LazyDeferred feature pkg to DoLoad:", $pkgUrl.url

--- a/src/depgraphs.nim
+++ b/src/depgraphs.nim
@@ -84,7 +84,8 @@ proc addCompatibleVersionChoice(b: var Builder; compatibleVersions: seq[VarId]) 
 
 proc packageFeatureName(pkg: Package; rel: NimbleRelease): string =
   let fallbackName =
-    if pkg.isRoot: pkg.url.projectName
+    if pkg.name.len > 0: pkg.name
+    elif pkg.isRoot: pkg.url.projectName
     else: pkg.url.shortName
   let declaredName =
     if rel.isNil: ""
@@ -93,7 +94,7 @@ proc packageFeatureName(pkg: Package; rel: NimbleRelease): string =
 
 proc matchesFeaturePackageName(pkg: Package; rel: NimbleRelease;
                                name: string): bool =
-  for candidate in [pkg.url.shortName, pkg.url.projectName, rel.name]:
+  for candidate in [pkg.url.shortName, pkg.url.projectName, rel.name, pkg.name]:
     if candidate.len > 0 and sameFeature(candidate, name):
       return true
 
@@ -143,7 +144,7 @@ proc canonicalFeatureDefine(graph: DepGraph; feature: string): string =
 
 proc hasContextFeature(pkg: Package; rel: NimbleRelease; feature: string): bool =
   result = hasRequestedFeature(pkg.url.shortName, pkg.url.projectName,
-                               rel.name, feature, pkg.isRoot)
+                               rel.name, pkg.name, feature, pkg.isRoot)
 
 proc requirementMatches*(query: VersionInterval; depVer: PackageVersion; depRel: NimbleRelease): bool =
   ## Match semver constraints against nimble-declared release versions, while

--- a/tests/test_data/markdown.nimble
+++ b/tests/test_data/markdown.nimble
@@ -1,0 +1,4 @@
+version = "1.0.0"
+
+feature "regex":
+  discard

--- a/tests/tfeature_duplicate_dependencies.nim
+++ b/tests/tfeature_duplicate_dependencies.nim
@@ -1,7 +1,7 @@
 import std / [paths, sets, unittest, uri]
 
 import basic/[context, deptypes, nimblecontext, nimbleparser, pkgurls, versions]
-import depgraphs
+import confighandler, depgraphs
 
 suite "duplicate feature dependencies":
   test "two enabled features can share one dependency":
@@ -100,3 +100,29 @@ suite "duplicate feature dependencies":
     doAssert dependency.activeFeatures == @["future"]
     let (_, features) = graph.activateGraph()
     doAssert "features.declared_dependency.future" in features
+
+  test "feature defines use the package name instead of the URL slug":
+    setContext(AtlasContext())
+    context().flags.incl NoExec
+
+    var nc = createUnfilledNimbleContext()
+    let markdownUrl = toPkgUriRaw(parseUri("https://example.com/nim-markdown"))
+    discard nc.put("markdown", markdownUrl)
+    let markdownRelease = nc.parseNimbleFile(Path"tests/test_data/markdown.nimble")
+    let markdownVersion = toVersionTag("1.0.0@-").toPkgVer
+
+    let markdown = nc.initPackage(markdownUrl, Processed)
+    markdown.versions[markdownVersion] = markdownRelease
+    markdown.activeVersion = markdownVersion
+    markdown.activeFeatures = @["regex"]
+    markdown.active = true
+    markdown.ondisk = Path"tests/test_data"
+
+    var graph = DepGraph()
+    graph.pkgs[markdownUrl] = markdown
+
+    let (_, features) = graph.activateGraph()
+    let cache = graph.toActivationCache()
+    doAssert cache.packages[0].name == "markdown"
+    doAssert "features.markdown.regex" in features
+    doAssert "features.nim-markdown.regex" notin features


### PR DESCRIPTION
## Summary

- generate feature defines from the Nimble package identity instead of the repository URL slug
- preserve package names in activation caches and package-scoped feature matching
- document the behavior and bump Atlas from 0.15.0 to 0.15.1

## Motivation

Dependencies such as markdown can resolve to repositories with a different slug, such as nim-markdown. Atlas emitted features.nim-markdown.regex, while Nimble expects features.markdown.regex.

## Testing

- nim c -r tests/tfeature_duplicate_dependencies.nim
- nim test
- nim build
- nim docs