### PR TITLE
fix: parse branch requirements with feature whitespace

### DIFF
--- a/atlas.nimble
+++ b/atlas.nimble
@@ -1,5 +1,5 @@
 # Package
-version = "0.15.2"
+version = "0.15.3"
 author = "Araq"
 description = "Atlas is a simple package cloner tool. It manages an isolated project."
 license = "MIT"

--- a/src/basic/nimbleparser.nim
+++ b/src/basic/nimbleparser.nim
@@ -20,7 +20,7 @@ proc processRequirement(nc: var NimbleContext;
                         feature: string;
                         result: var NimbleRelease) =
     let (name, reqsByFeatures, _) = extractRequirementName(req)
-    let requirement = removeRequirementFeatures(req)
+    let requirement = removeRequirementFeatures(req).strip()
     let (_, _, verIdx) = extractRequirementName(requirement)
     if usesLegacyRequirementFeatureSyntax(req):
       warn nimbleFile, "deprecated dependency feature syntax:", req,

--- a/tests/tnimbleparser.nim
+++ b/tests/tnimbleparser.nim
@@ -94,6 +94,26 @@ suite "nimbleparser":
     check release.reqsByFeatures[legacy].contains("old")
     check atlasReporter.warnings == warningsBefore + 1
 
+  test "parses URL branch requirements with features":
+    let nimbleFile = Path(genTempPath("atlas_url_branch_features_", ".nimble"))
+    defer:
+      removeFile($nimbleFile)
+
+    var nc = createUnfilledNimbleContext()
+    let markdown = toPkgUriRaw(parseUri "https://github.com/elcritch/nim-markdown")
+    for requirement in [
+        "https://github.com/elcritch/nim-markdown#devel [regex]",
+        "https://github.com/elcritch/nim-markdown#devel[regex]",
+        "https://github.com/elcritch/nim-markdown#devel [regex] ",
+        "https://github.com/elcritch/nim-markdown#devel[regex] "]:
+      writeFile($nimbleFile, "requires \"" & requirement & "\"\n")
+      let release = nc.parseNimbleFile(nimbleFile)
+      check release.status == Normal
+      require release.requirements.len == 1
+      check $release.requirements[0][0] == $markdown
+      check $release.requirements[0][1] == "#devel"
+      check release.reqsByFeatures[markdown].contains("regex")
+
   test "parse nimble file preserves empty features":
     let nimbleFile = Path("tests" / "test_data" / "empty_feature.nimble")
     writeFile($nimbleFile, dedent"""


### PR DESCRIPTION
## Summary

- trim requirements after removing dependency feature suffixes
- accept URL branch requirements whether the feature suffix is adjacent or space-separated
- cover trailing whitespace after the feature suffix

## Verification

- `nim c -r tests/tnimbleparser.nim`
- `nim unitTests`
- `nim build`
- end-to-end install of nim-markdown devel with the regex feature, followed by compiling an import through nim-regex