### PR TITLE
Derive direct URL package names from Nimble

### DIFF
--- a/atlas.nimble
+++ b/atlas.nimble
@@ -1,5 +1,5 @@
 # Package
-version = "0.15.1"
+version = "0.15.2"
 author = "Araq"
 description = "Atlas is a simple package cloner tool. It manages an isolated project."
 license = "MIT"

--- a/doc/atlas.md
+++ b/doc/atlas.md
@@ -68,9 +68,17 @@ requirements retain their full hashes internally but are shortened to eight
 characters in version-selection output.
 
 Atlas uses URLs internally; Nimble package names are translated to URLs
-via Nimble's  `packages.json` file. Atlas uses "shortnames" for known URLs from
-packages. Unofficial URLs, including forks, using a name triplet of the form
-`projectName.author.host`. For example Atlas would be `atlas.nim-lang.github.com`. Packages can be added using `nameOverrides` in `atlas.config` which adds a new name to URL mapping.
+via Nimble's `packages.json` file. Repository URLs identify what Atlas clones,
+but package names determine dependency directory and feature names. Explicit
+URLs and forge aliases derive that name from the `.nimble` filename after
+checkout. For example, a `nim-markdown` repository containing `markdown.nimble`
+uses `deps/markdown` and `features.markdown.*`.
+
+Unofficial URLs, including forks, use a name triplet of the form
+`projectName.author.host` when Atlas must disambiguate packages with the same
+name. For example, Atlas would be `atlas.nim-lang.github.com`. Packages can be
+added using `nameOverrides` in `atlas.config`, which adds a new name-to-URL
+mapping.
 Atlas downloads `packages.json` into `deps/_packages` by default; pass
 `--packagesRepo` to keep the git-clone behavior for the full packages repo.
 If dependency URLs use `git://`, pass `--forceGitToHttps` to rewrite them to

--- a/src/basic/nimblecontext.nim
+++ b/src/basic/nimblecontext.nim
@@ -179,7 +179,8 @@ proc initPackage*(nc: NimbleContext; url: PkgUrl; state = NotInitialized): Packa
     isFork: nc.isForkUrl(url)
   )
 
-proc putImpl(nc: var NimbleContext, name: string, url: PkgUrl, isFromPath = false): bool =
+proc putImpl(nc: var NimbleContext, name: string, url: PkgUrl,
+             isFromPath = false, authoritativeName = true): bool =
   ## Adds a package-name mapping to the context extras table.
   ##
   ## Returns false when the name is already reserved by the registry or by a
@@ -190,21 +191,29 @@ proc putImpl(nc: var NimbleContext, name: string, url: PkgUrl, isFromPath = fals
   elif name notin nc.packageExtras:
     nc.packageExtras[name] = url
     nc.urlToUrl[$url.cloneUri()] = url
-    nc.rememberPackageName(name, url)
+    if authoritativeName:
+      nc.rememberPackageName(name, url)
     result = true
   else:
     let existingPkg = nc.packageExtras[name]
     let existingUrl = existingPkg.cloneUri()
-    let url = url.cloneUri()
-    if existingUrl != url:
-      if existingUrl.scheme != url.scheme and existingUrl.port == url.port and
-          existingUrl.path == url.path and existingUrl.hostname == url.hostname:
-        info "atlas:nimblecontext", "different url schemes for the same package:", $name, "existing:", $existingUrl, "new:", $url
+    let newUrl = url.cloneUri()
+    if existingUrl != newUrl:
+      if existingUrl.scheme != newUrl.scheme and
+          existingUrl.port == newUrl.port and
+          existingUrl.path == newUrl.path and existingUrl.hostname == newUrl.hostname:
+        info "atlas:nimblecontext", "different url schemes for the same package:",
+             $name, "existing:", $existingUrl, "new:", $newUrl
       else:
         # this is handled in the solver which checks for conflicts
         # but users should be aware that this is happening as they can override stuff
-        warn "atlas:nimblecontext", "name already exists in packageExtras:", $name, "isFromPath:", $isFromPath, "with different url:", $nc.packageExtras[name], "and url:", $url
+        warn "atlas:nimblecontext", "name already exists in packageExtras:", $name,
+             "isFromPath:", $isFromPath, "with different url:",
+             $nc.packageExtras[name], "and url:", $newUrl
         result = false
+    elif authoritativeName:
+      nc.rememberPackageName(name, url)
+      result = true
 
 proc put*(nc: var NimbleContext, name: string, url: PkgUrl): bool {.discardable.} =
   ## Adds an explicit package-name to URL mapping.
@@ -275,7 +284,10 @@ proc createUrl*(nc: var NimbleContext, nameOrig: string): PkgUrl =
       raise newException(ValueError, "project name not found in packages database: " & $lname & " original: " & $nameOrig)
   
   if not result.isEmpty():
-    if nc.put(result.projectName, result):
+    let packageName =
+      if origWasUrl: result.projectName
+      else: nameOrig
+    if nc.putImpl(packageName, result, authoritativeName = not origWasUrl):
       debug "atlas:createUrl", "created url with name:", name, "orig:",
             nameOrig, "projectName:", $result.projectName,
             "url:", $result.url

--- a/src/basic/packageutils.nim
+++ b/src/basic/packageutils.nim
@@ -40,6 +40,16 @@ proc tmpCheckoutDir(pkg: Package): Path =
 proc matchesPackageUrl(path: Path; pkg: Package): bool =
   dirExists(path) and gitops.getCanonicalUrl(path) == $pkg.url.cloneUri()
 
+proc findPackageDirByUrl(pkg: Package): Path =
+  if not dirExists(depsDir()):
+    return
+  for kind, path in walkDir($depsDir()):
+    if kind == pcDir:
+      let candidate = Path(path)
+      if $candidate.splitPath().tail != ".tmp" and
+          matchesPackageUrl(candidate, pkg):
+        return candidate.absolutePath()
+
 proc disambiguatedDirectoryPath(pkg: Package): Path =
   let baseName =
     if pkg.url.fullName().len > 0: pkg.url.fullName()
@@ -82,7 +92,8 @@ proc finalizeClonedPackagePath*(pkg: var Package; checkoutDir: Path) =
              "preferred:", $pkg.url.toDirectoryPath(pkg.projectName()),
              "using:", $finalDir
         if dirExists(finalDir):
-          removeDir($checkoutDir)
+          if checkoutDir != finalDir:
+            removeDir($checkoutDir)
         else:
           moveDir($checkoutDir, $finalDir)
     else:
@@ -101,16 +112,23 @@ proc resolveExistingPackageDir*(pkg: var Package): bool =
   ## filename after cloning. If another unofficial package with the same nimble
   ## filename already owns that directory, look for this package's deterministic
   ## disambiguated directory instead of reusing the wrong checkout.
-  if not dirExists(pkg.ondisk):
-    return false
-  if not pkg.shouldCloneToTemp():
-    return true
-  if matchesPackageUrl(pkg.ondisk, pkg):
-    return true
+  if dirExists(pkg.ondisk):
+    if not pkg.shouldCloneToTemp():
+      return true
+    if matchesPackageUrl(pkg.ondisk, pkg):
+      pkg.finalizeClonedPackagePath(pkg.ondisk)
+      return true
 
   let alternateDir = disambiguatedDirectoryPath(pkg)
   if dirExists(alternateDir) and matchesPackageUrl(alternateDir, pkg):
     pkg.ondisk = alternateDir
+    pkg.finalizeClonedPackagePath(pkg.ondisk)
+    return true
+
+  let existingDir = findPackageDirByUrl(pkg)
+  if existingDir.len > 0:
+    pkg.ondisk = existingDir
+    pkg.finalizeClonedPackagePath(pkg.ondisk)
     return true
 
   false

--- a/tests/texplicit_history_leak.nim
+++ b/tests/texplicit_history_leak.nim
@@ -574,3 +574,65 @@ suite "historical explicit transitive pins":
           check graph2.pkgs[upstreamUrl2].ondisk == upstream.ondisk
           check graph2.pkgs[forkUrl2].ondisk == fork.ondisk
           check gitops.getCanonicalUrl(graph2.pkgs[forkUrl2].ondisk) == forkUrlString
+
+  test "forge URL uses Nimble name for checkout and feature define":
+    let ws = "tests/ws_explicit_history_leak"
+    removeDir(ws)
+    createDir(ws)
+
+    withDir ws:
+      project(paths.getCurrentDir())
+      context().flags = {KeepWorkspace, ListVersions, NoExec}
+      context().defaultAlgo = SemVer
+
+      createDir("remotes/elcritch/nim-markdown")
+      withDir "remotes/elcritch/nim-markdown":
+        writeFile("markdown.nimble", [
+          "version = \"1.0.0\"",
+          "feature \"regex\":",
+          "  discard",
+          ""
+        ].join("\n"))
+        writeFile("markdown.nim", "discard\n")
+        initGitRepo()
+        commitAll("markdown")
+        exec("git branch devel")
+
+      let remotesUrl = "file://" & $(Path("remotes").absolutePath()) & "/"
+      putEnv("GIT_CONFIG_COUNT", "1")
+      putEnv("GIT_CONFIG_KEY_0", "url." & remotesUrl & ".insteadOf")
+      putEnv("GIT_CONFIG_VALUE_0", "https://github.com/")
+
+      writeFile("ws_explicit_history_leak.nimble", [
+        "version = \"0.1.0\"",
+        "requires \"gh:elcritch/nim-markdown#devel[regex]\"",
+        ""
+      ].join("\n"))
+
+      var nc = createUnfilledNimbleContext()
+      var graph = loadWorkspace(project(), nc, AllReleases, DoClone, doSolve = true)
+      let markdownUrl = nc.createUrl("gh:elcritch/nim-markdown")
+      let (_, features) = graph.activateGraph()
+
+      check markdownUrl in graph.pkgs
+      check dirExists("deps/markdown")
+      check not dirExists("deps/nim-markdown")
+      check "features.markdown.regex" in features
+      check "features.nim-markdown.regex" notin features
+      if markdownUrl in graph.pkgs:
+        check graph.pkgs[markdownUrl].name == "markdown"
+        check graph.pkgs[markdownUrl].ondisk == Path("deps/markdown").absolutePath()
+
+      if dirExists("deps/markdown"):
+        moveDir("deps/markdown", "deps/nim-markdown")
+
+      var nc2 = createUnfilledNimbleContext()
+      var graph2 = loadWorkspace(project(), nc2, AllReleases, DoClone, doSolve = true)
+      let markdownUrl2 = nc2.createUrl("gh:elcritch/nim-markdown")
+      let (_, features2) = graph2.activateGraph()
+
+      check markdownUrl2 in graph2.pkgs
+      check dirExists("deps/markdown")
+      check not dirExists("deps/nim-markdown")
+      check "features.markdown.regex" in features2
+      check "features.nim-markdown.regex" notin features2


### PR DESCRIPTION
## Summary
- keep repository URL slugs separate from authoritative package names
- derive direct URL and forge-alias checkout names from Nimble filenames
- migrate and reuse existing slug-named checkouts by canonical remote URL
- add an exact gh:elcritch/nim-markdown#devel[regex] regression
- bump Atlas to 0.15.2

## Motivation
Atlas 0.15.1 still treated the repository slug in a direct forge URL as the package name. This installed nim-markdown into deps/nim-markdown and emitted features.nim-markdown.regex instead of using the markdown.nimble package name.

## Testing
- nim c -r tests/texplicit_history_leak.nim
- nim c -f -r tests/tbasics.nim
- nim c -r tests/tfeature_duplicate_dependencies.nim
- nim c -r tests/tfeatures.nim
- nim test
- nim build
- nim docs